### PR TITLE
🤖 refactor: add simplify workflow

### DIFF
--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -171,7 +171,7 @@ export default function simplifyWorkflow({
     diffCompactions: asArray(contexts.outputGitContext.diff?.workflowCompactions).length,
   });
 
-  if (hasOnlyUntrackedChanges(gitContext)) {
+  if (!input.target && hasOnlyUntrackedChanges(gitContext)) {
     const reason = untrackedChangesSkipReason();
     return {
       reportMarkdown: "## Simplify workflow result\n\n" + reason,

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -380,6 +380,12 @@ function collectApplyPreflight(action, log, input, gitContext) {
     return failedApplyPreflight(nonCurrentHeadSkipReason());
   }
 
+  if (!isReviewedBranchCurrent(gitContext.status, status, input)) {
+    return failedApplyPreflight(
+      "Auto-fix was skipped because the current branch changed since review. Rerun `/workflow simplify --fix`."
+    );
+  }
+
   const reviewedHeadSha = gitContext.status && gitContext.status.headSha;
   if (typeof reviewedHeadSha !== "string" || !reviewedHeadSha) {
     return failedApplyPreflight(
@@ -500,6 +506,15 @@ function shouldReadDiffs(changedFiles) {
   );
 }
 
+function isReviewedBranchCurrent(reviewedStatus, currentStatus, input) {
+  if (input.headRef && isGitCommitSha(input.headRef)) return true;
+  const reviewedBranch =
+    reviewedStatus && typeof reviewedStatus.branch === "string" ? reviewedStatus.branch : "";
+  const currentBranch =
+    currentStatus && typeof currentStatus.branch === "string" ? currentStatus.branch : "";
+  return Boolean(reviewedBranch && currentBranch && reviewedBranch === currentBranch);
+}
+
 function isRequestedHeadCurrent(status, input) {
   if (!status || typeof status !== "object") return false;
   const currentHeadSha = typeof status.headSha === "string" ? status.headSha : "";
@@ -561,7 +576,7 @@ function filePath(value) {
 
 function normalizedPath(value) {
   if (typeof value !== "string") return "";
-  const trimmed = value.trim();
+  const trimmed = value.trim().replace(/\\/g, "/");
   if (trimmed === "." || trimmed === "./") return ".";
   return trimmed.replace(/^\.\//, "").replace(/\/+$/, "");
 }

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -1,10 +1,13 @@
 // description: Review current changes for reuse, quality, and efficiency, then fix actionable issues.
 
+// Workflow files execute as self-contained JavaScript; keep small helpers inline instead of importing repo utilities.
 const DEFAULT_MAX_FINDINGS = 20;
 // Review agents get bounded diff text; synthesis/fix phases get metadata only.
 const REVIEW_DIFF_CHAR_BUDGET = 60000;
 const METADATA_ARRAY_ITEM_BUDGET = 200;
 const DIFF_STAT_CHAR_BUDGET = 20000;
+const REVIEW_EVIDENCE_ITEM_BUDGET = 3;
+const REVIEW_EVIDENCE_CHAR_BUDGET = 500;
 const NO_REVIEWABLE_CHANGES_SUMMARY = "No reviewable changes found.";
 const READ_ONLY_PROMPT =
   "This is a read-only review step. Do not edit files, create commits, apply patches, push branches, or open PRs. Inspect repository evidence only as needed and report findings.";
@@ -14,6 +17,9 @@ const VALUE_FLAGS = [
   { name: "--head", key: "headRef" },
   { name: "--max-findings", key: "maxFindings" },
 ];
+const STATUS_ARRAY_FIELDS = ["staged", "unstaged", "untracked", "ignored"];
+const CHANGED_FILE_ARRAY_FIELDS = ["branch", "staged", "unstaged", "untracked"];
+const DIFF_FIELDS = ["branch", "staged", "unstaged"];
 const REVIEW_AGENT_ID = "explore";
 const EXEC_AGENT_ID = "exec";
 const REVIEW_LANES = [
@@ -157,7 +163,7 @@ export default function simplifyWorkflow({
   if (input.help) return usageResult();
 
   phase("capture-context", { target: input.target || "current git changes", fix: input.fix });
-  const gitContext = collectGitContext(action, input);
+  const gitContext = collectGitContext(action, input, log);
   const contexts = promptContexts(input, gitContext);
   log("Captured simplify context", {
     target: input.target || "current git changes",
@@ -274,17 +280,17 @@ export default function simplifyWorkflow({
   };
 }
 
-function collectGitContext(action, input) {
+function collectGitContext(action, input, log) {
   const requestedRefs = gitRefs(input);
   const failures = [];
-  const status = gitSlice(failures, "status", function () {
+  const status = gitSlice(log, failures, "status", function () {
     return action.git.status({
       id: "git-status",
       input: { includeIgnored: false },
       builtInOnly: true,
     }).output;
   });
-  const changedFiles = gitSlice(failures, "changedFiles", function () {
+  const changedFiles = gitSlice(log, failures, "changedFiles", function () {
     return action.git.changedFiles({
       id: "git-changed-files",
       input: requestedRefs,
@@ -299,20 +305,24 @@ function collectGitContext(action, input) {
     failures: failures,
     status: status,
     changedFiles: changedFiles,
-    diffStat: gitSlice(failures, "diffStat", function () {
+    diffStat: gitSlice(log, failures, "diffStat", function () {
       return action.git.diffStat({ id: "git-diff-stat", input: refs, builtInOnly: true }).output;
     }),
-    diff: gitSlice(failures, "diff", function () {
+    diff: gitSlice(log, failures, "diff", function () {
       return action.git.diff({ id: "git-diff", input: refs, builtInOnly: true }).output;
     }),
   };
 }
 
-function gitSlice(failures, name, read) {
+function gitSlice(log, failures, name, read) {
   try {
     return read();
   } catch (error) {
-    failures.push({ name: name, error: String(error) });
+    const failure = { name: name, error: formatError(error) };
+    failures.push(failure);
+    if (typeof log === "function") {
+      log("Git workflow action failed; continuing with partial simplify context", failure);
+    }
     return null;
   }
 }
@@ -386,35 +396,29 @@ function compactMetadata(gitContext) {
 }
 
 function compactStatus(status) {
-  if (!status || typeof status !== "object") return status;
-  return {
-    ...status,
-    staged: compactArray(status.staged, METADATA_ARRAY_ITEM_BUDGET),
-    unstaged: compactArray(status.unstaged, METADATA_ARRAY_ITEM_BUDGET),
-    untracked: compactArray(status.untracked, METADATA_ARRAY_ITEM_BUDGET),
-    ignored: compactArray(status.ignored, METADATA_ARRAY_ITEM_BUDGET),
-  };
+  return compactFields(status, STATUS_ARRAY_FIELDS, compactArray, METADATA_ARRAY_ITEM_BUDGET);
 }
 
 function compactChangedFiles(changedFiles) {
-  if (!changedFiles || typeof changedFiles !== "object") return changedFiles;
-  return {
-    ...changedFiles,
-    branch: compactArray(changedFiles.branch, METADATA_ARRAY_ITEM_BUDGET),
-    staged: compactArray(changedFiles.staged, METADATA_ARRAY_ITEM_BUDGET),
-    unstaged: compactArray(changedFiles.unstaged, METADATA_ARRAY_ITEM_BUDGET),
-    untracked: compactArray(changedFiles.untracked, METADATA_ARRAY_ITEM_BUDGET),
-  };
+  return compactFields(
+    changedFiles,
+    CHANGED_FILE_ARRAY_FIELDS,
+    compactArray,
+    METADATA_ARRAY_ITEM_BUDGET
+  );
 }
 
 function compactDiffStat(diffStat) {
-  if (!diffStat || typeof diffStat !== "object") return diffStat;
-  return {
-    ...diffStat,
-    branch: compactText(diffStat.branch, DIFF_STAT_CHAR_BUDGET),
-    staged: compactText(diffStat.staged, DIFF_STAT_CHAR_BUDGET),
-    unstaged: compactText(diffStat.unstaged, DIFF_STAT_CHAR_BUDGET),
-  };
+  return compactFields(diffStat, DIFF_FIELDS, compactText, DIFF_STAT_CHAR_BUDGET);
+}
+
+function compactFields(value, fields, compactor, limit) {
+  if (!value || typeof value !== "object") return value;
+  const compacted = { ...value };
+  fields.forEach(function (field) {
+    compacted[field] = compactor(value[field], limit);
+  });
+  return compacted;
 }
 
 function compactArray(value, limit) {
@@ -449,7 +453,7 @@ function compactDiff(diff, budget) {
   };
   let remaining = budget;
 
-  ["branch", "staged", "unstaged"].forEach(function (field) {
+  DIFF_FIELDS.forEach(function (field) {
     const value = diff[field];
     if (typeof value !== "string") {
       compacted[field] = value;
@@ -481,12 +485,16 @@ function diffSummary(diff, compactedDiff) {
     truncated: diff.truncated,
     workflowBudgetChars: compactedDiff && compactedDiff.workflowBudgetChars,
     workflowCompactions: compactedDiff ? asArray(compactedDiff.workflowCompactions) : [],
-    chars: {
-      branch: stringLength(diff.branch),
-      staged: stringLength(diff.staged),
-      unstaged: stringLength(diff.unstaged),
-    },
+    chars: diffFieldLengths(diff),
   };
+}
+
+function diffFieldLengths(diff) {
+  const lengths = {};
+  DIFF_FIELDS.forEach(function (field) {
+    lengths[field] = stringLength(diff[field]);
+  });
+  return lengths;
 }
 
 function diffOmittedMessage(field) {
@@ -518,22 +526,58 @@ function synthesisPrompt(input, compactContext, reviewOutputs) {
     "Deduplicate and triage these simplify review findings. Keep actionableFindings to the " +
       input.maxFindings +
       " highest-value issues.",
-    "Fix actionable issues directly when fix mode is enabled. If a finding is false positive or not worth addressing, put it in skippedFindings without debating it.",
+    "Do not edit files in this step. Produce triage and fix plans for the later fixer step. If a finding is false positive or not worth addressing, put it in skippedFindings without debating it.",
     "Allowed severity values are: high, medium, low. Prefer minimal cleanup over broad refactors.",
     "\nCompact review context without raw diff text:\n" + compactContext,
-    "\nLane outputs:\n" + fencedJson(reviewOutputs),
+    "\nCompacted lane outputs:\n" + fencedJson(compactReviewOutputs(reviewOutputs)),
   ].join("\n\n");
 }
 
 function fixPrompt(compactContext, synthesized) {
   return [
-    "Fix the actionable simplify findings with minimal, correct, reviewable changes. Do not push, commit, or open a PR.",
+    "Fix the actionable simplify findings with minimal, correct, reviewable changes. Do not push or open a PR.",
+    "If you change files, create one local commit containing only those changes so the workflow can export a patch artifact.",
     "Use the compact context for file lists and diff metadata; inspect files directly instead of relying on raw diff text being embedded in this prompt.",
     "Preserve existing style and functionality. Run targeted validation for touched code when feasible and report exact commands/results.",
     "If a finding is false positive or not worth addressing, skip it and note why. Set madeChanges true only when files changed.",
     "\nCompact review context:\n" + compactContext,
-    "\nSynthesized findings:\n" + fencedJson(synthesized),
+    "\nActionable findings:\n" + fencedJson(fixerPayload(synthesized)),
   ].join("\n\n");
+}
+
+function compactReviewOutputs(reviewOutputs) {
+  return asArray(reviewOutputs).map(function (output) {
+    return {
+      summary: output && output.summary,
+      findings: asArray(output && output.findings).map(compactReviewFinding),
+    };
+  });
+}
+
+function compactReviewFinding(finding) {
+  return {
+    id: finding && finding.id,
+    title: finding && finding.title,
+    severity: finding && finding.severity,
+    filePaths: asArray(finding && finding.filePaths),
+    rationale: finding && finding.rationale,
+    recommendation: finding && finding.recommendation,
+    evidenceCount: asArray(finding && finding.evidence).length,
+    evidenceSamples: asArray(finding && finding.evidence)
+      .slice(0, REVIEW_EVIDENCE_ITEM_BUDGET)
+      .map(function (evidence) {
+        return compactText(evidence, REVIEW_EVIDENCE_CHAR_BUDGET);
+      }),
+  };
+}
+
+function fixerPayload(synthesized) {
+  return {
+    summary: synthesized && synthesized.summary,
+    shouldFix: Boolean(synthesized && synthesized.shouldFix),
+    actionableFindings: asArray(synthesized && synthesized.actionableFindings),
+    validationPlan: asArray(synthesized && synthesized.validationPlan),
+  };
 }
 
 function parseArgs(args) {
@@ -701,6 +745,10 @@ function stringLength(value) {
 function positiveInt(value, fallback) {
   const number = Number(value);
   return Number.isFinite(number) && number >= 1 ? Math.floor(number) : fallback;
+}
+
+function formatError(error) {
+  return error && typeof error.message === "string" ? error.message : String(error);
 }
 
 function assert(condition, message) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -235,18 +235,24 @@ export default function simplifyWorkflow({
 
   // git am cannot apply onto a dirty index; keep the review result but skip auto-fix.
   if (hasStagedChanges(gitContext)) {
-    return {
-      reportMarkdown:
-        synthesis.reportMarkdown +
-        "\n\n---\n\n## Simplify workflow result\n\n" +
-        stagedChangesSkipReason(),
-      structuredOutput: {
-        mode: "staged-changes-skip-fix",
-        gitContext: contexts.outputGitContext,
-        reviews: reviewOutputs,
-        synthesis: synthesized,
-      },
-    };
+    return skipFixResult(
+      synthesis.reportMarkdown,
+      stagedChangesSkipReason(),
+      "staged-changes-skip-fix",
+      contexts.outputGitContext,
+      reviewOutputs,
+      synthesized
+    );
+  }
+  if (!isRequestedHeadCurrent(gitContext.status)) {
+    return skipFixResult(
+      synthesis.reportMarkdown,
+      nonCurrentHeadSkipReason(),
+      "non-current-head-skip-fix",
+      contexts.outputGitContext,
+      reviewOutputs,
+      synthesized
+    );
   }
 
   phase("fix", { actionableFindingCount: actionableFindings.length });
@@ -276,7 +282,7 @@ export default function simplifyWorkflow({
   }
 
   phase("apply-fixes", { madeChanges: true });
-  const applyPreflight = collectApplyPreflight(action, log, gitContext);
+  const applyPreflight = collectApplyPreflight(action, log, input, gitContext);
   if (applyPreflight.skippedReason) {
     return {
       reportMarkdown:
@@ -318,12 +324,31 @@ export default function simplifyWorkflow({
   };
 }
 
-function collectApplyPreflight(action, log, gitContext) {
+function skipFixResult(
+  synthesisMarkdown,
+  reason,
+  mode,
+  outputGitContext,
+  reviewOutputs,
+  synthesized
+) {
+  return {
+    reportMarkdown: synthesisMarkdown + "\n\n---\n\n## Simplify workflow result\n\n" + reason,
+    structuredOutput: {
+      mode: mode,
+      gitContext: outputGitContext,
+      reviews: reviewOutputs,
+      synthesis: synthesized,
+    },
+  };
+}
+
+function collectApplyPreflight(action, log, input, gitContext) {
   let status = null;
   try {
     status = action.git.status({
       id: "apply-git-status",
-      input: { includeIgnored: false },
+      input: gitStatusInput(input),
       builtInOnly: true,
       cache: false,
     }).output;
@@ -338,6 +363,10 @@ function collectApplyPreflight(action, log, gitContext) {
   }
   if (hasArrayItems(status.staged)) {
     return failedApplyPreflight(stagedChangesSkipReason());
+  }
+
+  if (!isRequestedHeadCurrent(status)) {
+    return failedApplyPreflight(nonCurrentHeadSkipReason());
   }
 
   const reviewedHeadSha = gitContext.status && gitContext.status.headSha;
@@ -359,6 +388,10 @@ function failedApplyPreflight(reason) {
   return { success: false, status: "failed", skippedReason: reason, error: reason };
 }
 
+function nonCurrentHeadSkipReason() {
+  return "Auto-fix was skipped because the requested `--head` is not the current checkout. Check out that ref or rerun without `--head` before applying fixes.";
+}
+
 function stagedChangesSkipReason() {
   return "Auto-fix was skipped because staged changes are present. Unstage or commit staged changes, then rerun `/workflow simplify --fix`.";
 }
@@ -369,7 +402,7 @@ function collectGitContext(action, input, log) {
   const status = gitSlice(log, failures, "status", function () {
     return action.git.status({
       id: "git-status",
-      input: { includeIgnored: false },
+      input: gitStatusInput(input),
       builtInOnly: true,
     }).output;
   });
@@ -416,6 +449,12 @@ function gitSlice(log, failures, name, read) {
   }
 }
 
+function gitStatusInput(input) {
+  const statusInput = { includeIgnored: false };
+  if (input.headRef) statusInput.head = input.headRef;
+  return statusInput;
+}
+
 function gitRefs(input) {
   const refs = {};
   if (input.baseRef) refs.base = input.baseRef;
@@ -444,6 +483,14 @@ function shouldReadDiffs(changedFiles) {
     hasArrayItems(changedFiles.staged) ||
     hasArrayItems(changedFiles.unstaged)
   );
+}
+
+function isRequestedHeadCurrent(status) {
+  if (!status || typeof status !== "object") return false;
+  const currentHeadSha = typeof status.headSha === "string" ? status.headSha : "";
+  const requestedHeadSha =
+    typeof status.requestedHeadSha === "string" ? status.requestedHeadSha : currentHeadSha;
+  return Boolean(currentHeadSha && requestedHeadSha && currentHeadSha === requestedHeadSha);
 }
 
 function hasStagedChanges(gitContext) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -1,6 +1,8 @@
 // description: Review current changes for reuse, quality, and efficiency, then fix actionable issues.
 
 const DEFAULT_MAX_FINDINGS = 20;
+// Review agents get bounded diff text; synthesis/fix phases get metadata only.
+const REVIEW_DIFF_CHAR_BUDGET = 60000;
 const REVIEW_AGENT_ID = "explore";
 const EXEC_AGENT_ID = "exec";
 const REVIEW_LANES = [
@@ -119,29 +121,44 @@ const FIXER_SCHEMA = {
   },
 };
 
-export default function simplifyWorkflow({ args, phase, log, action, parallelAgents, agent, applyPatch }) {
+export default function simplifyWorkflow({
+  args,
+  phase,
+  log,
+  action,
+  parallelAgents,
+  agent,
+  applyPatch,
+}) {
   assert(action && parallelAgents && agent && applyPatch, "workflow runtime APIs are required");
 
-  const input = parseArgs(args);
+  const parsed = parseArgs(args);
+  if (parsed.error) return usageResult(parsed.error);
+
+  const input = parsed.input;
   if (input.help) return usageResult();
 
   phase("capture-context", { target: input.target || "current git changes", fix: input.fix });
   const gitContext = collectGitContext(action, input);
+  const contexts = promptContexts(input, gitContext);
   log("Captured simplify context", {
     target: input.target || "current git changes",
     gitFailures: gitContext.failures.length,
+    diffCompactions: diffCompactions(contexts.outputGitContext).length,
   });
 
-  const reviewContext = renderReviewContext(input, gitContext);
-
-  phase("review", { lanes: REVIEW_LANES.map(function (lane) { return lane.id; }) });
+  phase("review", {
+    lanes: REVIEW_LANES.map(function (lane) {
+      return lane.id;
+    }),
+  });
   const reviewOutputs = parallelAgents(
     REVIEW_LANES.map(function (lane) {
       return {
         id: lane.id + "-review",
         title: lane.title,
         agentId: REVIEW_AGENT_ID,
-        prompt: reviewPrompt(lane, input, reviewContext),
+        prompt: reviewPrompt(lane, input, contexts.review),
         outputSchema: REVIEW_SCHEMA,
       };
     }),
@@ -159,10 +176,13 @@ export default function simplifyWorkflow({ args, phase, log, action, parallelAge
     id: "synthesize-simplify-findings",
     title: "Simplify: synthesize findings",
     agentId: EXEC_AGENT_ID,
-    prompt: synthesisPrompt(input, reviewContext, reviewOutputs),
+    prompt: synthesisPrompt(input, contexts.compact, reviewOutputs),
     outputSchema: SYNTHESIS_SCHEMA,
   });
-  const synthesized = mustObject(synthesis.structuredOutput, "synthesis structured output is required");
+  const synthesized = mustObject(
+    synthesis.structuredOutput,
+    "synthesis structured output is required"
+  );
   const actionableFindings = asArray(synthesized.actionableFindings);
 
   if (!input.fix || !synthesized.shouldFix || actionableFindings.length === 0) {
@@ -170,7 +190,7 @@ export default function simplifyWorkflow({ args, phase, log, action, parallelAge
       reportMarkdown: reviewOnlyReport(input, synthesis.reportMarkdown),
       structuredOutput: {
         mode: input.fix ? "no-actionable-fixes" : "review-only",
-        gitContext: gitContext,
+        gitContext: contexts.outputGitContext,
         reviews: reviewOutputs,
         synthesis: synthesized,
       },
@@ -182,17 +202,20 @@ export default function simplifyWorkflow({ args, phase, log, action, parallelAge
     id: "fix-simplify-findings",
     title: "Simplify: fix actionable findings",
     agentId: EXEC_AGENT_ID,
-    prompt: fixPrompt(reviewContext, synthesized),
+    prompt: fixPrompt(contexts.compact, synthesized),
     outputSchema: FIXER_SCHEMA,
   });
   const fixerOutput = mustObject(fixer.structuredOutput, "fixer structured output is required");
 
   if (!fixerOutput.madeChanges) {
     return {
-      reportMarkdown: synthesis.reportMarkdown + "\n\n---\n\n## Fix pass\n\nThe fixer did not make file changes.\n\n" + fixer.reportMarkdown,
+      reportMarkdown:
+        synthesis.reportMarkdown +
+        "\n\n---\n\n## Fix pass\n\nThe fixer did not make file changes.\n\n" +
+        fixer.reportMarkdown,
       structuredOutput: {
         mode: "fixer-made-no-changes",
-        gitContext: gitContext,
+        gitContext: contexts.outputGitContext,
         reviews: reviewOutputs,
         synthesis: synthesized,
         fix: { fixer: fixerOutput, applied: null },
@@ -213,7 +236,7 @@ export default function simplifyWorkflow({ args, phase, log, action, parallelAge
     reportMarkdown: fixReport(synthesis.reportMarkdown, fixer.reportMarkdown, applied),
     structuredOutput: {
       mode: "fix-attempted",
-      gitContext: gitContext,
+      gitContext: contexts.outputGitContext,
       reviews: reviewOutputs,
       synthesis: synthesized,
       fix: { fixer: fixerOutput, applied: applied },
@@ -229,10 +252,15 @@ function collectGitContext(action, input) {
     refs: refs,
     failures: failures,
     status: gitSlice(failures, "status", function () {
-      return action.git.status({ id: "git-status", input: { includeIgnored: false }, builtInOnly: true }).output;
+      return action.git.status({
+        id: "git-status",
+        input: { includeIgnored: false },
+        builtInOnly: true,
+      }).output;
     }),
     changedFiles: gitSlice(failures, "changedFiles", function () {
-      return action.git.changedFiles({ id: "git-changed-files", input: refs, builtInOnly: true }).output;
+      return action.git.changedFiles({ id: "git-changed-files", input: refs, builtInOnly: true })
+        .output;
     }),
     diffStat: gitSlice(failures, "diffStat", function () {
       return action.git.diffStat({ id: "git-diff-stat", input: refs, builtInOnly: true }).output;
@@ -260,18 +288,110 @@ function gitRefs(input) {
   return refs;
 }
 
-function renderReviewContext(input, gitContext) {
+function promptContexts(input, gitContext) {
+  const reviewGitContext = withCompactedDiff(gitContext, REVIEW_DIFF_CHAR_BUDGET);
+  const outputGitContext = withoutDiffText(gitContext, reviewGitContext.diff);
+  return {
+    review: renderContext(input, reviewGitContext),
+    compact: renderContext(input, outputGitContext),
+    outputGitContext: outputGitContext,
+  };
+}
+
+function renderContext(input, gitContext) {
   return fencedJson({
-    input: {
-      target: input.target,
-      fix: input.fix,
-      baseRef: input.baseRef,
-      trunkRef: input.trunkRef,
-      headRef: input.headRef,
-      maxFindings: input.maxFindings,
-    },
+    input: { target: input.target, fix: input.fix, maxFindings: input.maxFindings },
     gitContext: gitContext,
   });
+}
+
+function withCompactedDiff(gitContext, budget) {
+  return {
+    target: gitContext.target,
+    refs: gitContext.refs,
+    failures: gitContext.failures,
+    status: gitContext.status,
+    changedFiles: gitContext.changedFiles,
+    diffStat: gitContext.diffStat,
+    diff: compactDiff(gitContext.diff, budget),
+  };
+}
+
+function withoutDiffText(gitContext, compactedDiff) {
+  return {
+    target: gitContext.target,
+    refs: gitContext.refs,
+    failures: gitContext.failures,
+    status: gitContext.status,
+    changedFiles: gitContext.changedFiles,
+    diffStat: gitContext.diffStat,
+    diff: diffSummary(gitContext.diff, compactedDiff),
+  };
+}
+
+function compactDiff(diff, budget) {
+  if (!diff || typeof diff !== "object") return diff;
+
+  const compacted = {
+    base: diff.base,
+    head: diff.head,
+    mergeBase: diff.mergeBase,
+    truncated: diff.truncated,
+    workflowBudgetChars: budget,
+    workflowCompactions: [],
+  };
+  let remaining = budget;
+
+  ["branch", "staged", "unstaged"].forEach(function (field) {
+    const value = diff[field];
+    if (typeof value !== "string") {
+      compacted[field] = value;
+      return;
+    }
+
+    const included = Math.max(0, Math.min(value.length, remaining));
+    compacted[field] =
+      included === value.length ? value : value.slice(0, included) + diffOmittedMessage(field);
+    remaining -= included;
+    if (included < value.length) {
+      compacted.workflowCompactions.push({
+        field: field,
+        originalChars: value.length,
+        includedChars: included,
+      });
+    }
+  });
+
+  return compacted;
+}
+
+function diffSummary(diff, compactedDiff) {
+  if (!diff || typeof diff !== "object") return diff;
+  return {
+    base: diff.base,
+    head: diff.head,
+    mergeBase: diff.mergeBase,
+    truncated: diff.truncated,
+    workflowBudgetChars: compactedDiff && compactedDiff.workflowBudgetChars,
+    workflowCompactions: diffCompactions({ diff: compactedDiff }),
+    chars: {
+      branch: stringLength(diff.branch),
+      staged: stringLength(diff.staged),
+      unstaged: stringLength(diff.unstaged),
+    },
+  };
+}
+
+function diffCompactions(gitContext) {
+  return asArray(gitContext && gitContext.diff && gitContext.diff.workflowCompactions);
+}
+
+function diffOmittedMessage(field) {
+  return (
+    "\n\n[Workflow prompt budget omitted the rest of the " +
+    field +
+    " diff. Inspect the file directly before making claims about omitted hunks.]"
+  );
 }
 
 function reviewPrompt(lane, input, reviewContext) {
@@ -279,30 +399,36 @@ function reviewPrompt(lane, input, reviewContext) {
     readOnlyPrompt(),
     "You are the " + lane.title + " lane. Review every changed file in the supplied Git context.",
     "If an explicit target is provided and the Git diff is empty, inspect that target path in the workspace before making claims.",
+    "Diff text is capped by workflowBudgetChars; if workflowCompactions or built-in truncated flags are present, inspect files directly before making claims about omitted hunks.",
     "Allowed severity values are: high, medium, low. Return high-signal, actionable findings only; an empty findings array is fine.",
-    "The synthesis step will keep at most " + input.maxFindings + " actionable findings. Use stable finding ids and arrays for filePaths/evidence.",
+    "The synthesis step will keep at most " +
+      input.maxFindings +
+      " actionable findings. Use stable finding ids and arrays for filePaths/evidence.",
     "\nLane checklist:\n- " + lane.instructions.join("\n- "),
     "\nReview context:\n" + reviewContext,
   ].join("\n\n");
 }
 
-function synthesisPrompt(input, reviewContext, reviewOutputs) {
+function synthesisPrompt(input, compactContext, reviewOutputs) {
   return [
     readOnlyPrompt(),
-    "Deduplicate and triage these simplify review findings. Keep actionableFindings to the " + input.maxFindings + " highest-value issues.",
+    "Deduplicate and triage these simplify review findings. Keep actionableFindings to the " +
+      input.maxFindings +
+      " highest-value issues.",
     "Fix actionable issues directly when fix mode is enabled. If a finding is false positive or not worth addressing, put it in skippedFindings without debating it.",
     "Allowed severity values are: high, medium, low. Prefer minimal cleanup over broad refactors.",
-    "\nOriginal review context:\n" + reviewContext,
+    "\nCompact review context without raw diff text:\n" + compactContext,
     "\nLane outputs:\n" + fencedJson(reviewOutputs),
   ].join("\n\n");
 }
 
-function fixPrompt(reviewContext, synthesized) {
+function fixPrompt(compactContext, synthesized) {
   return [
     "Fix the actionable simplify findings with minimal, correct, reviewable changes. Do not push, commit, or open a PR.",
+    "Use the compact context for file lists and diff metadata; inspect files directly instead of relying on raw diff text being embedded in this prompt.",
     "Preserve existing style and functionality. Run targeted validation for touched code when feasible and report exact commands/results.",
     "If a finding is false positive or not worth addressing, skip it and note why. Set madeChanges true only when files changed.",
-    "\nOriginal review context:\n" + reviewContext,
+    "\nCompact review context:\n" + compactContext,
     "\nSynthesized findings:\n" + fencedJson(synthesized),
   ].join("\n\n");
 }
@@ -318,23 +444,31 @@ function parseArgs(args) {
     headRef: text(raw.headRef || raw.head),
     maxFindings: positiveInt(raw.maxFindings, DEFAULT_MAX_FINDINGS),
   };
-  const targetParts = [];
-  const tokens = tokenize(String(raw.input || ""));
+  const tokenized = tokenize(String(raw.input || ""));
+  if (tokenized.error) return { input: input, error: tokenized.error };
 
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index];
-    const valueFlag = parseValueFlag(tokens, index);
+  const targetParts = [];
+  let index = 0;
+  while (index < tokenized.tokens.length) {
+    const token = tokenized.tokens[index];
+    const valueFlag = parseValueFlag(tokenized.tokens, index);
     if (token === "--help" || token === "-h") input.help = true;
     else if (token === "--review-only" || token === "--no-fix") input.fix = false;
     else if (token === "--fix") input.fix = true;
+    else if (valueFlag && valueFlag.error) return { input: input, error: valueFlag.error };
     else if (valueFlag) {
-      input[valueFlag.key] = valueFlag.key === "maxFindings" ? positiveInt(valueFlag.value, DEFAULT_MAX_FINDINGS) : valueFlag.value;
-      index = valueFlag.index;
+      input[valueFlag.key] =
+        valueFlag.key === "maxFindings"
+          ? positiveInt(valueFlag.value, DEFAULT_MAX_FINDINGS)
+          : valueFlag.value;
+      index = valueFlag.nextIndex;
+      continue;
     } else targetParts.push(token);
+    index += 1;
   }
 
   if (!input.target) input.target = targetParts.join(" ").trim();
-  return input;
+  return { input: input, error: "" };
 }
 
 function parseValueFlag(tokens, index) {
@@ -348,11 +482,13 @@ function parseValueFlag(tokens, index) {
   for (let flagIndex = 0; flagIndex < flags.length; flagIndex += 1) {
     const flag = flags[flagIndex];
     if (token === flag.name) {
-      assert(index + 1 < tokens.length, flag.name + " requires a value");
-      return { key: flag.key, value: tokens[index + 1], index: index + 1 };
+      if (index + 1 >= tokens.length) return { error: flag.name + " requires a value" };
+      return { key: flag.key, value: tokens[index + 1], nextIndex: index + 2 };
     }
     if (token.indexOf(flag.name + "=") === 0) {
-      return { key: flag.key, value: token.slice(flag.name.length + 1), index: index };
+      const value = token.slice(flag.name.length + 1);
+      if (!value) return { error: flag.name + " requires a value" };
+      return { key: flag.key, value: value, nextIndex: index + 1 };
     }
   }
   return null;
@@ -380,10 +516,10 @@ function tokenize(input) {
       current = "";
     } else current += char;
   }
-  assert(!quote, "unterminated quoted argument");
+  if (quote) return { tokens: tokens, error: "unterminated quoted argument" };
   if (escaped) current += "\\";
   if (current) tokens.push(current);
-  return tokens;
+  return { tokens: tokens, error: "" };
 }
 
 function readOnlyPrompt() {
@@ -391,40 +527,52 @@ function readOnlyPrompt() {
 }
 
 function reviewOnlyReport(input, markdown) {
-  const mode = input.fix ? "No actionable fixes were selected." : "Review-only mode; no fixes were applied.";
+  const mode = input.fix
+    ? "No actionable fixes were selected."
+    : "Review-only mode; no fixes were applied.";
   return markdown + "\n\n---\n\n## Simplify workflow result\n\n" + mode;
 }
 
 function fixReport(synthesisMarkdown, fixerMarkdown, applied) {
   const status = applied && applied.status ? applied.status : "unknown";
   const success = Boolean(applied && applied.success);
-  return synthesisMarkdown + "\n\n---\n\n## Fix pass\n\n" + fixerMarkdown + "\n\n### Patch application\n\n- Status: " + status + "\n- Success: " + String(success);
+  return (
+    synthesisMarkdown +
+    "\n\n---\n\n## Fix pass\n\n" +
+    fixerMarkdown +
+    "\n\n### Patch application\n\n- Status: " +
+    status +
+    "\n- Success: " +
+    String(success)
+  );
 }
 
-function usageResult() {
+function usageResult(error) {
+  const lines = [
+    "# simplify workflow",
+    "",
+    "Review current git changes for code reuse, quality, and efficiency, then fix actionable issues.",
+    "",
+    "## Usage",
+    "",
+    "- `/workflow simplify` — review current git changes and apply fixes.",
+    "- `/workflow simplify --review-only` — review and synthesize findings without applying fixes.",
+    "- `/workflow simplify --base main --head HEAD` — review a specific ref range.",
+    "- `/workflow simplify path/or/context` — provide an explicit target when there are no Git changes.",
+    "",
+    "## Options",
+    "",
+    "- `--review-only` / `--no-fix`",
+    "- `--fix`",
+    "- `--base <ref>`",
+    "- `--trunk <ref>`",
+    "- `--head <ref>`",
+    "- `--max-findings <n>`",
+  ];
+  if (error) lines.splice(2, 0, "", "**Argument error:** " + error);
   return {
-    reportMarkdown: [
-      "# simplify workflow",
-      "",
-      "Review current git changes for code reuse, quality, and efficiency, then fix actionable issues.",
-      "",
-      "## Usage",
-      "",
-      "- `/workflow simplify` — review current git changes and apply fixes.",
-      "- `/workflow simplify --review-only` — review and synthesize findings without applying fixes.",
-      "- `/workflow simplify --base main --head HEAD` — review a specific ref range.",
-      "- `/workflow simplify path/or/context` — provide an explicit target when there are no Git changes.",
-      "",
-      "## Options",
-      "",
-      "- `--review-only` / `--no-fix`",
-      "- `--fix`",
-      "- `--base <ref>`",
-      "- `--trunk <ref>`",
-      "- `--head <ref>`",
-      "- `--max-findings <n>`",
-    ].join("\n"),
-    structuredOutput: { help: true },
+    reportMarkdown: lines.join("\n"),
+    structuredOutput: { help: true, error: error || "" },
   };
 }
 
@@ -443,6 +591,10 @@ function mustObject(value, message) {
 
 function text(value) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function stringLength(value) {
+  return typeof value === "string" ? value.length : 0;
 }
 
 function positiveInt(value, fallback) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -171,6 +171,19 @@ export default function simplifyWorkflow({
     diffCompactions: asArray(contexts.outputGitContext.diff?.workflowCompactions).length,
   });
 
+  if (hasUntrackedChanges(gitContext)) {
+    const reason = untrackedChangesSkipReason();
+    return {
+      reportMarkdown: "## Simplify workflow result\n\n" + reason,
+      structuredOutput: {
+        mode: "untracked-changes-skip-review",
+        gitContext: contexts.outputGitContext,
+        reviews: [],
+        synthesis: { ...EMPTY_SYNTHESIS, summary: reason },
+      },
+    };
+  }
+
   if (!hasReviewableContext(input, gitContext)) {
     return {
       reportMarkdown: "## Simplify workflow result\n\n" + NO_REVIEWABLE_CHANGES_SUMMARY,
@@ -390,6 +403,10 @@ function nonCurrentHeadSkipReason() {
   return "Auto-fix was skipped because the requested `--head` is not the current checkout. Check out that branch/ref or pass the current commit SHA before applying fixes.";
 }
 
+function untrackedChangesSkipReason() {
+  return "Review was skipped because untracked file contents are not available to workflow child workspaces. Add them with `git add -N` or commit them, then rerun `/workflow simplify`.";
+}
+
 function uncommittedChangesSkipReason() {
   return "Auto-fix was skipped because uncommitted changes are present. Commit or stash them, then rerun `/workflow simplify --fix`.";
 }
@@ -510,6 +527,13 @@ function isRequestedHeadCurrent(status, input) {
 
 function isGitCommitSha(value) {
   return /^[0-9a-f]{7,40}$/i.test(value);
+}
+
+function hasUntrackedChanges(gitContext) {
+  return (
+    hasArrayItems(gitContext.status && gitContext.status.untracked) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.untracked)
+  );
 }
 
 function hasUncommittedChanges(gitContext) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -914,7 +914,9 @@ function tokenize(input) {
       current += char;
       escaped = false;
     } else if (quote && char === "\\") {
-      escaped = true;
+      const next = input[index + 1];
+      if (next === quote || next === "\\") escaped = true;
+      else current += char;
     } else if (quote) {
       if (char === quote) quote = "";
       else current += char;

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -244,7 +244,7 @@ export default function simplifyWorkflow({
       synthesized
     );
   }
-  if (!isRequestedHeadCurrent(gitContext.status)) {
+  if (!isRequestedHeadCurrent(gitContext.status, input)) {
     return skipFixResult(
       synthesis.reportMarkdown,
       nonCurrentHeadSkipReason(),
@@ -365,7 +365,7 @@ function collectApplyPreflight(action, log, input, gitContext) {
     return failedApplyPreflight(stagedChangesSkipReason());
   }
 
-  if (!isRequestedHeadCurrent(status)) {
+  if (!isRequestedHeadCurrent(status, input)) {
     return failedApplyPreflight(nonCurrentHeadSkipReason());
   }
 
@@ -389,7 +389,7 @@ function failedApplyPreflight(reason) {
 }
 
 function nonCurrentHeadSkipReason() {
-  return "Auto-fix was skipped because the requested `--head` is not the current checkout. Check out that ref or rerun without `--head` before applying fixes.";
+  return "Auto-fix was skipped because the requested `--head` is not the current checkout. Check out that branch/ref or pass the current commit SHA before applying fixes.";
 }
 
 function stagedChangesSkipReason() {
@@ -485,12 +485,29 @@ function shouldReadDiffs(changedFiles) {
   );
 }
 
-function isRequestedHeadCurrent(status) {
+function isRequestedHeadCurrent(status, input) {
   if (!status || typeof status !== "object") return false;
   const currentHeadSha = typeof status.headSha === "string" ? status.headSha : "";
   const requestedHeadSha =
     typeof status.requestedHeadSha === "string" ? status.requestedHeadSha : currentHeadSha;
-  return Boolean(currentHeadSha && requestedHeadSha && currentHeadSha === requestedHeadSha);
+  if (!currentHeadSha || !requestedHeadSha || currentHeadSha !== requestedHeadSha) return false;
+
+  const requestedHead = input && input.headRef ? input.headRef : "";
+  if (!requestedHead || requestedHead === "HEAD") return true;
+
+  const currentBranch = typeof status.branch === "string" ? status.branch : "";
+  const currentBranchRef = currentBranch ? "refs/heads/" + currentBranch : "";
+  const requestedHeadRef =
+    typeof status.requestedHeadRef === "string" ? status.requestedHeadRef : "";
+  if (requestedHeadRef) return Boolean(currentBranchRef && requestedHeadRef === currentBranchRef);
+  if (currentBranch && (requestedHead === currentBranch || requestedHead === currentBranchRef)) {
+    return true;
+  }
+  return isGitCommitSha(requestedHead);
+}
+
+function isGitCommitSha(value) {
+  return /^[0-9a-f]{7,40}$/i.test(value);
 }
 
 function hasStagedChanges(gitContext) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -245,23 +245,30 @@ export default function simplifyWorkflow({
 }
 
 function collectGitContext(action, input) {
-  const refs = gitRefs(input);
+  const requestedRefs = gitRefs(input);
   const failures = [];
+  const status = gitSlice(failures, "status", function () {
+    return action.git.status({
+      id: "git-status",
+      input: { includeIgnored: false },
+      builtInOnly: true,
+    }).output;
+  });
+  const changedFiles = gitSlice(failures, "changedFiles", function () {
+    return action.git.changedFiles({
+      id: "git-changed-files",
+      input: requestedRefs,
+      builtInOnly: true,
+    }).output;
+  });
+  const refs = refsWithResolvedBase(requestedRefs, changedFiles);
+
   return {
     target: input.target,
     refs: refs,
     failures: failures,
-    status: gitSlice(failures, "status", function () {
-      return action.git.status({
-        id: "git-status",
-        input: { includeIgnored: false },
-        builtInOnly: true,
-      }).output;
-    }),
-    changedFiles: gitSlice(failures, "changedFiles", function () {
-      return action.git.changedFiles({ id: "git-changed-files", input: refs, builtInOnly: true })
-        .output;
-    }),
+    status: status,
+    changedFiles: changedFiles,
     diffStat: gitSlice(failures, "diffStat", function () {
       return action.git.diffStat({ id: "git-diff-stat", input: refs, builtInOnly: true }).output;
     }),
@@ -286,6 +293,17 @@ function gitRefs(input) {
   if (input.trunkRef) refs.trunk = input.trunkRef;
   if (input.headRef) refs.head = input.headRef;
   return refs;
+}
+
+function refsWithResolvedBase(refs, changedFiles) {
+  if (refs.base || refs.trunk || !changedFiles || typeof changedFiles.base !== "string") {
+    return refs;
+  }
+  if (!changedFiles.base) return refs;
+
+  const resolved = { base: changedFiles.base };
+  if (refs.head) resolved.head = refs.head;
+  return resolved;
 }
 
 function promptContexts(input, gitContext) {
@@ -373,7 +391,7 @@ function diffSummary(diff, compactedDiff) {
     mergeBase: diff.mergeBase,
     truncated: diff.truncated,
     workflowBudgetChars: compactedDiff && compactedDiff.workflowBudgetChars,
-    workflowCompactions: diffCompactions({ diff: compactedDiff }),
+    workflowCompactions: compactedDiff ? asArray(compactedDiff.workflowCompactions) : [],
     chars: {
       branch: stringLength(diff.branch),
       staged: stringLength(diff.staged),

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -171,7 +171,7 @@ export default function simplifyWorkflow({
     diffCompactions: asArray(contexts.outputGitContext.diff?.workflowCompactions).length,
   });
 
-  if (hasOnlyUntrackedChanges(gitContext) && targetNeedsUntrackedContent(input, gitContext)) {
+  if (shouldSkipForUntrackedContent(input, gitContext)) {
     const reason = untrackedChangesSkipReason();
     return {
       reportMarkdown: "## Simplify workflow result\n\n" + reason,
@@ -527,6 +527,13 @@ function isRequestedHeadCurrent(status, input) {
 
 function isGitCommitSha(value) {
   return /^[0-9a-f]{7,40}$/i.test(value);
+}
+
+function shouldSkipForUntrackedContent(input, gitContext) {
+  if (!hasUntrackedChanges(gitContext)) return false;
+  return input.target
+    ? targetNeedsUntrackedContent(input, gitContext)
+    : hasOnlyUntrackedChanges(gitContext);
 }
 
 function targetNeedsUntrackedContent(input, gitContext) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -541,7 +541,7 @@ function isRequestedHeadCurrent(status, input) {
 }
 
 function isGitCommitSha(value) {
-  return /^[0-9a-f]{7,40}$/i.test(value);
+  return /^[0-9a-f]{7,64}$/i.test(value);
 }
 
 function shouldSkipForUntrackedContent(input, gitContext) {
@@ -915,8 +915,9 @@ function tokenize(input) {
       escaped = false;
     } else if (quote && char === "\\") {
       const next = input[index + 1];
-      if (next === quote || next === "\\") escaped = true;
-      else current += char;
+      if (next === "\\" || (next === quote && !isClosingQuote(input, index + 1))) {
+        escaped = true;
+      } else current += char;
     } else if (quote) {
       if (char === quote) quote = "";
       else current += char;
@@ -931,6 +932,10 @@ function tokenize(input) {
   if (escaped) current += "\\";
   if (current) tokens.push(current);
   return { tokens: tokens, error: "" };
+}
+
+function isClosingQuote(input, quoteIndex) {
+  return quoteIndex + 1 >= input.length || /\s/.test(input[quoteIndex + 1]);
 }
 
 function reviewOnlyReport(input, markdown) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -540,6 +540,7 @@ function targetNeedsUntrackedContent(input, gitContext) {
   if (!input.target) return true;
   const target = normalizedPath(input.target);
   if (!target) return false;
+  if (target === ".") return true;
   return untrackedPaths(gitContext).some(function (path) {
     const untracked = normalizedPath(path);
     return untracked === target || untracked.startsWith(target + "/");
@@ -560,7 +561,9 @@ function filePath(value) {
 
 function normalizedPath(value) {
   if (typeof value !== "string") return "";
-  return value.trim().replace(/^\.\//, "").replace(/\/+$/, "");
+  const trimmed = value.trim();
+  if (trimmed === "." || trimmed === "./") return ".";
+  return trimmed.replace(/^\.\//, "").replace(/\/+$/, "");
 }
 
 function hasOnlyUntrackedChanges(gitContext) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -233,6 +233,22 @@ export default function simplifyWorkflow({
     };
   }
 
+  // git am cannot apply onto a dirty index; keep the review result but skip auto-fix.
+  if (hasStagedChanges(gitContext)) {
+    return {
+      reportMarkdown:
+        synthesis.reportMarkdown +
+        "\n\n---\n\n## Simplify workflow result\n\n" +
+        "Auto-fix was skipped because staged changes are present. Unstage or commit staged changes, then rerun `/workflow simplify --fix`.",
+      structuredOutput: {
+        mode: "staged-changes-skip-fix",
+        gitContext: contexts.outputGitContext,
+        reviews: reviewOutputs,
+        synthesis: synthesized,
+      },
+    };
+  }
+
   phase("fix", { actionableFindingCount: actionableFindings.length });
   const fixer = agent({
     id: "fix-simplify-findings",
@@ -362,6 +378,13 @@ function shouldReadDiffs(changedFiles) {
     hasArrayItems(changedFiles.branch) ||
     hasArrayItems(changedFiles.staged) ||
     hasArrayItems(changedFiles.unstaged)
+  );
+}
+
+function hasStagedChanges(gitContext) {
+  return (
+    hasArrayItems(gitContext.status && gitContext.status.staged) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.staged)
   );
 }
 

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -265,6 +265,8 @@ export default function simplifyWorkflow({
     source: fixer,
     target: "parent",
     threeWay: true,
+    // simplify fixes the dirty changes it just reviewed, so patch onto that worktree.
+    force: true,
     onConflict: "return",
   });
 

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -488,11 +488,15 @@ function shouldReadDiffs(changedFiles) {
 function isRequestedHeadCurrent(status, input) {
   if (!status || typeof status !== "object") return false;
   const currentHeadSha = typeof status.headSha === "string" ? status.headSha : "";
+  const requestedHead = input && input.headRef ? input.headRef : "";
   const requestedHeadSha =
-    typeof status.requestedHeadSha === "string" ? status.requestedHeadSha : currentHeadSha;
+    typeof status.requestedHeadSha === "string"
+      ? status.requestedHeadSha
+      : requestedHead
+        ? ""
+        : currentHeadSha;
   if (!currentHeadSha || !requestedHeadSha || currentHeadSha !== requestedHeadSha) return false;
 
-  const requestedHead = input && input.headRef ? input.headRef : "";
   if (!requestedHead || requestedHead === "HEAD") return true;
 
   const currentBranch = typeof status.branch === "string" ? status.branch : "";

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -1,0 +1,455 @@
+// description: Review current changes for reuse, quality, and efficiency, then fix actionable issues.
+
+const DEFAULT_MAX_FINDINGS = 20;
+const REVIEW_AGENT_ID = "explore";
+const EXEC_AGENT_ID = "exec";
+const REVIEW_LANES = [
+  {
+    id: "reuse",
+    title: "Simplify: code reuse review",
+    instructions: [
+      "Search for existing utilities and helpers that could replace newly written code.",
+      "Flag new functions that duplicate existing functionality and name the existing function to use instead.",
+      "Flag inline logic that could use an existing utility: string handling, path handling, environment checks, type guards, and similar patterns.",
+    ],
+  },
+  {
+    id: "quality",
+    title: "Simplify: code quality review",
+    instructions: [
+      "Find redundant state, cached values that could be derived, and observers/effects that could be direct calls.",
+      "Find parameter sprawl, copy-paste with slight variation, and leaky abstractions.",
+      "Find stringly-typed code and unnecessary JSX wrappers that add no layout value.",
+    ],
+  },
+  {
+    id: "efficiency",
+    title: "Simplify: efficiency review",
+    instructions: [
+      "Find redundant computations, repeated file reads, duplicate network/API calls, N+1 patterns, and missed concurrency.",
+      "Find hot-path bloat, recurring no-op updates, and updater wrappers that defeat same-reference no-op returns.",
+      "Find TOCTOU existence pre-checks, unbounded memory, missing cleanup, and overly broad reads or loads.",
+    ],
+  },
+];
+
+const SEVERITY_SCHEMA = { type: "string", enum: ["high", "medium", "low"] };
+const FINDING_SCHEMA = {
+  type: "object",
+  required: ["id", "title", "severity", "filePaths", "rationale", "recommendation", "evidence"],
+  properties: {
+    id: { type: "string" },
+    title: { type: "string" },
+    severity: SEVERITY_SCHEMA,
+    filePaths: { type: "array", items: { type: "string" } },
+    rationale: { type: "string" },
+    recommendation: { type: "string" },
+    evidence: { type: "array", items: { type: "string" } },
+  },
+};
+const REVIEW_SCHEMA = {
+  type: "object",
+  required: ["summary", "findings"],
+  properties: {
+    summary: { type: "string" },
+    findings: { type: "array", items: FINDING_SCHEMA },
+  },
+};
+const SYNTHESIS_FINDING_SCHEMA = {
+  type: "object",
+  required: ["id", "title", "severity", "filePaths", "rationale", "fixPlan"],
+  properties: {
+    id: { type: "string" },
+    title: { type: "string" },
+    severity: SEVERITY_SCHEMA,
+    filePaths: { type: "array", items: { type: "string" } },
+    rationale: { type: "string" },
+    fixPlan: { type: "string" },
+  },
+};
+const SKIPPED_FINDING_SCHEMA = {
+  type: "object",
+  required: ["id", "title", "reason"],
+  properties: {
+    id: { type: "string" },
+    title: { type: "string" },
+    reason: { type: "string" },
+  },
+};
+const SYNTHESIS_SCHEMA = {
+  type: "object",
+  required: ["summary", "shouldFix", "actionableFindings", "skippedFindings", "validationPlan"],
+  properties: {
+    summary: { type: "string" },
+    shouldFix: { type: "boolean" },
+    actionableFindings: { type: "array", items: SYNTHESIS_FINDING_SCHEMA },
+    skippedFindings: { type: "array", items: SKIPPED_FINDING_SCHEMA },
+    validationPlan: { type: "array", items: { type: "string" } },
+  },
+};
+const FIXER_SCHEMA = {
+  type: "object",
+  required: ["madeChanges", "fixedFindingIds", "skippedFindings", "validation"],
+  properties: {
+    madeChanges: { type: "boolean" },
+    fixedFindingIds: { type: "array", items: { type: "string" } },
+    skippedFindings: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["id", "reason"],
+        properties: {
+          id: { type: "string" },
+          reason: { type: "string" },
+        },
+      },
+    },
+    validation: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["command", "status", "summary"],
+        properties: {
+          command: { type: "string" },
+          status: { type: "string" },
+          summary: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+export default function simplifyWorkflow({ args, phase, log, action, parallelAgents, agent, applyPatch }) {
+  assert(action && parallelAgents && agent && applyPatch, "workflow runtime APIs are required");
+
+  const input = parseArgs(args);
+  if (input.help) return usageResult();
+
+  phase("capture-context", { target: input.target || "current git changes", fix: input.fix });
+  const gitContext = collectGitContext(action, input);
+  log("Captured simplify context", {
+    target: input.target || "current git changes",
+    gitFailures: gitContext.failures.length,
+  });
+
+  const reviewContext = renderReviewContext(input, gitContext);
+
+  phase("review", { lanes: REVIEW_LANES.map(function (lane) { return lane.id; }) });
+  const reviewOutputs = parallelAgents(
+    REVIEW_LANES.map(function (lane) {
+      return {
+        id: lane.id + "-review",
+        title: lane.title,
+        agentId: REVIEW_AGENT_ID,
+        prompt: reviewPrompt(lane, input, reviewContext),
+        outputSchema: REVIEW_SCHEMA,
+      };
+    }),
+    { maxParallel: REVIEW_LANES.length }
+  ).map(function (review) {
+    return mustObject(review.structuredOutput, "review structured output is required");
+  });
+
+  const rawFindingCount = reviewOutputs.reduce(function (count, output) {
+    return count + asArray(output.findings).length;
+  }, 0);
+
+  phase("synthesize", { rawFindingCount: rawFindingCount });
+  const synthesis = agent({
+    id: "synthesize-simplify-findings",
+    title: "Simplify: synthesize findings",
+    agentId: EXEC_AGENT_ID,
+    prompt: synthesisPrompt(input, reviewContext, reviewOutputs),
+    outputSchema: SYNTHESIS_SCHEMA,
+  });
+  const synthesized = mustObject(synthesis.structuredOutput, "synthesis structured output is required");
+  const actionableFindings = asArray(synthesized.actionableFindings);
+
+  if (!input.fix || !synthesized.shouldFix || actionableFindings.length === 0) {
+    return {
+      reportMarkdown: reviewOnlyReport(input, synthesis.reportMarkdown),
+      structuredOutput: {
+        mode: input.fix ? "no-actionable-fixes" : "review-only",
+        gitContext: gitContext,
+        reviews: reviewOutputs,
+        synthesis: synthesized,
+      },
+    };
+  }
+
+  phase("fix", { actionableFindingCount: actionableFindings.length });
+  const fixer = agent({
+    id: "fix-simplify-findings",
+    title: "Simplify: fix actionable findings",
+    agentId: EXEC_AGENT_ID,
+    prompt: fixPrompt(reviewContext, synthesized),
+    outputSchema: FIXER_SCHEMA,
+  });
+  const fixerOutput = mustObject(fixer.structuredOutput, "fixer structured output is required");
+
+  if (!fixerOutput.madeChanges) {
+    return {
+      reportMarkdown: synthesis.reportMarkdown + "\n\n---\n\n## Fix pass\n\nThe fixer did not make file changes.\n\n" + fixer.reportMarkdown,
+      structuredOutput: {
+        mode: "fixer-made-no-changes",
+        gitContext: gitContext,
+        reviews: reviewOutputs,
+        synthesis: synthesized,
+        fix: { fixer: fixerOutput, applied: null },
+      },
+    };
+  }
+
+  phase("apply-fixes", { madeChanges: true });
+  const applied = applyPatch({
+    id: "apply-simplify-fixes",
+    source: fixer,
+    target: "parent",
+    threeWay: true,
+    onConflict: "return",
+  });
+
+  return {
+    reportMarkdown: fixReport(synthesis.reportMarkdown, fixer.reportMarkdown, applied),
+    structuredOutput: {
+      mode: "fix-attempted",
+      gitContext: gitContext,
+      reviews: reviewOutputs,
+      synthesis: synthesized,
+      fix: { fixer: fixerOutput, applied: applied },
+    },
+  };
+}
+
+function collectGitContext(action, input) {
+  const refs = gitRefs(input);
+  const failures = [];
+  return {
+    target: input.target,
+    refs: refs,
+    failures: failures,
+    status: gitSlice(failures, "status", function () {
+      return action.git.status({ id: "git-status", input: { includeIgnored: false }, builtInOnly: true }).output;
+    }),
+    changedFiles: gitSlice(failures, "changedFiles", function () {
+      return action.git.changedFiles({ id: "git-changed-files", input: refs, builtInOnly: true }).output;
+    }),
+    diffStat: gitSlice(failures, "diffStat", function () {
+      return action.git.diffStat({ id: "git-diff-stat", input: refs, builtInOnly: true }).output;
+    }),
+    diff: gitSlice(failures, "diff", function () {
+      return action.git.diff({ id: "git-diff", input: refs, builtInOnly: true }).output;
+    }),
+  };
+}
+
+function gitSlice(failures, name, read) {
+  try {
+    return read();
+  } catch (error) {
+    failures.push({ name: name, error: String(error) });
+    return null;
+  }
+}
+
+function gitRefs(input) {
+  const refs = {};
+  if (input.baseRef) refs.base = input.baseRef;
+  if (input.trunkRef) refs.trunk = input.trunkRef;
+  if (input.headRef) refs.head = input.headRef;
+  return refs;
+}
+
+function renderReviewContext(input, gitContext) {
+  return fencedJson({
+    input: {
+      target: input.target,
+      fix: input.fix,
+      baseRef: input.baseRef,
+      trunkRef: input.trunkRef,
+      headRef: input.headRef,
+      maxFindings: input.maxFindings,
+    },
+    gitContext: gitContext,
+  });
+}
+
+function reviewPrompt(lane, input, reviewContext) {
+  return [
+    readOnlyPrompt(),
+    "You are the " + lane.title + " lane. Review every changed file in the supplied Git context.",
+    "If an explicit target is provided and the Git diff is empty, inspect that target path in the workspace before making claims.",
+    "Allowed severity values are: high, medium, low. Return high-signal, actionable findings only; an empty findings array is fine.",
+    "The synthesis step will keep at most " + input.maxFindings + " actionable findings. Use stable finding ids and arrays for filePaths/evidence.",
+    "\nLane checklist:\n- " + lane.instructions.join("\n- "),
+    "\nReview context:\n" + reviewContext,
+  ].join("\n\n");
+}
+
+function synthesisPrompt(input, reviewContext, reviewOutputs) {
+  return [
+    readOnlyPrompt(),
+    "Deduplicate and triage these simplify review findings. Keep actionableFindings to the " + input.maxFindings + " highest-value issues.",
+    "Fix actionable issues directly when fix mode is enabled. If a finding is false positive or not worth addressing, put it in skippedFindings without debating it.",
+    "Allowed severity values are: high, medium, low. Prefer minimal cleanup over broad refactors.",
+    "\nOriginal review context:\n" + reviewContext,
+    "\nLane outputs:\n" + fencedJson(reviewOutputs),
+  ].join("\n\n");
+}
+
+function fixPrompt(reviewContext, synthesized) {
+  return [
+    "Fix the actionable simplify findings with minimal, correct, reviewable changes. Do not push, commit, or open a PR.",
+    "Preserve existing style and functionality. Run targeted validation for touched code when feasible and report exact commands/results.",
+    "If a finding is false positive or not worth addressing, skip it and note why. Set madeChanges true only when files changed.",
+    "\nOriginal review context:\n" + reviewContext,
+    "\nSynthesized findings:\n" + fencedJson(synthesized),
+  ].join("\n\n");
+}
+
+function parseArgs(args) {
+  const raw = args && typeof args === "object" ? args : {};
+  const input = {
+    help: Boolean(raw.help),
+    fix: raw.fix !== false && raw.reviewOnly !== true,
+    target: text(raw.target),
+    baseRef: text(raw.baseRef || raw.base),
+    trunkRef: text(raw.trunkRef || raw.trunk),
+    headRef: text(raw.headRef || raw.head),
+    maxFindings: positiveInt(raw.maxFindings, DEFAULT_MAX_FINDINGS),
+  };
+  const targetParts = [];
+  const tokens = tokenize(String(raw.input || ""));
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const valueFlag = parseValueFlag(tokens, index);
+    if (token === "--help" || token === "-h") input.help = true;
+    else if (token === "--review-only" || token === "--no-fix") input.fix = false;
+    else if (token === "--fix") input.fix = true;
+    else if (valueFlag) {
+      input[valueFlag.key] = valueFlag.key === "maxFindings" ? positiveInt(valueFlag.value, DEFAULT_MAX_FINDINGS) : valueFlag.value;
+      index = valueFlag.index;
+    } else targetParts.push(token);
+  }
+
+  if (!input.target) input.target = targetParts.join(" ").trim();
+  return input;
+}
+
+function parseValueFlag(tokens, index) {
+  const flags = [
+    { name: "--base", key: "baseRef" },
+    { name: "--trunk", key: "trunkRef" },
+    { name: "--head", key: "headRef" },
+    { name: "--max-findings", key: "maxFindings" },
+  ];
+  const token = tokens[index];
+  for (let flagIndex = 0; flagIndex < flags.length; flagIndex += 1) {
+    const flag = flags[flagIndex];
+    if (token === flag.name) {
+      assert(index + 1 < tokens.length, flag.name + " requires a value");
+      return { key: flag.key, value: tokens[index + 1], index: index + 1 };
+    }
+    if (token.indexOf(flag.name + "=") === 0) {
+      return { key: flag.key, value: token.slice(flag.name.length + 1), index: index };
+    }
+  }
+  return null;
+}
+
+function tokenize(input) {
+  const tokens = [];
+  let current = "";
+  let quote = "";
+  let escaped = false;
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+    if (escaped) {
+      current += char;
+      escaped = false;
+    } else if (quote && char === "\\") {
+      escaped = true;
+    } else if (quote) {
+      if (char === quote) quote = "";
+      else current += char;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (/\s/.test(char)) {
+      if (current) tokens.push(current);
+      current = "";
+    } else current += char;
+  }
+  assert(!quote, "unterminated quoted argument");
+  if (escaped) current += "\\";
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function readOnlyPrompt() {
+  return "This is a read-only review step. Do not edit files, create commits, apply patches, push branches, or open PRs. Inspect repository evidence only as needed and report findings.";
+}
+
+function reviewOnlyReport(input, markdown) {
+  const mode = input.fix ? "No actionable fixes were selected." : "Review-only mode; no fixes were applied.";
+  return markdown + "\n\n---\n\n## Simplify workflow result\n\n" + mode;
+}
+
+function fixReport(synthesisMarkdown, fixerMarkdown, applied) {
+  const status = applied && applied.status ? applied.status : "unknown";
+  const success = Boolean(applied && applied.success);
+  return synthesisMarkdown + "\n\n---\n\n## Fix pass\n\n" + fixerMarkdown + "\n\n### Patch application\n\n- Status: " + status + "\n- Success: " + String(success);
+}
+
+function usageResult() {
+  return {
+    reportMarkdown: [
+      "# simplify workflow",
+      "",
+      "Review current git changes for code reuse, quality, and efficiency, then fix actionable issues.",
+      "",
+      "## Usage",
+      "",
+      "- `/workflow simplify` — review current git changes and apply fixes.",
+      "- `/workflow simplify --review-only` — review and synthesize findings without applying fixes.",
+      "- `/workflow simplify --base main --head HEAD` — review a specific ref range.",
+      "- `/workflow simplify path/or/context` — provide an explicit target when there are no Git changes.",
+      "",
+      "## Options",
+      "",
+      "- `--review-only` / `--no-fix`",
+      "- `--fix`",
+      "- `--base <ref>`",
+      "- `--trunk <ref>`",
+      "- `--head <ref>`",
+      "- `--max-findings <n>`",
+    ].join("\n"),
+    structuredOutput: { help: true },
+  };
+}
+
+function fencedJson(value) {
+  return "```json\n" + JSON.stringify(value, null, 2) + "\n```";
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function mustObject(value, message) {
+  assert(value && typeof value === "object", message);
+  return value;
+}
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function positiveInt(value, fallback) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 1 ? Math.floor(number) : fallback;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -5,6 +5,15 @@ const DEFAULT_MAX_FINDINGS = 20;
 const REVIEW_DIFF_CHAR_BUDGET = 60000;
 const METADATA_ARRAY_ITEM_BUDGET = 200;
 const DIFF_STAT_CHAR_BUDGET = 20000;
+const NO_REVIEWABLE_CHANGES_SUMMARY = "No reviewable changes found.";
+const READ_ONLY_PROMPT =
+  "This is a read-only review step. Do not edit files, create commits, apply patches, push branches, or open PRs. Inspect repository evidence only as needed and report findings.";
+const VALUE_FLAGS = [
+  { name: "--base", key: "baseRef" },
+  { name: "--trunk", key: "trunkRef" },
+  { name: "--head", key: "headRef" },
+  { name: "--max-findings", key: "maxFindings" },
+];
 const REVIEW_AGENT_ID = "explore";
 const EXEC_AGENT_ID = "exec";
 const REVIEW_LANES = [
@@ -122,6 +131,14 @@ const FIXER_SCHEMA = {
   },
 };
 
+const EMPTY_SYNTHESIS = {
+  summary: NO_REVIEWABLE_CHANGES_SUMMARY,
+  shouldFix: false,
+  actionableFindings: [],
+  skippedFindings: [],
+  validationPlan: [],
+};
+
 export default function simplifyWorkflow({
   args,
   phase,
@@ -145,17 +162,17 @@ export default function simplifyWorkflow({
   log("Captured simplify context", {
     target: input.target || "current git changes",
     gitFailures: gitContext.failures.length,
-    diffCompactions: diffCompactions(contexts.outputGitContext).length,
+    diffCompactions: asArray(contexts.outputGitContext.diff?.workflowCompactions).length,
   });
 
   if (!hasReviewableContext(input, gitContext)) {
     return {
-      reportMarkdown: "## Simplify workflow result\n\nNo reviewable changes found.",
+      reportMarkdown: "## Simplify workflow result\n\n" + NO_REVIEWABLE_CHANGES_SUMMARY,
       structuredOutput: {
         mode: "no-reviewable-changes",
         gitContext: contexts.outputGitContext,
         reviews: [],
-        synthesis: emptySynthesis("No reviewable changes found."),
+        synthesis: EMPTY_SYNTHESIS,
       },
     };
   }
@@ -337,19 +354,14 @@ function hasReviewableContext(input, gitContext) {
   );
 }
 
-function emptySynthesis(summary) {
-  return {
-    summary: summary,
-    shouldFix: false,
-    actionableFindings: [],
-    skippedFindings: [],
-    validationPlan: [],
-  };
-}
-
 function promptContexts(input, gitContext) {
-  const reviewGitContext = compactMetadata(withCompactedDiff(gitContext, REVIEW_DIFF_CHAR_BUDGET));
-  const outputGitContext = compactMetadata(withoutDiffText(gitContext, reviewGitContext.diff));
+  const compactedGitContext = compactMetadata(gitContext);
+  const reviewDiff = compactDiff(gitContext.diff, REVIEW_DIFF_CHAR_BUDGET);
+  const reviewGitContext = { ...compactedGitContext, diff: reviewDiff };
+  const outputGitContext = {
+    ...compactedGitContext,
+    diff: diffSummary(gitContext.diff, reviewDiff),
+  };
   return {
     review: renderContext(input, reviewGitContext),
     compact: renderContext(input, outputGitContext),
@@ -424,14 +436,6 @@ function compactText(value, limit) {
   );
 }
 
-function withCompactedDiff(gitContext, budget) {
-  return { ...gitContext, diff: compactDiff(gitContext.diff, budget) };
-}
-
-function withoutDiffText(gitContext, compactedDiff) {
-  return { ...gitContext, diff: diffSummary(gitContext.diff, compactedDiff) };
-}
-
 function compactDiff(diff, budget) {
   if (!diff || typeof diff !== "object") return diff;
 
@@ -485,10 +489,6 @@ function diffSummary(diff, compactedDiff) {
   };
 }
 
-function diffCompactions(gitContext) {
-  return asArray(gitContext && gitContext.diff && gitContext.diff.workflowCompactions);
-}
-
 function diffOmittedMessage(field) {
   return (
     "\n\n[Workflow prompt budget omitted the rest of the " +
@@ -499,7 +499,7 @@ function diffOmittedMessage(field) {
 
 function reviewPrompt(lane, input, reviewContext) {
   return [
-    readOnlyPrompt(),
+    READ_ONLY_PROMPT,
     "You are the " + lane.title + " lane. Review every changed file in the supplied Git context.",
     "If an explicit target is provided and the Git diff is empty, inspect that target path in the workspace before making claims.",
     "Diff text is capped by workflowBudgetChars; if workflowCompactions or built-in truncated flags are present, inspect files directly before making claims about omitted hunks.",
@@ -514,7 +514,7 @@ function reviewPrompt(lane, input, reviewContext) {
 
 function synthesisPrompt(input, compactContext, reviewOutputs) {
   return [
-    readOnlyPrompt(),
+    READ_ONLY_PROMPT,
     "Deduplicate and triage these simplify review findings. Keep actionableFindings to the " +
       input.maxFindings +
       " highest-value issues.",
@@ -575,20 +575,14 @@ function parseArgs(args) {
 }
 
 function parseValueFlag(tokens, index) {
-  const flags = [
-    { name: "--base", key: "baseRef" },
-    { name: "--trunk", key: "trunkRef" },
-    { name: "--head", key: "headRef" },
-    { name: "--max-findings", key: "maxFindings" },
-  ];
   const token = tokens[index];
-  for (let flagIndex = 0; flagIndex < flags.length; flagIndex += 1) {
-    const flag = flags[flagIndex];
+  for (let flagIndex = 0; flagIndex < VALUE_FLAGS.length; flagIndex += 1) {
+    const flag = VALUE_FLAGS[flagIndex];
     if (token === flag.name) {
       if (index + 1 >= tokens.length) return { error: flag.name + " requires a value" };
       return { key: flag.key, value: tokens[index + 1], nextIndex: index + 2 };
     }
-    if (token.indexOf(flag.name + "=") === 0) {
+    if (token.startsWith(flag.name + "=")) {
       const value = token.slice(flag.name.length + 1);
       if (!value) return { error: flag.name + " requires a value" };
       return { key: flag.key, value: value, nextIndex: index + 1 };
@@ -623,10 +617,6 @@ function tokenize(input) {
   if (escaped) current += "\\";
   if (current) tokens.push(current);
   return { tokens: tokens, error: "" };
-}
-
-function readOnlyPrompt() {
-  return "This is a read-only review step. Do not edit files, create commits, apply patches, push branches, or open PRs. Inspect repository evidence only as needed and report findings.";
 }
 
 function reviewOnlyReport(input, markdown) {
@@ -697,11 +687,11 @@ function text(value) {
 }
 
 function hasArrayItems(value) {
-  return Array.isArray(value) && value.length > 0;
+  return asArray(value).length > 0;
 }
 
 function hasText(value) {
-  return typeof value === "string" && value.length > 0;
+  return stringLength(value) > 0;
 }
 
 function stringLength(value) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -171,7 +171,7 @@ export default function simplifyWorkflow({
     diffCompactions: asArray(contexts.outputGitContext.diff?.workflowCompactions).length,
   });
 
-  if (hasUntrackedChanges(gitContext)) {
+  if (hasOnlyUntrackedChanges(gitContext)) {
     const reason = untrackedChangesSkipReason();
     return {
       reportMarkdown: "## Simplify workflow result\n\n" + reason,
@@ -529,6 +529,18 @@ function isGitCommitSha(value) {
   return /^[0-9a-f]{7,40}$/i.test(value);
 }
 
+function hasOnlyUntrackedChanges(gitContext) {
+  return (
+    hasUntrackedChanges(gitContext) &&
+    !hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.branch) &&
+    !hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.staged) &&
+    !hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.unstaged) &&
+    !hasText(gitContext.diff && gitContext.diff.branch) &&
+    !hasText(gitContext.diff && gitContext.diff.staged) &&
+    !hasText(gitContext.diff && gitContext.diff.unstaged)
+  );
+}
+
 function hasUntrackedChanges(gitContext) {
   return (
     hasArrayItems(gitContext.status && gitContext.status.untracked) ||
@@ -715,6 +727,7 @@ function reviewPrompt(lane, input, reviewContext) {
     "You are the " + lane.title + " lane. Review every changed file in the supplied Git context.",
     "If an explicit target is provided and the Git diff is empty, inspect that target path in the workspace before making claims.",
     "Diff text is capped by workflowBudgetChars; if workflowCompactions or built-in truncated flags are present, inspect files directly before making claims about omitted hunks.",
+    "Untracked paths in Git metadata are names only. Do not make findings about untracked files unless their contents are visible in a diff or explicit target.",
     "Allowed severity values are: high, medium, low. Return high-signal, actionable findings only; an empty findings array is fine.",
     "The synthesis step will keep at most " +
       input.maxFindings +

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -239,7 +239,7 @@ export default function simplifyWorkflow({
       reportMarkdown:
         synthesis.reportMarkdown +
         "\n\n---\n\n## Simplify workflow result\n\n" +
-        "Auto-fix was skipped because staged changes are present. Unstage or commit staged changes, then rerun `/workflow simplify --fix`.",
+        stagedChangesSkipReason(),
       structuredOutput: {
         mode: "staged-changes-skip-fix",
         gitContext: contexts.outputGitContext,
@@ -276,11 +276,31 @@ export default function simplifyWorkflow({
   }
 
   phase("apply-fixes", { madeChanges: true });
+  const applyPreflight = collectApplyPreflight(action, log, gitContext);
+  if (applyPreflight.skippedReason) {
+    return {
+      reportMarkdown:
+        synthesis.reportMarkdown +
+        "\n\n---\n\n## Fix pass\n\n" +
+        fixer.reportMarkdown +
+        "\n\n### Patch application\n\n" +
+        applyPreflight.skippedReason,
+      structuredOutput: {
+        mode: "apply-preflight-skip",
+        gitContext: contexts.outputGitContext,
+        reviews: reviewOutputs,
+        synthesis: synthesized,
+        fix: { fixer: fixerOutput, applied: applyPreflight },
+      },
+    };
+  }
+
   const applied = applyPatch({
     id: "apply-simplify-fixes",
     source: fixer,
     target: "parent",
     threeWay: true,
+    expectedHeadSha: applyPreflight.expectedHeadSha,
     // simplify fixes the dirty changes it just reviewed, so patch onto that worktree.
     force: true,
     onConflict: "return",
@@ -296,6 +316,51 @@ export default function simplifyWorkflow({
       fix: { fixer: fixerOutput, applied: applied },
     },
   };
+}
+
+function collectApplyPreflight(action, log, gitContext) {
+  let status = null;
+  try {
+    status = action.git.status({
+      id: "apply-git-status",
+      input: { includeIgnored: false },
+      builtInOnly: true,
+      cache: false,
+    }).output;
+  } catch (error) {
+    const message = formatError(error);
+    log("Git status unavailable for simplify auto-fix preflight", { error: message });
+    return failedApplyPreflight("Auto-fix was skipped because fresh Git status was unavailable.");
+  }
+
+  if (!status || typeof status !== "object") {
+    return failedApplyPreflight("Auto-fix was skipped because fresh Git status was unavailable.");
+  }
+  if (hasArrayItems(status.staged)) {
+    return failedApplyPreflight(stagedChangesSkipReason());
+  }
+
+  const reviewedHeadSha = gitContext.status && gitContext.status.headSha;
+  if (typeof reviewedHeadSha !== "string" || !reviewedHeadSha) {
+    return failedApplyPreflight(
+      "Auto-fix was skipped because the reviewed HEAD snapshot is unavailable."
+    );
+  }
+  if (status.headSha !== reviewedHeadSha) {
+    return failedApplyPreflight(
+      "Auto-fix was skipped because HEAD changed since review. Rerun `/workflow simplify --fix`."
+    );
+  }
+
+  return { success: true, status: "ready", expectedHeadSha: reviewedHeadSha };
+}
+
+function failedApplyPreflight(reason) {
+  return { success: false, status: "failed", skippedReason: reason, error: reason };
+}
+
+function stagedChangesSkipReason() {
+  return "Auto-fix was skipped because staged changes are present. Unstage or commit staged changes, then rerun `/workflow simplify --fix`.";
 }
 
 function collectGitContext(action, input, log) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -171,7 +171,7 @@ export default function simplifyWorkflow({
     diffCompactions: asArray(contexts.outputGitContext.diff?.workflowCompactions).length,
   });
 
-  if (!input.target && hasOnlyUntrackedChanges(gitContext)) {
+  if (hasOnlyUntrackedChanges(gitContext) && targetNeedsUntrackedContent(input, gitContext)) {
     const reason = untrackedChangesSkipReason();
     return {
       reportMarkdown: "## Simplify workflow result\n\n" + reason,
@@ -527,6 +527,33 @@ function isRequestedHeadCurrent(status, input) {
 
 function isGitCommitSha(value) {
   return /^[0-9a-f]{7,40}$/i.test(value);
+}
+
+function targetNeedsUntrackedContent(input, gitContext) {
+  if (!input.target) return true;
+  const target = normalizedPath(input.target);
+  if (!target) return false;
+  return untrackedPaths(gitContext).some(function (path) {
+    const untracked = normalizedPath(path);
+    return untracked === target || untracked.startsWith(target + "/");
+  });
+}
+
+function untrackedPaths(gitContext) {
+  return asArray(gitContext.status && gitContext.status.untracked)
+    .concat(asArray(gitContext.changedFiles && gitContext.changedFiles.untracked))
+    .map(filePath)
+    .filter(Boolean);
+}
+
+function filePath(value) {
+  if (typeof value === "string") return value;
+  return value && typeof value.path === "string" ? value.path : "";
+}
+
+function normalizedPath(value) {
+  if (typeof value !== "string") return "";
+  return value.trim().replace(/^\.\//, "").replace(/\/+$/, "");
 }
 
 function hasOnlyUntrackedChanges(gitContext) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -233,12 +233,12 @@ export default function simplifyWorkflow({
     };
   }
 
-  // git am cannot apply onto a dirty index; keep the review result but skip auto-fix.
-  if (hasStagedChanges(gitContext)) {
+  // Workflow child workspaces do not inherit parent dirt; keep the review result but skip auto-fix.
+  if (hasUncommittedChanges(gitContext)) {
     return skipFixResult(
       synthesis.reportMarkdown,
-      stagedChangesSkipReason(),
-      "staged-changes-skip-fix",
+      uncommittedChangesSkipReason(),
+      "uncommitted-changes-skip-fix",
       contexts.outputGitContext,
       reviewOutputs,
       synthesized
@@ -307,8 +307,6 @@ export default function simplifyWorkflow({
     target: "parent",
     threeWay: true,
     expectedHeadSha: applyPreflight.expectedHeadSha,
-    // simplify fixes the dirty changes it just reviewed, so patch onto that worktree.
-    force: true,
     onConflict: "return",
   });
 
@@ -361,8 +359,8 @@ function collectApplyPreflight(action, log, input, gitContext) {
   if (!status || typeof status !== "object") {
     return failedApplyPreflight("Auto-fix was skipped because fresh Git status was unavailable.");
   }
-  if (hasArrayItems(status.staged)) {
-    return failedApplyPreflight(stagedChangesSkipReason());
+  if (hasUncommittedStatus(status)) {
+    return failedApplyPreflight(uncommittedChangesSkipReason());
   }
 
   if (!isRequestedHeadCurrent(status, input)) {
@@ -392,8 +390,8 @@ function nonCurrentHeadSkipReason() {
   return "Auto-fix was skipped because the requested `--head` is not the current checkout. Check out that branch/ref or pass the current commit SHA before applying fixes.";
 }
 
-function stagedChangesSkipReason() {
-  return "Auto-fix was skipped because staged changes are present. Unstage or commit staged changes, then rerun `/workflow simplify --fix`.";
+function uncommittedChangesSkipReason() {
+  return "Auto-fix was skipped because uncommitted changes are present. Commit or stash them, then rerun `/workflow simplify --fix`.";
 }
 
 function collectGitContext(action, input, log) {
@@ -514,10 +512,20 @@ function isGitCommitSha(value) {
   return /^[0-9a-f]{7,40}$/i.test(value);
 }
 
-function hasStagedChanges(gitContext) {
+function hasUncommittedChanges(gitContext) {
   return (
-    hasArrayItems(gitContext.status && gitContext.status.staged) ||
-    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.staged)
+    hasUncommittedStatus(gitContext.status) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.staged) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.unstaged) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.untracked)
+  );
+}
+
+function hasUncommittedStatus(status) {
+  return (
+    hasArrayItems(status && status.staged) ||
+    hasArrayItems(status && status.unstaged) ||
+    hasArrayItems(status && status.untracked)
   );
 }
 

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -204,7 +204,7 @@ export default function simplifyWorkflow({
   });
 
   const rawFindingCount = reviewOutputs.reduce(function (count, output) {
-    return count + asArray(output.findings).length;
+    return count + output.findings.length;
   }, 0);
 
   phase("synthesize", { rawFindingCount: rawFindingCount });
@@ -219,7 +219,7 @@ export default function simplifyWorkflow({
     synthesis.structuredOutput,
     "synthesis structured output is required"
   );
-  const actionableFindings = asArray(synthesized.actionableFindings);
+  const actionableFindings = synthesized.actionableFindings;
 
   if (!input.fix || !synthesized.shouldFix || actionableFindings.length === 0) {
     return {
@@ -298,6 +298,7 @@ function collectGitContext(action, input, log) {
     }).output;
   });
   const refs = refsWithResolvedBase(requestedRefs, changedFiles);
+  const readDiffs = shouldReadDiffs(changedFiles);
 
   return {
     target: input.target,
@@ -305,12 +306,17 @@ function collectGitContext(action, input, log) {
     failures: failures,
     status: status,
     changedFiles: changedFiles,
-    diffStat: gitSlice(log, failures, "diffStat", function () {
-      return action.git.diffStat({ id: "git-diff-stat", input: refs, builtInOnly: true }).output;
-    }),
-    diff: gitSlice(log, failures, "diff", function () {
-      return action.git.diff({ id: "git-diff", input: refs, builtInOnly: true }).output;
-    }),
+    diffStat: readDiffs
+      ? gitSlice(log, failures, "diffStat", function () {
+          return action.git.diffStat({ id: "git-diff-stat", input: refs, builtInOnly: true })
+            .output;
+        })
+      : null,
+    diff: readDiffs
+      ? gitSlice(log, failures, "diff", function () {
+          return action.git.diff({ id: "git-diff", input: refs, builtInOnly: true }).output;
+        })
+      : null,
   };
 }
 
@@ -336,14 +342,25 @@ function gitRefs(input) {
 }
 
 function refsWithResolvedBase(refs, changedFiles) {
-  if (refs.base || refs.trunk || !changedFiles || typeof changedFiles.base !== "string") {
-    return refs;
-  }
-  if (!changedFiles.base) return refs;
+  const base =
+    changedFiles && typeof changedFiles === "object" && typeof changedFiles.base === "string"
+      ? changedFiles.base
+      : "";
+  if (refs.base || refs.trunk || !base) return refs;
+  return { ...refs, base };
+}
 
-  const resolved = { base: changedFiles.base };
-  if (refs.head) resolved.head = refs.head;
-  return resolved;
+// The diff actions only return branch/staged/unstaged hunks; untracked-only contexts
+// are captured by changedFiles.
+function shouldReadDiffs(changedFiles) {
+  if (!changedFiles || typeof changedFiles !== "object" || Array.isArray(changedFiles)) {
+    return true;
+  }
+  return (
+    hasArrayItems(changedFiles.branch) ||
+    hasArrayItems(changedFiles.staged) ||
+    hasArrayItems(changedFiles.unstaged)
+  );
 }
 
 function hasReviewableContext(input, gitContext) {
@@ -351,9 +368,6 @@ function hasReviewableContext(input, gitContext) {
   if (asArray(gitContext.failures).length > 0) return true;
   if (!gitContext.status || gitContext.status.clean !== true) return true;
   return (
-    hasArrayItems(gitContext.status.staged) ||
-    hasArrayItems(gitContext.status.unstaged) ||
-    hasArrayItems(gitContext.status.untracked) ||
     hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.branch) ||
     hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.staged) ||
     hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.unstaged) ||
@@ -546,37 +560,36 @@ function fixPrompt(compactContext, synthesized) {
 }
 
 function compactReviewOutputs(reviewOutputs) {
-  return asArray(reviewOutputs).map(function (output) {
+  return reviewOutputs.map(function (output) {
     return {
-      summary: output && output.summary,
-      findings: asArray(output && output.findings).map(compactReviewFinding),
+      summary: output.summary,
+      findings: output.findings.map(compactReviewFinding),
     };
   });
 }
 
 function compactReviewFinding(finding) {
+  const evidence = finding.evidence;
   return {
-    id: finding && finding.id,
-    title: finding && finding.title,
-    severity: finding && finding.severity,
-    filePaths: asArray(finding && finding.filePaths),
-    rationale: finding && finding.rationale,
-    recommendation: finding && finding.recommendation,
-    evidenceCount: asArray(finding && finding.evidence).length,
-    evidenceSamples: asArray(finding && finding.evidence)
-      .slice(0, REVIEW_EVIDENCE_ITEM_BUDGET)
-      .map(function (evidence) {
-        return compactText(evidence, REVIEW_EVIDENCE_CHAR_BUDGET);
-      }),
+    id: finding.id,
+    title: finding.title,
+    severity: finding.severity,
+    filePaths: finding.filePaths,
+    rationale: finding.rationale,
+    recommendation: finding.recommendation,
+    evidenceCount: evidence.length,
+    evidenceSamples: evidence.slice(0, REVIEW_EVIDENCE_ITEM_BUDGET).map(function (evidenceItem) {
+      return compactText(evidenceItem, REVIEW_EVIDENCE_CHAR_BUDGET);
+    }),
   };
 }
 
 function fixerPayload(synthesized) {
   return {
-    summary: synthesized && synthesized.summary,
-    shouldFix: Boolean(synthesized && synthesized.shouldFix),
-    actionableFindings: asArray(synthesized && synthesized.actionableFindings),
-    validationPlan: asArray(synthesized && synthesized.validationPlan),
+    summary: synthesized.summary,
+    shouldFix: synthesized.shouldFix,
+    actionableFindings: synthesized.actionableFindings,
+    validationPlan: synthesized.validationPlan,
   };
 }
 
@@ -731,7 +744,7 @@ function text(value) {
 }
 
 function hasArrayItems(value) {
-  return asArray(value).length > 0;
+  return Array.isArray(value) && value.length > 0;
 }
 
 function hasText(value) {

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -3,6 +3,8 @@
 const DEFAULT_MAX_FINDINGS = 20;
 // Review agents get bounded diff text; synthesis/fix phases get metadata only.
 const REVIEW_DIFF_CHAR_BUDGET = 60000;
+const METADATA_ARRAY_ITEM_BUDGET = 200;
+const DIFF_STAT_CHAR_BUDGET = 20000;
 const REVIEW_AGENT_ID = "explore";
 const EXEC_AGENT_ID = "exec";
 const REVIEW_LANES = [
@@ -36,15 +38,18 @@ const REVIEW_LANES = [
 ];
 
 const SEVERITY_SCHEMA = { type: "string", enum: ["high", "medium", "low"] };
+const FINDING_CORE_PROPERTIES = {
+  id: { type: "string" },
+  title: { type: "string" },
+  severity: SEVERITY_SCHEMA,
+  filePaths: { type: "array", items: { type: "string" } },
+  rationale: { type: "string" },
+};
 const FINDING_SCHEMA = {
   type: "object",
   required: ["id", "title", "severity", "filePaths", "rationale", "recommendation", "evidence"],
   properties: {
-    id: { type: "string" },
-    title: { type: "string" },
-    severity: SEVERITY_SCHEMA,
-    filePaths: { type: "array", items: { type: "string" } },
-    rationale: { type: "string" },
+    ...FINDING_CORE_PROPERTIES,
     recommendation: { type: "string" },
     evidence: { type: "array", items: { type: "string" } },
   },
@@ -61,11 +66,7 @@ const SYNTHESIS_FINDING_SCHEMA = {
   type: "object",
   required: ["id", "title", "severity", "filePaths", "rationale", "fixPlan"],
   properties: {
-    id: { type: "string" },
-    title: { type: "string" },
-    severity: SEVERITY_SCHEMA,
-    filePaths: { type: "array", items: { type: "string" } },
-    rationale: { type: "string" },
+    ...FINDING_CORE_PROPERTIES,
     fixPlan: { type: "string" },
   },
 };
@@ -146,6 +147,18 @@ export default function simplifyWorkflow({
     gitFailures: gitContext.failures.length,
     diffCompactions: diffCompactions(contexts.outputGitContext).length,
   });
+
+  if (!hasReviewableContext(input, gitContext)) {
+    return {
+      reportMarkdown: "## Simplify workflow result\n\nNo reviewable changes found.",
+      structuredOutput: {
+        mode: "no-reviewable-changes",
+        gitContext: contexts.outputGitContext,
+        reviews: [],
+        synthesis: emptySynthesis("No reviewable changes found."),
+      },
+    };
+  }
 
   phase("review", {
     lanes: REVIEW_LANES.map(function (lane) {
@@ -306,9 +319,37 @@ function refsWithResolvedBase(refs, changedFiles) {
   return resolved;
 }
 
+function hasReviewableContext(input, gitContext) {
+  if (input.target) return true;
+  if (asArray(gitContext.failures).length > 0) return true;
+  if (!gitContext.status || gitContext.status.clean !== true) return true;
+  return (
+    hasArrayItems(gitContext.status.staged) ||
+    hasArrayItems(gitContext.status.unstaged) ||
+    hasArrayItems(gitContext.status.untracked) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.branch) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.staged) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.unstaged) ||
+    hasArrayItems(gitContext.changedFiles && gitContext.changedFiles.untracked) ||
+    hasText(gitContext.diff && gitContext.diff.branch) ||
+    hasText(gitContext.diff && gitContext.diff.staged) ||
+    hasText(gitContext.diff && gitContext.diff.unstaged)
+  );
+}
+
+function emptySynthesis(summary) {
+  return {
+    summary: summary,
+    shouldFix: false,
+    actionableFindings: [],
+    skippedFindings: [],
+    validationPlan: [],
+  };
+}
+
 function promptContexts(input, gitContext) {
-  const reviewGitContext = withCompactedDiff(gitContext, REVIEW_DIFF_CHAR_BUDGET);
-  const outputGitContext = withoutDiffText(gitContext, reviewGitContext.diff);
+  const reviewGitContext = compactMetadata(withCompactedDiff(gitContext, REVIEW_DIFF_CHAR_BUDGET));
+  const outputGitContext = compactMetadata(withoutDiffText(gitContext, reviewGitContext.diff));
   return {
     review: renderContext(input, reviewGitContext),
     compact: renderContext(input, outputGitContext),
@@ -323,28 +364,72 @@ function renderContext(input, gitContext) {
   });
 }
 
-function withCompactedDiff(gitContext, budget) {
+function compactMetadata(gitContext) {
   return {
-    target: gitContext.target,
-    refs: gitContext.refs,
-    failures: gitContext.failures,
-    status: gitContext.status,
-    changedFiles: gitContext.changedFiles,
-    diffStat: gitContext.diffStat,
-    diff: compactDiff(gitContext.diff, budget),
+    ...gitContext,
+    status: compactStatus(gitContext.status),
+    changedFiles: compactChangedFiles(gitContext.changedFiles),
+    diffStat: compactDiffStat(gitContext.diffStat),
   };
 }
 
-function withoutDiffText(gitContext, compactedDiff) {
+function compactStatus(status) {
+  if (!status || typeof status !== "object") return status;
   return {
-    target: gitContext.target,
-    refs: gitContext.refs,
-    failures: gitContext.failures,
-    status: gitContext.status,
-    changedFiles: gitContext.changedFiles,
-    diffStat: gitContext.diffStat,
-    diff: diffSummary(gitContext.diff, compactedDiff),
+    ...status,
+    staged: compactArray(status.staged, METADATA_ARRAY_ITEM_BUDGET),
+    unstaged: compactArray(status.unstaged, METADATA_ARRAY_ITEM_BUDGET),
+    untracked: compactArray(status.untracked, METADATA_ARRAY_ITEM_BUDGET),
+    ignored: compactArray(status.ignored, METADATA_ARRAY_ITEM_BUDGET),
   };
+}
+
+function compactChangedFiles(changedFiles) {
+  if (!changedFiles || typeof changedFiles !== "object") return changedFiles;
+  return {
+    ...changedFiles,
+    branch: compactArray(changedFiles.branch, METADATA_ARRAY_ITEM_BUDGET),
+    staged: compactArray(changedFiles.staged, METADATA_ARRAY_ITEM_BUDGET),
+    unstaged: compactArray(changedFiles.unstaged, METADATA_ARRAY_ITEM_BUDGET),
+    untracked: compactArray(changedFiles.untracked, METADATA_ARRAY_ITEM_BUDGET),
+  };
+}
+
+function compactDiffStat(diffStat) {
+  if (!diffStat || typeof diffStat !== "object") return diffStat;
+  return {
+    ...diffStat,
+    branch: compactText(diffStat.branch, DIFF_STAT_CHAR_BUDGET),
+    staged: compactText(diffStat.staged, DIFF_STAT_CHAR_BUDGET),
+    unstaged: compactText(diffStat.unstaged, DIFF_STAT_CHAR_BUDGET),
+  };
+}
+
+function compactArray(value, limit) {
+  if (!Array.isArray(value) || value.length <= limit) return value;
+  return {
+    total: value.length,
+    shown: value.slice(0, limit),
+    omitted: value.length - limit,
+  };
+}
+
+function compactText(value, limit) {
+  if (typeof value !== "string" || value.length <= limit) return value;
+  return (
+    value.slice(0, limit) +
+    "\n\n[Workflow metadata budget omitted " +
+    (value.length - limit) +
+    " chars.]"
+  );
+}
+
+function withCompactedDiff(gitContext, budget) {
+  return { ...gitContext, diff: compactDiff(gitContext.diff, budget) };
+}
+
+function withoutDiffText(gitContext, compactedDiff) {
+  return { ...gitContext, diff: diffSummary(gitContext.diff, compactedDiff) };
 }
 
 function compactDiff(diff, budget) {
@@ -609,6 +694,14 @@ function mustObject(value, message) {
 
 function text(value) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function hasArrayItems(value) {
+  return Array.isArray(value) && value.length > 0;
+}
+
+function hasText(value) {
+  return typeof value === "string" && value.length > 0;
 }
 
 function stringLength(value) {


### PR DESCRIPTION
## Summary

Adds a tracked `simplify` workflow that reviews current changes for code reuse, quality, and efficiency, synthesizes actionable findings, and applies minimal fixes through a committed child-workspace patch when the reviewed content is available in child workspaces.

## Background

This ports the ad-hoc global simplify skill into a durable Mux workflow so the review lanes run in parallel with structured outputs, bounded prompt context, resumable workflow steps, and native patch application.

## Implementation

- Captures git status, changed files, diff stats, and bounded diff text through built-in git workflow actions.
- Runs reuse, quality, and efficiency review lanes in parallel with strict JSON schemas.
- Uses compact handoff payloads so synthesis and fix phases avoid raw diff/token bloat.
- Short-circuits clean/no-op scopes and skips expensive diff reads when `changedFiles` proves there are no diffable hunks.
- Skips review with clear guidance for untracked-only current-change scopes, and for explicit targets that are themselves untracked, contain untracked files, or target the repo root with untracked files, because workflow child workspaces cannot read parent-only untracked contents.
- Allows explicit target reviews when untracked scratch files are unrelated to the target, even alongside reviewable branch diffs.
- Normalizes Windows-style target separators before checking untracked target containment, while preserving literal/trailing backslashes in quoted target args.
- Tells reviewers that untracked metadata paths are names only when branch/staged/unstaged diffs are still reviewable.
- Skips auto-fix with clear guidance when uncommitted changes are present, because workflow child workspaces do not inherit parent dirty files.
- Forces unresolved/non-current symbolic `--head` ranges into review-only/no-apply behavior so patches are never applied to the wrong checkout; resolved raw SHA-1/SHA-256 commit IDs are allowed by SHA equality.
- Refreshes Git status with `cache: false` immediately before patch application, rejects dirty/changed checkouts, verifies the reviewed branch is still current unless a raw SHA was requested, and passes the reviewed `expectedHeadSha` to avoid stale patch application.
- Keeps workflow helpers self-contained for the workflow runtime and logs partial git-context failures.

## Validation

- `make static-check`
- `node --check .mux/workflows/simplify.js`
- `bunx prettier --check .mux/workflows/simplify.js`
- `git diff --check`
- Targeted Bun harness verifying untracked-only current changes skip review agents, untracked explicit targets/directories/root targets skip review agents even when other diffs exist, Windows-style and quoted/trailing-backslash untracked targets normalize correctly, explicit target reviews still run with unrelated untracked files, branch diffs with unrelated untracked files still run review-only, other uncommitted changes skip fixer/applyPatch, non-current symbolic `--head` skips fixer/applyPatch even at the same SHA, unresolved hex-looking `--head` skips fixer/applyPatch, SHA-1/SHA-256 raw heads may apply by SHA equality, clean branch changes refresh status with `cache: false` and call `applyPatch` with reviewed `expectedHeadSha`, same-SHA branch drift skips patch application, raw SHA review may apply across same-SHA branch names, dirty drift skips patch application, and changed HEAD skips patch application.
- `/simplify` dogfood run; workflow patch application succeeded before the final dirty-worktree auto-fix guard was added.
- `/workflow simplify --review-only --base HEAD --head HEAD` no-op dogfood; returned `No reviewable changes found` and exercised the diff-skip path.

## Risks

Low to medium. This is a new workflow file and does not alter existing app runtime paths, but it exercises workflow orchestration, agent handoffs, and patch-application behavior. Review/fix now intentionally applies only when the relevant content is present in child workspaces and the parent checkout is clean/matches the reviewed head; dirty worktrees still receive explicit guidance to add/commit/stash before rerunning.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `3424244{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=48.25 -->
