### PR TITLE
🤖 fix: dedupe memory consolidation summaries

### DIFF
--- a/src/browser/features/Memory/MemoryBrowser.tsx
+++ b/src/browser/features/Memory/MemoryBrowser.tsx
@@ -485,6 +485,20 @@ function MemoryFileRow(props: MemoryFileRowProps) {
   );
 }
 
+function uniqueConsolidationSummaryLines(
+  summaries: ReadonlyArray<string | null | undefined>
+): string[] {
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const summary of summaries) {
+    const line = summary?.trim();
+    if (!line || seen.has(line)) continue;
+    seen.add(line);
+    lines.push(line);
+  }
+  return lines;
+}
+
 function formatConsolidationRecord(record: MemoryConsolidationRecordPayload | null): string {
   if (record === null) return "never";
   const appliedCount = record.ops.filter((op) => op.applied).length;
@@ -556,14 +570,15 @@ function ConsolidationFooter(props: {
     : "never";
   const harvestError =
     status?.latestHarvestRecord?.status === "failed" ? status.latestHarvestRecord.error : undefined;
-  const summaryTitle = [
+  // One consolidation pass can cover workspace, project, and global memory at
+  // once, so those scope records often share the exact same summary. Keep the
+  // per-scope status lines below, but avoid repeating identical tooltip text.
+  const summaryTitle = uniqueConsolidationSummaryLines([
     status?.workspaceRecord?.summary,
     status?.projectRecord?.summary,
     status?.globalRecord?.summary,
     status?.latestHarvestRecord?.error,
-  ]
-    .filter(Boolean)
-    .join("\n");
+  ]).join("\n");
 
   return (
     <div className="border-border-light flex items-center justify-between gap-2 border-t px-3 py-2 text-xs">

--- a/src/browser/features/RightSidebar/Memory/MemoryTab.test.tsx
+++ b/src/browser/features/RightSidebar/Memory/MemoryTab.test.tsx
@@ -269,6 +269,39 @@ describe("MemoryTab", () => {
     expect(getByText(/^Project:/).textContent).not.toContain("manual");
   });
 
+  test("deduplicates identical consolidation summaries in the tooltip", async () => {
+    const sharedRecord = {
+      ...DEFAULT_CONSOLIDATION_RECORD,
+      summary: "shared consolidation summary",
+    };
+    fake = createFakeMemoryApi([], {
+      consolidationStatus: {
+        workspaceRecord: sharedRecord,
+        projectRecord: sharedRecord,
+        globalRecord: sharedRecord,
+        latestHarvestRecord: null,
+        projectAvailable: true,
+      },
+    });
+    const { findByText } = render(<MemoryTab workspaceId="ws-1" />);
+
+    const workspaceLine = await findByText(/^Workspace: .*manual/);
+    const statusBlock = workspaceLine.parentElement;
+    expect(statusBlock).not.toBeNull();
+    fireEvent.pointerMove(statusBlock!);
+
+    await waitFor(() => {
+      const tooltipBlocks = Array.from(
+        document.querySelectorAll<HTMLElement>(".whitespace-pre-line")
+      );
+      expect(tooltipBlocks.length).toBeGreaterThan(0);
+      for (const block of tooltipBlocks) {
+        const matches = block.textContent?.match(/shared consolidation summary/g) ?? [];
+        expect(matches).toHaveLength(1);
+      }
+    });
+  });
+
   test("consolidation summary does not leave a native title tooltip", async () => {
     fake = createFakeMemoryApi([], {
       consolidationStatus: {

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -901,7 +901,7 @@ export class HistoryService {
       let summary: MuxMessage | undefined;
       const lowerBound = metadata.previousBoundaryHistorySequence;
 
-      await this.iterateForward(workspaceId, (chunk) => {
+      const iteration = await this.iterateFullHistory(workspaceId, "forward", (chunk) => {
         for (const message of chunk) {
           const sequence = message.metadata?.historySequence;
           if (!isNonNegativeInteger(sequence)) continue;
@@ -921,6 +921,9 @@ export class HistoryService {
           messages.push(message);
         }
       });
+      if (!iteration.success) {
+        return Err(`Failed to read compaction epoch messages: ${iteration.error}`);
+      }
 
       if (summary === undefined) {
         return Err(`Compaction summary not found: ${metadata.summaryMessageId}`);


### PR DESCRIPTION
## Summary

Deduplicates identical memory-consolidation summaries in the Memory tab tooltip while preserving the separate Workspace, Project, and Global status lines. Also fixes the latest-main compaction epoch reader regression that surfaced when the PR entered the merge queue.

## Background

A single consolidation pass can cover workspace, project, and global memory scopes. When those status records share the same summary, the footer tooltip repeated the same text once per scope, which made the UI look broken.

After rebasing onto the latest `main`, merge-queue Unit runs exposed that `HistoryService.getMessagesForCompactionEpoch` was passing a workspace id into a file-path iterator. That made compaction harvest tests fail on main/merge-group runs because the summary row was never found.

## Implementation

- Added a small helper that trims and deduplicates consolidation summary lines before building the tooltip body.
- Kept the visible per-scope status metadata unchanged so users can still see which scopes were covered.
- Updated the compaction epoch reader to iterate full workspace history, including sealed archives and active chat history.
- Added a MemoryTab regression test for identical workspace/project/global summaries.

## Validation

- `bun test src/browser/features/RightSidebar/Memory/MemoryTab.test.tsx`
- `bun test src/node/services/historyService.test.ts --test-name-pattern "getMessagesForCompactionEpoch"`
- `bun test src/node/services/memoryConsolidationService.test.ts --test-name-pattern "harvest|post-harvest|re-harvest|retryable"`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `make fmt-check`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`

## Risks

Low to medium. The tooltip change only affects memory consolidation status rendering. The HistoryService fix restores the intended full-history iteration path used by compaction harvesting; regression coverage already existed and now passes again.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$3.54`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=3.54 -->
