### PR TITLE
🤖 fix: read compaction epochs from archived history

### DIFF
--- a/src/node/services/historyService.test.ts
+++ b/src/node/services/historyService.test.ts
@@ -1149,6 +1149,156 @@ describe("HistoryService", () => {
       }
     });
 
+    it("deduplicates rotation replay rows across archive and active history", async () => {
+      const workspaceId = "ws-compaction-epoch-rotation-replay";
+      const workspaceDir = config.getSessionDir(workspaceId);
+      await fs.mkdir(workspaceDir, { recursive: true });
+
+      const replayedPrefix = [
+        messageLine(
+          workspaceId,
+          createMuxMessage("old-boundary", "assistant", "old summary", {
+            historySequence: 0,
+            compactionBoundary: true,
+            compacted: "user",
+            compactionEpoch: 1,
+          })
+        ),
+        messageLine(
+          workspaceId,
+          createMuxMessage("kept-user", "user", "durable preference", { historySequence: 1 })
+        ),
+        messageLine(
+          workspaceId,
+          createMuxMessage("compact-request", "user", "Please compact", {
+            historySequence: 2,
+            muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
+          })
+        ),
+      ];
+      const summary = messageLine(
+        workspaceId,
+        createMuxMessage("new-summary", "assistant", "new summary", {
+          historySequence: 3,
+          compactionBoundary: true,
+          compacted: "user",
+          compactionEpoch: 2,
+        })
+      );
+
+      await fs.writeFile(
+        path.join(workspaceDir, "chat-archive.jsonl"),
+        replayedPrefix.join("\n") + "\n"
+      );
+      await fs.writeFile(
+        path.join(workspaceDir, "chat.jsonl"),
+        [...replayedPrefix, summary].join("\n") + "\n"
+      );
+
+      const result = await service.getMessagesForCompactionEpoch(workspaceId, {
+        workspaceId,
+        summaryMessageId: "new-summary",
+        summaryHistorySequence: 3,
+        compactionEpoch: 2,
+        previousBoundaryHistorySequence: 0,
+        compactionRequestMessageId: "compact-request",
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.messages.map((message) => message.id)).toEqual(["kept-user"]);
+        expect(result.data.summary.id).toBe("new-summary");
+      }
+    });
+
+    it("holds the workspace lock while scanning archive and active history", async () => {
+      const workspaceId = "ws-compaction-epoch-lock";
+      await writeHistoryLines(config, workspaceId, [
+        messageLine(
+          workspaceId,
+          createMuxMessage("old-boundary", "assistant", "old summary", {
+            historySequence: 0,
+            compactionBoundary: true,
+            compacted: "user",
+            compactionEpoch: 1,
+          })
+        ),
+        messageLine(
+          workspaceId,
+          createMuxMessage("kept-user", "user", "durable preference", { historySequence: 1 })
+        ),
+        messageLine(
+          workspaceId,
+          createMuxMessage("compact-request", "user", "Please compact", {
+            historySequence: 2,
+            muxMetadata: { type: "compaction-request", rawCommand: "/compact", parsed: {} },
+          })
+        ),
+        messageLine(
+          workspaceId,
+          createMuxMessage("summary", "assistant", "summary", {
+            historySequence: 3,
+            compactionBoundary: true,
+            compacted: "user",
+            compactionEpoch: 2,
+          })
+        ),
+      ]);
+
+      let releaseScan!: () => void;
+      const scanReleased = new Promise<void>((resolve) => {
+        releaseScan = resolve;
+      });
+      let markScanStarted!: () => void;
+      const scanStarted = new Promise<void>((resolve) => {
+        markScanStarted = resolve;
+      });
+      const originalIterateFullHistory: HistoryService["iterateFullHistory"] =
+        service.iterateFullHistory.bind(service);
+      const blockingIterateFullHistory: HistoryService["iterateFullHistory"] = async (
+        workspaceIdArg,
+        direction,
+        visitor
+      ) => {
+        markScanStarted();
+        await scanReleased;
+        return originalIterateFullHistory(workspaceIdArg, direction, visitor);
+      };
+      service.iterateFullHistory = blockingIterateFullHistory;
+
+      const scan = service.getMessagesForCompactionEpoch(workspaceId, {
+        workspaceId,
+        summaryMessageId: "summary",
+        summaryHistorySequence: 3,
+        compactionEpoch: 2,
+        previousBoundaryHistorySequence: 0,
+        compactionRequestMessageId: "compact-request",
+      });
+      await scanStarted;
+
+      interface WorkspaceLockProbe {
+        fileLocks: {
+          withLock<T>(key: string, operation: () => Promise<T>): Promise<T>;
+        };
+      }
+      const { fileLocks } = service as unknown as WorkspaceLockProbe;
+      let probeStarted = false;
+      const probe = fileLocks.withLock(workspaceId, () => {
+        probeStarted = true;
+        return Promise.resolve();
+      });
+      await Promise.resolve();
+
+      expect(probeStarted).toBe(false);
+      releaseScan();
+
+      const result = await scan;
+      await probe;
+
+      expect(result.success).toBe(true);
+      expect(probeStarted).toBe(true);
+    });
+
     it("uses reset boundaries as lower bounds and excludes the reset marker", async () => {
       const workspaceId = "ws-compaction-reset-epoch";
       await writeHistoryLines(config, workspaceId, [

--- a/src/node/services/historyService.ts
+++ b/src/node/services/historyService.ts
@@ -900,27 +900,35 @@ export class HistoryService {
       const messages: MuxMessage[] = [];
       let summary: MuxMessage | undefined;
       const lowerBound = metadata.previousBoundaryHistorySequence;
+      const seenHistorySequences = new Set<number>();
 
-      const iteration = await this.iterateFullHistory(workspaceId, "forward", (chunk) => {
-        for (const message of chunk) {
-          const sequence = message.metadata?.historySequence;
-          if (!isNonNegativeInteger(sequence)) continue;
+      // The just-compacted epoch can straddle chat-archive.jsonl and chat.jsonl after
+      // sealed-history rotation, so scan the full logical history under the workspace
+      // lock; otherwise a concurrent boundary rotation can move rows between files mid-scan.
+      const iteration = await this.fileLocks.withLock(workspaceId, () =>
+        this.iterateFullHistory(workspaceId, "forward", (chunk) => {
+          for (const message of chunk) {
+            const sequence = message.metadata?.historySequence;
+            if (!isNonNegativeInteger(sequence)) continue;
+            if (seenHistorySequences.has(sequence)) continue;
+            seenHistorySequences.add(sequence);
 
-          if (
-            sequence === metadata.summaryHistorySequence &&
-            message.id === metadata.summaryMessageId
-          ) {
-            summary = message;
-            continue;
+            if (
+              sequence === metadata.summaryHistorySequence &&
+              message.id === metadata.summaryMessageId
+            ) {
+              summary = message;
+              continue;
+            }
+
+            if (sequence >= metadata.summaryHistorySequence) continue;
+            if (lowerBound !== undefined && sequence <= lowerBound) continue;
+            if (message.id === metadata.compactionRequestMessageId) continue;
+            if (isDurableContextBoundaryMarker(message)) continue;
+            messages.push(message);
           }
-
-          if (sequence >= metadata.summaryHistorySequence) continue;
-          if (lowerBound !== undefined && sequence <= lowerBound) continue;
-          if (message.id === metadata.compactionRequestMessageId) continue;
-          if (isDurableContextBoundaryMarker(message)) continue;
-          messages.push(message);
-        }
-      });
+        })
+      );
       if (!iteration.success) {
         return Err(`Failed to read compaction epoch messages: ${iteration.error}`);
       }


### PR DESCRIPTION
## Summary

Fix memory-harvest compaction epoch reads after sealed-history rotation by using the archive-aware full-history iterator when gathering evidence for a completed compaction boundary, while holding the history lock and deduplicating crash-replayed rows.

## Background

Recent main failures clustered around `HistoryService.getMessagesForCompactionEpoch` and the memory harvest pipeline. The history service's private `iterateForward` helper now expects a file path after `chat-archive.jsonl` rotation work, but this callsite still passed a workspace ID. That made the epoch scan read nothing, so harvests failed before the mocked harvest stream could start.

## Implementation

`getMessagesForCompactionEpoch` now iterates the full logical history in forward order. This covers both `chat-archive.jsonl` and `chat.jsonl`, which is required because a just-compacted epoch can straddle the archive seam after sealed-history rotation. The scan runs under the workspace file lock so archive+active reads form one stable snapshot, and collection deduplicates by `historySequence` so a crash between archive append and active-file rewrite cannot feed duplicate evidence rows into memory harvest.

## Validation

- `bun test src/node/services/historyService.test.ts`
- `bun test src/node/services/memoryConsolidationService.test.ts`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`

## Risks

Low. This only changes the compaction-harvest evidence read path from the accidentally wrong file-path call to the existing archive-aware logical-history iterator, with defensive locking and dedupe for documented rotation edge cases. The tradeoff is an O(total history) scan under the workspace file lock for harvest recovery, but this path runs after compaction boundaries rather than on hot provider request assembly.

## Pains

The default `make static-check` run OOM-killed ESLint at concurrency 8 in this workspace; rerunning the required target with `MUX_ESLINT_CONCURRENCY=1` passed.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$3.31`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=3.31 -->
