### PR TITLE
🤖 fix: clarify simplify workflow git context

### DIFF
--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -9,6 +9,9 @@ const DIFF_STAT_CHAR_BUDGET = 20000;
 const REVIEW_EVIDENCE_ITEM_BUDGET = 3;
 const REVIEW_EVIDENCE_CHAR_BUDGET = 500;
 const NO_REVIEWABLE_CHANGES_SUMMARY = "No reviewable changes found.";
+const GIT_CONTEXT_SOURCE = "parent-workflow-checkout";
+const GIT_CONTEXT_PROVENANCE_NOTE =
+  "Git context was captured from the parent workflow checkout before child agent workspaces were spawned. Child agent branches may differ; status.branch/upstream describe the reviewed parent checkout.";
 const READ_ONLY_PROMPT =
   "This is a read-only review step. Do not edit files, create commits, apply patches, push branches, or open PRs. Inspect repository evidence only as needed and report findings.";
 const VALUE_FLAGS = [
@@ -650,6 +653,7 @@ function promptContexts(input, gitContext) {
 function renderContext(input, gitContext) {
   return fencedJson({
     input: { target: input.target, fix: input.fix, maxFindings: input.maxFindings },
+    gitContextSource: GIT_CONTEXT_SOURCE,
     gitContext: gitContext,
   });
 }
@@ -785,6 +789,7 @@ function reviewPrompt(lane, input, reviewContext) {
       input.maxFindings +
       " actionable findings. Use stable finding ids and arrays for filePaths/evidence.",
     "\nLane checklist:\n- " + lane.instructions.join("\n- "),
+    GIT_CONTEXT_PROVENANCE_NOTE,
     "\nReview context:\n" + reviewContext,
   ].join("\n\n");
 }
@@ -797,6 +802,7 @@ function synthesisPrompt(input, compactContext, reviewOutputs) {
       " highest-value issues.",
     "Do not edit files in this step. Produce triage and fix plans for the later fixer step. If a finding is false positive or not worth addressing, put it in skippedFindings without debating it.",
     "Allowed severity values are: high, medium, low. Prefer minimal cleanup over broad refactors.",
+    GIT_CONTEXT_PROVENANCE_NOTE,
     "\nCompact review context without raw diff text:\n" + compactContext,
     "\nCompacted lane outputs:\n" + fencedJson(compactReviewOutputs(reviewOutputs)),
   ].join("\n\n");
@@ -809,6 +815,7 @@ function fixPrompt(compactContext, synthesized) {
     "Use the compact context for file lists and diff metadata; inspect files directly instead of relying on raw diff text being embedded in this prompt.",
     "Preserve existing style and functionality. Run targeted validation for touched code when feasible and report exact commands/results.",
     "If a finding is false positive or not worth addressing, skip it and note why. Set madeChanges true only when files changed.",
+    GIT_CONTEXT_PROVENANCE_NOTE,
     "\nCompact review context:\n" + compactContext,
     "\nActionable findings:\n" + fencedJson(fixerPayload(synthesized)),
   ].join("\n\n");

--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -566,10 +566,11 @@ function targetNeedsUntrackedContent(input, gitContext) {
 }
 
 function untrackedPaths(gitContext) {
-  return asArray(gitContext.status && gitContext.status.untracked)
+  const paths = asArray(gitContext.status && gitContext.status.untracked)
     .concat(asArray(gitContext.changedFiles && gitContext.changedFiles.untracked))
     .map(filePath)
     .filter(Boolean);
+  return Array.from(new Set(paths));
 }
 
 function filePath(value) {
@@ -788,9 +789,9 @@ function reviewPrompt(lane, input, reviewContext) {
     "The synthesis step will keep at most " +
       input.maxFindings +
       " actionable findings. Use stable finding ids and arrays for filePaths/evidence.",
-    "\nLane checklist:\n- " + lane.instructions.join("\n- "),
+    "Lane checklist:\n- " + lane.instructions.join("\n- "),
     GIT_CONTEXT_PROVENANCE_NOTE,
-    "\nReview context:\n" + reviewContext,
+    "Review context:\n" + reviewContext,
   ].join("\n\n");
 }
 
@@ -803,8 +804,8 @@ function synthesisPrompt(input, compactContext, reviewOutputs) {
     "Do not edit files in this step. Produce triage and fix plans for the later fixer step. If a finding is false positive or not worth addressing, put it in skippedFindings without debating it.",
     "Allowed severity values are: high, medium, low. Prefer minimal cleanup over broad refactors.",
     GIT_CONTEXT_PROVENANCE_NOTE,
-    "\nCompact review context without raw diff text:\n" + compactContext,
-    "\nCompacted lane outputs:\n" + fencedJson(compactReviewOutputs(reviewOutputs)),
+    "Compact review context without raw diff text:\n" + compactContext,
+    "Compacted lane outputs:\n" + fencedJson(compactReviewOutputs(reviewOutputs)),
   ].join("\n\n");
 }
 
@@ -816,8 +817,8 @@ function fixPrompt(compactContext, synthesized) {
     "Preserve existing style and functionality. Run targeted validation for touched code when feasible and report exact commands/results.",
     "If a finding is false positive or not worth addressing, skip it and note why. Set madeChanges true only when files changed.",
     GIT_CONTEXT_PROVENANCE_NOTE,
-    "\nCompact review context:\n" + compactContext,
-    "\nActionable findings:\n" + fencedJson(fixerPayload(synthesized)),
+    "Compact review context:\n" + compactContext,
+    "Actionable findings:\n" + fencedJson(fixerPayload(synthesized)),
   ].join("\n\n");
 }
 


### PR DESCRIPTION
## Summary

Clarifies simplify workflow Git context provenance so child review prompts explain that branch/upstream metadata comes from the reviewed parent checkout, not necessarily the spawned child agent branch. Also applies the simplify workflow's self-review cleanup findings for prompt spacing and duplicated untracked-path handling.

## Background

A simplify review prompt showed a generated branch name that looked wrong from the child agent's perspective. The built-in Git actions were reporting the parent workflow checkout correctly, but the prompt did not make that provenance explicit.

## Implementation

- Add a reusable provenance note and `gitContextSource: "parent-workflow-checkout"` field to simplify review context JSON.
- Include the provenance note in review, synthesis, and fix prompts.
- Remove redundant leading newlines in prompt sections now separated by `join("\n\n")`.
- Deduplicate merged untracked paths from `git.status` and `git.changedFiles`.

## Validation

- Targeted workflow harness reproduced the missing provenance note before the fix and passed after the fix.
- `workflow_run simplify --help` completed successfully.
- `workflow_run simplify` completed and applied the cleanup commit.
- `bun .mux/workflows/simplify.js` passed.
- `bunx prettier --check .mux/workflows/simplify.js` passed.
- `MUX_ESLINT_CONCURRENCY=1 make static-check` passed locally before pushing.

## Risks

Low. This changes a project workflow prompt and small metadata helpers only; runtime Git action semantics are unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$15.69`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=15.69 -->
