### PR TITLE
🤖 fix: auto-collapse workflow tool cards

### DIFF
--- a/src/browser/features/Tools/Shared/toolUtils.tsx
+++ b/src/browser/features/Tools/Shared/toolUtils.tsx
@@ -32,6 +32,71 @@ export function useToolExpansion(initialExpanded = false, options?: UseStickyExp
   return useStickyExpand("tools", initialExpanded, options);
 }
 
+interface AutoCollapsingToolExpansionOptions {
+  autoCollapsed: boolean;
+  resetKey: string | undefined;
+}
+
+/**
+ * Tool expansion with a non-persisted presentation-only auto-collapse layer.
+ * Header toggles still go through useToolExpansion and are the only path that
+ * updates the sticky per-tool preference.
+ */
+export function useAutoCollapsingToolExpansion(
+  initialExpanded: boolean,
+  options: AutoCollapsingToolExpansionOptions
+) {
+  const { expanded: stickyExpanded, setExpanded: setStickyExpanded } =
+    useToolExpansion(initialExpanded);
+  const [userInteraction, setUserInteraction] = React.useState<{
+    key: string | undefined;
+    interacted: boolean;
+  }>(() => ({ key: options.resetKey, interacted: false }));
+  const [localExpanded, setLocalExpandedState] = React.useState<{
+    key: string | undefined;
+    expanded: boolean;
+  } | null>(null);
+  const localExpandedValue =
+    localExpanded != null && localExpanded.key === options.resetKey ? localExpanded.expanded : null;
+  const userInteracted =
+    localExpandedValue != null ||
+    (userInteraction.interacted && userInteraction.key === options.resetKey);
+  const expanded =
+    options.autoCollapsed && !userInteracted ? false : (localExpandedValue ?? stickyExpanded);
+
+  const expandedRef = React.useRef(expanded);
+  expandedRef.current = expanded;
+  const resetKeyRef = React.useRef(options.resetKey);
+  resetKeyRef.current = options.resetKey;
+
+  // These callbacks intentionally keep stable identities: WorkflowRunToolCall registers
+  // command-palette actions from an effect and relies on the expansion setter not changing
+  // unless the underlying sticky setter changes.
+  const markInteracted = React.useCallback((): void => {
+    setUserInteraction({ key: resetKeyRef.current, interacted: true });
+  }, []);
+  const setExpanded = React.useCallback(
+    (next: boolean): void => {
+      markInteracted();
+      setLocalExpandedState(null);
+      setStickyExpanded(next);
+    },
+    [markInteracted, setStickyExpanded]
+  );
+  const setLocalExpanded = React.useCallback(
+    (next: boolean): void => {
+      markInteracted();
+      setLocalExpandedState({ key: resetKeyRef.current, expanded: next });
+    },
+    [markInteracted]
+  );
+  const toggleExpanded = React.useCallback(() => {
+    setExpanded(!expandedRef.current);
+  }, [setExpanded]);
+
+  return { expanded, setExpanded, setLocalExpanded, toggleExpanded, markInteracted };
+}
+
 /**
  * Get display element for tool status
  */

--- a/src/browser/features/Tools/WorkflowActionListToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowActionListToolCall.test.tsx
@@ -16,6 +16,12 @@ function renderWithTooltip(ui: React.ReactElement) {
   );
 }
 
+function clickToolHeader(view: ReturnType<typeof render>, label: string) {
+  const header = view.getByText(label).closest('[data-scroll-intent="ignore"]');
+  expect(header).toBeTruthy();
+  fireEvent.click(header as HTMLElement);
+}
+
 describe("WorkflowActionListToolCall", () => {
   let originalWindow: typeof globalThis.window;
   let originalDocument: typeof globalThis.document;
@@ -37,7 +43,7 @@ describe("WorkflowActionListToolCall", () => {
     globalThis.localStorage = originalLocalStorage;
   });
 
-  test("renders action rows with effect and blocked badges", () => {
+  test("renders action rows with effect and blocked badges after manual expansion", () => {
     const view = renderWithTooltip(
       <WorkflowActionListToolCall
         args={{}}
@@ -69,6 +75,11 @@ describe("WorkflowActionListToolCall", () => {
     );
 
     expect(view.getByText("2 actions")).toBeTruthy();
+    expect(view.queryByText("git.changedFiles")).toBeNull();
+    expect(view.queryByText("Project is not trusted")).toBeNull();
+
+    clickToolHeader(view, "2 actions");
+
     expect(view.getByText("git.changedFiles")).toBeTruthy();
     expect(view.getByText("read")).toBeTruthy();
     expect(view.getByText("blocked")).toBeTruthy();
@@ -104,6 +115,7 @@ describe("WorkflowActionListToolCall", () => {
 
     expect(view.queryByText("Input schema")).toBeNull();
 
+    clickToolHeader(view, "1 action");
     fireEvent.click(view.getByRole("button", { expanded: false }));
 
     expect(view.getByText("/__mux_builtin_workflow_actions__/git/changedFiles.js")).toBeTruthy();

--- a/src/browser/features/Tools/WorkflowActionListToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowActionListToolCall.test.tsx
@@ -6,7 +6,12 @@ import type React from "react";
 
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { MessageListProvider } from "@/browser/features/Messages/MessageListContext";
+import { ToolNameProvider } from "@/browser/features/Messages/ToolNameContext";
+import { getAutoExpandPrefsKey } from "@/common/constants/storage";
 import { WorkflowActionListToolCall } from "./WorkflowActionListToolCall";
+
+const TEST_WORKSPACE_ID = "workflow-action-list-tool-test";
 
 function renderWithTooltip(ui: React.ReactElement) {
   return render(
@@ -14,6 +19,22 @@ function renderWithTooltip(ui: React.ReactElement) {
       <TooltipProvider>{ui}</TooltipProvider>
     </ThemeProvider>
   );
+}
+
+function renderWithStickyToolProviders(ui: React.ReactElement) {
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <MessageListProvider value={{ workspaceId: TEST_WORKSPACE_ID, latestMessageId: null }}>
+        <ToolNameProvider toolName="workflow_action_list">
+          <TooltipProvider>{ui}</TooltipProvider>
+        </ToolNameProvider>
+      </MessageListProvider>
+    </ThemeProvider>
+  );
+}
+
+function getStoredPrefs(): string | null {
+  return globalThis.localStorage.getItem(getAutoExpandPrefsKey(TEST_WORKSPACE_ID));
 }
 
 function clickToolHeader(view: ReturnType<typeof render>, label: string) {
@@ -41,6 +62,43 @@ describe("WorkflowActionListToolCall", () => {
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
     globalThis.localStorage = originalLocalStorage;
+  });
+
+  test("auto-collapses completed action lists without mutating sticky preferences", () => {
+    const completedView = renderWithStickyToolProviders(
+      <WorkflowActionListToolCall
+        args={{}}
+        status="completed"
+        result={{
+          actions: [
+            {
+              name: "git.changedFiles",
+              scope: "built-in",
+              sourcePath: "/__mux_builtin_workflow_actions__/git/changedFiles.js",
+              executable: true,
+              hasReconcile: false,
+              metadata: {
+                version: 1,
+                description: "Return changed file lists.",
+                effect: "read",
+              },
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(completedView.getByText("1 action")).toBeTruthy();
+    expect(completedView.queryByText("git.changedFiles")).toBeNull();
+    expect(getStoredPrefs()).toBeNull();
+    completedView.unmount();
+
+    const executingView = renderWithStickyToolProviders(
+      <WorkflowActionListToolCall args={{}} status="executing" />
+    );
+
+    expect(executingView.container.textContent).toContain("Waiting for workflow result");
+    expect(getStoredPrefs()).toBeNull();
   });
 
   test("renders action rows with effect and blocked badges after manual expansion", () => {

--- a/src/browser/features/Tools/WorkflowActionListToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowActionListToolCall.tsx
@@ -18,18 +18,14 @@ import {
   ToolIcon,
   ToolName,
 } from "./Shared/ToolPrimitives";
-import {
-  getStatusDisplay,
-  isToolErrorResult,
-  type ToolStatus,
-  useToolExpansion,
-} from "./Shared/toolUtils";
+import { getStatusDisplay, isToolErrorResult, type ToolStatus } from "./Shared/toolUtils";
 import {
   WorkflowBadge,
   WorkflowJsonBlock,
   WorkflowKindBadge,
   WorkflowLoadingState,
   WorkflowSection,
+  useAutoCollapsingWorkflowLookup,
 } from "./WorkflowDefinitionToolCall";
 
 interface WorkflowActionListToolCallProps {
@@ -167,7 +163,7 @@ export const WorkflowActionListToolCall: React.FC<WorkflowActionListToolCallProp
   result,
   status = "pending",
 }) => {
-  const { expanded, toggleExpanded } = useToolExpansion(true);
+  const { expanded, toggleExpanded } = useAutoCollapsingWorkflowLookup(status);
   const errorResult = isToolErrorResult(result) ? result : null;
   const successResult = isWorkflowActionListSuccessResult(result) ? result : null;
   const actions = successResult?.actions ?? [];

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.stories.tsx
@@ -28,6 +28,13 @@ function NarrowContainerDecorator(Story: ComponentType) {
   );
 }
 
+function expandToolCard(canvasElement: HTMLElement, summaryText: string) {
+  const canvas = within(canvasElement);
+  const header = canvas.getByText(summaryText).closest('[data-scroll-intent="ignore"]');
+  if (header == null) throw new Error(`Could not find tool header for "${summaryText}"`);
+  (header as HTMLElement).click();
+}
+
 /**
  * Assert the narrow list layout engaged: the description must wrap onto its own
  * grid row below the name instead of sharing the single-line wide layout.
@@ -165,6 +172,7 @@ export const WorkflowActionListNarrow: Story = {
     chromatic: { modes: { "dark-mobile": { theme: "dark", viewport: "mobile1", hasTouch: true } } },
   },
   play: async ({ canvasElement }) => {
+    expandToolCard(canvasElement, "4 actions");
     await expectDescriptionBelowName(
       canvasElement,
       "git.changedFiles",
@@ -218,6 +226,7 @@ export const WorkflowListNarrow: Story = {
     chromatic: { modes: { "dark-mobile": { theme: "dark", viewport: "mobile1", hasTouch: true } } },
   },
   play: async ({ canvasElement }) => {
+    expandToolCard(canvasElement, "3 definitions");
     await expectDescriptionBelowName(canvasElement, "deep-research", /Coordinate staged research/);
   },
 };

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.test.tsx
@@ -6,6 +6,9 @@ import type React from "react";
 
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { MessageListProvider } from "@/browser/features/Messages/MessageListContext";
+import { ToolNameProvider } from "@/browser/features/Messages/ToolNameContext";
+import { getAutoExpandPrefsKey } from "@/common/constants/storage";
 import { WorkflowListToolCall, WorkflowReadToolCall } from "./WorkflowDefinitionToolCall";
 
 const source = `export default function workflow({ args, agent }) {
@@ -13,12 +16,30 @@ const source = `export default function workflow({ args, agent }) {
   return agent({ id: "review", prompt: "Review " + topic });
 }`;
 
+const TEST_WORKSPACE_ID = "workflow-definition-tool-test";
+
 function renderWithTooltip(ui: React.ReactElement) {
   return render(
     <ThemeProvider forcedTheme="dark">
       <TooltipProvider>{ui}</TooltipProvider>
     </ThemeProvider>
   );
+}
+
+function renderWithStickyToolProviders(ui: React.ReactElement, toolName: string) {
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <MessageListProvider value={{ workspaceId: TEST_WORKSPACE_ID, latestMessageId: null }}>
+        <ToolNameProvider toolName={toolName}>
+          <TooltipProvider>{ui}</TooltipProvider>
+        </ToolNameProvider>
+      </MessageListProvider>
+    </ThemeProvider>
+  );
+}
+
+function getStoredPrefs(): string | null {
+  return globalThis.localStorage.getItem(getAutoExpandPrefsKey(TEST_WORKSPACE_ID));
 }
 
 function expectWorkflowHeaderBadge(view: ReturnType<typeof render>, label: string) {
@@ -52,6 +73,38 @@ describe("WorkflowDefinitionToolCall", () => {
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
     globalThis.localStorage = originalLocalStorage;
+  });
+
+  test("auto-collapses completed workflow_read without mutating sticky preferences", () => {
+    const completedView = renderWithStickyToolProviders(
+      <WorkflowReadToolCall
+        args={{ name: "deep-research" }}
+        status="completed"
+        result={{
+          descriptor: {
+            name: "deep-research",
+            description: "Deep research",
+            scope: "built-in",
+            executable: true,
+          },
+          source,
+        }}
+      />,
+      "workflow_read"
+    );
+
+    expect(completedView.queryByText("Deep research")).toBeNull();
+    expect(completedView.container.textContent).not.toContain("return agent");
+    expect(getStoredPrefs()).toBeNull();
+    completedView.unmount();
+
+    const executingView = renderWithStickyToolProviders(
+      <WorkflowReadToolCall args={{ name: "deep-research" }} status="executing" />,
+      "workflow_read"
+    );
+
+    expect(executingView.container.textContent).toContain("Waiting for workflow result");
+    expect(getStoredPrefs()).toBeNull();
   });
 
   test("renders workflow_read metadata and highlighted source", () => {

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { GlobalWindow } from "happy-dom";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 
 import type React from "react";
 
@@ -25,6 +25,12 @@ function expectWorkflowHeaderBadge(view: ReturnType<typeof render>, label: strin
   const workflowBadge = view.getByText("Workflow");
   const headerText = workflowBadge.closest('[data-scroll-intent="ignore"]')?.textContent ?? "";
   expect(headerText.indexOf("Workflow")).toBeLessThan(headerText.indexOf(label));
+}
+
+function clickToolHeader(view: ReturnType<typeof render>, label: string) {
+  const header = view.getByText(label).closest('[data-scroll-intent="ignore"]');
+  expect(header).toBeTruthy();
+  fireEvent.click(header as HTMLElement);
 }
 
 describe("WorkflowDefinitionToolCall", () => {
@@ -66,11 +72,16 @@ describe("WorkflowDefinitionToolCall", () => {
     );
 
     expectWorkflowHeaderBadge(view, "deep-research");
+    expect(view.queryByText("Deep research")).toBeNull();
+    expect(view.container.textContent).not.toContain("return agent");
+
+    clickToolHeader(view, "deep-research");
+
     expect(view.getByText("Deep research")).toBeTruthy();
     expect(view.container.textContent).toContain("return agent");
   });
 
-  test("renders workflow_list as definition cards", () => {
+  test("renders workflow_list as definition cards after manual expansion", () => {
     const view = renderWithTooltip(
       <WorkflowListToolCall
         args={{}}
@@ -97,6 +108,11 @@ describe("WorkflowDefinitionToolCall", () => {
 
     expectWorkflowHeaderBadge(view, "list");
     expect(view.getByText("2 definitions")).toBeTruthy();
+    expect(view.queryByText("blocked")).toBeNull();
+    expect(view.queryByText("Project is not trusted")).toBeNull();
+
+    clickToolHeader(view, "2 definitions");
+
     expect(view.queryByText("executable")).toBeNull();
     expect(view.getByText("blocked")).toBeTruthy();
     expect(view.getByText("Project is not trusted")).toBeTruthy();

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
@@ -27,7 +27,7 @@ import {
   getStatusDisplay,
   isToolErrorResult,
   type ToolStatus,
-  useToolExpansion,
+  useAutoCollapsingToolExpansion,
 } from "./Shared/toolUtils";
 import { HighlightedCode, JsonHighlight } from "./Shared/HighlightedCode";
 
@@ -225,23 +225,13 @@ function isWorkflowReadSuccessResult(
 const AUTO_COLLAPSE_WORKFLOW_LOOKUP_STATUSES = new Set<ToolStatus>(["completed"]);
 
 export function useAutoCollapsingWorkflowLookup(status: ToolStatus) {
-  const { expanded, setExpanded, toggleExpanded } = useToolExpansion(true);
-  const userToggledExpansionRef = React.useRef(false);
-
-  const toggleAutoCollapsingExpanded = () => {
-    userToggledExpansionRef.current = true;
-    toggleExpanded();
-  };
-
-  React.useLayoutEffect(() => {
-    // Completed workflow lookup/action payloads can be bulky; collapse them once
-    // the result arrives for transcript scanability, but keep explicit user intent.
-    if (AUTO_COLLAPSE_WORKFLOW_LOOKUP_STATUSES.has(status) && !userToggledExpansionRef.current) {
-      setExpanded(false);
-    }
-  }, [status, setExpanded]);
-
-  return { expanded, toggleExpanded: toggleAutoCollapsingExpanded };
+  // Completed workflow lookup/action payloads can be bulky, so collapse them for
+  // transcript scanability without writing that automatic presentation choice to
+  // the user's sticky expansion preference. Header clicks still persist intent.
+  return useAutoCollapsingToolExpansion(true, {
+    autoCollapsed: AUTO_COLLAPSE_WORKFLOW_LOOKUP_STATUSES.has(status),
+    resetKey: undefined,
+  });
 }
 
 export function WorkflowLoadingState() {

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
@@ -222,6 +222,28 @@ function isWorkflowReadSuccessResult(
   return value != null && !isToolErrorResult(value);
 }
 
+const AUTO_COLLAPSE_WORKFLOW_LOOKUP_STATUSES = new Set<ToolStatus>(["completed"]);
+
+export function useAutoCollapsingWorkflowLookup(status: ToolStatus) {
+  const { expanded, setExpanded, toggleExpanded } = useToolExpansion(true);
+  const userToggledExpansionRef = React.useRef(false);
+
+  const toggleAutoCollapsingExpanded = () => {
+    userToggledExpansionRef.current = true;
+    toggleExpanded();
+  };
+
+  React.useLayoutEffect(() => {
+    // Completed workflow lookup/action payloads can be bulky; collapse them once
+    // the result arrives for transcript scanability, but keep explicit user intent.
+    if (AUTO_COLLAPSE_WORKFLOW_LOOKUP_STATUSES.has(status) && !userToggledExpansionRef.current) {
+      setExpanded(false);
+    }
+  }, [status, setExpanded]);
+
+  return { expanded, toggleExpanded: toggleAutoCollapsingExpanded };
+}
+
 export function WorkflowLoadingState() {
   return (
     <div className="text-muted text-[11px] italic">
@@ -235,7 +257,7 @@ export const WorkflowListToolCall: React.FC<WorkflowListToolCallProps> = ({
   result,
   status = "pending",
 }) => {
-  const { expanded, toggleExpanded } = useToolExpansion(true);
+  const { expanded, toggleExpanded } = useAutoCollapsingWorkflowLookup(status);
   const errorResult = isToolErrorResult(result) ? result : null;
   const successResult = isWorkflowListSuccessResult(result) ? result : null;
   const workflows = successResult?.workflows ?? [];
@@ -276,7 +298,7 @@ export const WorkflowReadToolCall: React.FC<WorkflowReadToolCallProps> = ({
   result,
   status = "pending",
 }) => {
-  const { expanded, toggleExpanded } = useToolExpansion(true);
+  const { expanded, toggleExpanded } = useAutoCollapsingWorkflowLookup(status);
   const errorResult = isToolErrorResult(result) ? result : null;
   const successResult = isWorkflowReadSuccessResult(result) ? result : null;
 

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -23,6 +23,9 @@ import {
 } from "@/browser/contexts/CommandRegistryContext";
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { MessageListProvider } from "@/browser/features/Messages/MessageListContext";
+import { ToolNameProvider } from "@/browser/features/Messages/ToolNameContext";
+import { getAutoExpandPrefsKey } from "@/common/constants/storage";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 function createWorkflowTaskWorkspaceMetadata(workspaceId: string): FrontendWorkspaceMetadata {
   return {
@@ -117,6 +120,77 @@ function APIHarness(props: { client: unknown; children: ReactNode }) {
   );
 }
 
+const TEST_WORKSPACE_ID = "workflow-run-tool-test";
+
+function withStickyToolProviders(ui: ReactElement, toolName = "workflow_run") {
+  return (
+    <ThemeProvider forcedTheme="dark">
+      <MessageListProvider value={{ workspaceId: TEST_WORKSPACE_ID, latestMessageId: null }}>
+        <ToolNameProvider toolName={toolName}>
+          <TooltipProvider>{ui}</TooltipProvider>
+        </ToolNameProvider>
+      </MessageListProvider>
+    </ThemeProvider>
+  );
+}
+
+function renderWithStickyToolProviders(ui: ReactElement, toolName = "workflow_run") {
+  return render(withStickyToolProviders(ui, toolName));
+}
+
+function getStoredPrefs(): string | null {
+  return globalThis.localStorage.getItem(getAutoExpandPrefsKey(TEST_WORKSPACE_ID));
+}
+
+function createWorkflowRunForExpansionTest(input: {
+  id: string;
+  status: "running" | "completed";
+  reportMarkdown?: string;
+}) {
+  return {
+    id: input.id,
+    workspaceId: TEST_WORKSPACE_ID,
+    definition: {
+      name: "deep-research",
+      description: "Deep research",
+      scope: "built-in" as const,
+      executable: true,
+    },
+    definitionSource: "export default function workflow() { return null; }",
+    definitionHash: "sha256:test",
+    args: { topic: "workflow cards" },
+    status: input.status,
+    createdAt: "2026-05-29T00:00:00.000Z",
+    updatedAt:
+      input.status === "completed" ? "2026-05-29T00:00:02.000Z" : "2026-05-29T00:00:01.000Z",
+    events:
+      input.status === "completed"
+        ? [
+            {
+              sequence: 1,
+              type: "result" as const,
+              at: "2026-05-29T00:00:02.000Z",
+              result: { reportMarkdown: input.reportMarkdown ?? `${input.id} result` },
+            },
+            {
+              sequence: 2,
+              type: "status" as const,
+              at: "2026-05-29T00:00:02.000Z",
+              status: "completed" as const,
+            },
+          ]
+        : [
+            {
+              sequence: 1,
+              type: "status" as const,
+              at: "2026-05-29T00:00:01.000Z",
+              status: "running" as const,
+            },
+          ],
+    steps: [],
+  };
+}
+
 function CommandActionCapture(props: { onActions: (actions: CommandAction[]) => void }) {
   const registry = useCommandRegistry();
   useEffect(() => {
@@ -155,6 +229,96 @@ describe("WorkflowRunToolCall", () => {
     globalThis.window = originalWindow;
     globalThis.document = originalDocument;
     globalThis.localStorage = originalLocalStorage;
+  });
+
+  test("auto-collapses completed workflow runs without mutating sticky preferences", () => {
+    const completedRun = createWorkflowRunForExpansionTest({
+      id: "wfr_auto_collapse",
+      status: "completed",
+      reportMarkdown: "auto result",
+    });
+    const completedView = renderWithStickyToolProviders(
+      <WorkflowRunToolCall
+        args={{
+          name: "deep-research",
+          args: { topic: "workflow cards" },
+          run_in_background: false,
+        }}
+        status="completed"
+        result={{
+          status: "completed",
+          runId: completedRun.id,
+          result: { reportMarkdown: "auto result" },
+          run: completedRun,
+        }}
+      />
+    );
+
+    expect(completedView.queryByText("wfr_auto_collapse")).toBeNull();
+    expect(completedView.queryByText("auto result")).toBeNull();
+    expect(getStoredPrefs()).toBeNull();
+    completedView.unmount();
+
+    const runningRun = createWorkflowRunForExpansionTest({ id: "wfr_running", status: "running" });
+    const executingView = renderWithStickyToolProviders(
+      <WorkflowRunToolCall
+        args={{ name: "deep-research", args: { topic: "workflow cards" }, run_in_background: true }}
+        status="executing"
+        result={{ status: "running", runId: runningRun.id, result: null, run: runningRun }}
+      />
+    );
+
+    expect(executingView.getByText("wfr_running")).toBeTruthy();
+    expect(getStoredPrefs()).toBeNull();
+  });
+
+  test("resets completed workflow auto-collapse interaction for a new run id", () => {
+    const firstRun = createWorkflowRunForExpansionTest({ id: "wfr_first", status: "completed" });
+    const secondRun = createWorkflowRunForExpansionTest({ id: "wfr_second", status: "completed" });
+    const view = renderWithStickyToolProviders(
+      <WorkflowRunToolCall
+        args={{
+          name: "deep-research",
+          args: { topic: "workflow cards" },
+          run_in_background: false,
+        }}
+        status="completed"
+        result={{
+          status: "completed",
+          runId: firstRun.id,
+          result: { reportMarkdown: "first result" },
+          run: firstRun,
+        }}
+      />
+    );
+
+    expect(view.queryByText("wfr_first")).toBeNull();
+    fireEvent.click(getWorkflowHeader(view));
+    expect(view.getByText("wfr_first")).toBeTruthy();
+    expect(JSON.parse(getStoredPrefs() ?? "{}")).toEqual({ tools: { workflow_run: true } });
+
+    view.rerender(
+      withStickyToolProviders(
+        <WorkflowRunToolCall
+          args={{
+            name: "deep-research",
+            args: { topic: "workflow cards" },
+            run_in_background: false,
+          }}
+          status="completed"
+          result={{
+            status: "completed",
+            runId: secondRun.id,
+            result: { reportMarkdown: "second result" },
+            run: secondRun,
+          }}
+        />
+      )
+    );
+
+    expect(view.queryByText("wfr_second")).toBeNull();
+    expect(view.queryByText("second result")).toBeNull();
+    expect(JSON.parse(getStoredPrefs() ?? "{}")).toEqual({ tools: { workflow_run: true } });
   });
 
   test("renders workflow run phases, linked task ids, and final report", async () => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import React, { useContext, useEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import { APIContext, type APIClient } from "@/browser/contexts/API";
 import {
@@ -50,7 +43,7 @@ import {
   getStatusDisplay,
   isToolErrorResult,
   type ToolStatus,
-  useToolExpansion,
+  useAutoCollapsingToolExpansion,
 } from "./Shared/toolUtils";
 import { HighlightedCode } from "./Shared/HighlightedCode";
 import {
@@ -1039,9 +1032,6 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
 }) => {
   const apiState = useContext(APIContext);
   const commandRegistry = useOptionalCommandRegistry();
-  const { expanded, setExpanded, toggleExpanded } = useToolExpansion(true);
-  const userToggledExpansionRef = useRef(false);
-  const autoCollapseRunIdRef = useRef<string | undefined>(undefined);
   const registerCommandSource = commandRegistry?.registerSource;
   const errorResult = isToolErrorResult(result) ? result : null;
   const successResult = isWorkflowRunSuccessResult(result) ? result : null;
@@ -1075,22 +1065,21 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   const displayRows = getWorkflowDisplayRows(events);
   const headerStatus = toToolStatus(displayStatus);
   const workspaceStore = useWorkspaceStoreRaw();
+  const {
+    expanded,
+    setLocalExpanded,
+    toggleExpanded,
+    markInteracted: markExpansionInteracted,
+  } = useAutoCollapsingToolExpansion(true, {
+    // Completed workflow runs can contain large reports and event logs. Collapse them for
+    // scanability without persisting that automatic presentation choice as user intent.
+    autoCollapsed: AUTO_COLLAPSE_WORKFLOW_STATUSES.has(displayStatus),
+    resetKey: runId,
+  });
 
   const toggleWorkflowExpanded = () => {
-    userToggledExpansionRef.current = true;
     toggleExpanded();
   };
-  useLayoutEffect(() => {
-    if (autoCollapseRunIdRef.current !== runId) {
-      autoCollapseRunIdRef.current = runId;
-      userToggledExpansionRef.current = false;
-    }
-    // Completed workflow runs can contain large reports and event logs. Collapse them once for
-    // scanability, but never override an explicit user expansion/collapse choice.
-    if (AUTO_COLLAPSE_WORKFLOW_STATUSES.has(displayStatus) && !userToggledExpansionRef.current) {
-      setExpanded(false);
-    }
-  }, [displayStatus, runId, setExpanded]);
 
   const [actionError, setActionError] = useState<string | null>(null);
   const [promotedDefinition, setPromotedDefinition] = useState<WorkflowDefinitionDescriptor | null>(
@@ -1291,8 +1280,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
             section: "Workflows",
             keywords: ["workflow", "save", "project", "scratch", displayName, runId],
             run: () => {
-              userToggledExpansionRef.current = true;
-              setExpanded(true);
+              setLocalExpanded(true);
               saveScratchWorkflowRef.current("project");
             },
           },
@@ -1303,8 +1291,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
             section: "Workflows",
             keywords: ["workflow", "save", "global", "scratch", displayName, runId],
             run: () => {
-              userToggledExpansionRef.current = true;
-              setExpanded(true);
+              setLocalExpanded(true);
               saveScratchWorkflowRef.current("global");
             },
           }
@@ -1325,7 +1312,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     registerCommandSource,
     run?.workspaceId,
     runId,
-    setExpanded,
+    setLocalExpanded,
   ]);
 
   useEffect(() => {
@@ -1578,10 +1565,10 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                           steps={run?.steps ?? []}
                           onNavigate={(taskId) => workspaceStore.navigateToWorkspace(taskId)}
                           onOpenReport={() => {
-                            userToggledExpansionRef.current = true;
+                            markExpansionInteracted();
                           }}
                           onInspectStructuredOutput={() => {
-                            userToggledExpansionRef.current = true;
+                            markExpansionInteracted();
                           }}
                         />
                       );


### PR DESCRIPTION
## Summary

Auto-collapse completed workflow lookup cards so workflow list, workflow read, and workflow action list results match the scannability behavior of the other workflow cards.

## Background

Completed workflow definition/action payloads can be large, especially workflow source blocks and action schemas. Leaving them expanded made transcripts noisy compared with the rest of the tool UI.

## Implementation

- Added a shared non-persisting auto-collapse layer for tool expansion state.
- Updated `workflow_list`, `workflow_read`, and `workflow_action_list` cards to collapse completed results while keeping executing cards visible by default.
- Kept manual header toggles as the only path that persists sticky expansion preference, so automatic collapse does not affect future tool cards.
- Extended the same preference-safe behavior to workflow run cards after the simplify workflow caught the sticky-preference edge case.
- Added regression coverage for workflow lookup/action list/run cards under workspace + tool-name providers.

## Validation

- `bun test src/browser/features/Tools/WorkflowDefinitionToolCall.test.tsx src/browser/features/Tools/WorkflowActionListToolCall.test.tsx src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- Storybook dogfood captured collapsed/expanded states for workflow list, workflow read, and workflow action list cards with screenshots and video.
- Simplify workflow `wfr_9ab2221bb2f4656b` reviewed the initial implementation, applied the preference-safety fix, and validated with targeted tests plus static checks.

## Risks

Low-to-medium UI state risk. The change touches shared expansion behavior and workflow run presentation, but tests cover the critical sticky-preference invariant: automatic collapse must not write persisted user preference, and executing cards should still mount expanded unless the user manually collapsed that tool.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$23.71`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=23.71 -->
