### PR TITLE
🤖 fix: detect MCP OAuth on POST-only servers

### DIFF
--- a/src/node/services/mcpOauthService.test.ts
+++ b/src/node/services/mcpOauthService.test.ts
@@ -5,7 +5,11 @@ import * as os from "os";
 import * as path from "path";
 import { Config } from "@/node/config";
 import { MCPConfigService } from "./mcpConfigService";
-import { McpOauthService, parseBearerWwwAuthenticate } from "./mcpOauthService";
+import {
+  McpOauthService,
+  parseBearerWwwAuthenticate,
+  probeServerForBearerChallenge,
+} from "./mcpOauthService";
 
 function getStoreFilePath(muxHome: string): string {
   return path.join(muxHome, "mcp-oauth.json");
@@ -238,6 +242,98 @@ describe("parseBearerWwwAuthenticate", () => {
     expect(challenge).not.toBeNull();
     expect(challenge?.scope).toBe("mcp.read");
     expect(challenge?.resourceMetadataUrl).toBeUndefined();
+  });
+});
+
+describe("probeServerForBearerChallenge", () => {
+  test("prefers POST for http servers that reject GET", async () => {
+    let resourceMetadataUrl = "";
+    const seenMethods: string[] = [];
+
+    const server = createServer((req, res) => {
+      seenMethods.push(req.method ?? "UNKNOWN");
+      res.statusCode = req.method === "POST" ? 401 : 405;
+      if (req.method === "POST") {
+        res.setHeader(
+          "WWW-Authenticate",
+          `Bearer scope="mcp.read" resource_metadata="${resourceMetadataUrl}"`
+        );
+      }
+      res.end(req.method === "POST" ? "Unauthorized" : "Method Not Allowed");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to bind probe test server");
+      }
+
+      const baseUrl = `http://127.0.0.1:${address.port}/mcp`;
+      resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+
+      const challenge = await probeServerForBearerChallenge({
+        serverUrl: baseUrl,
+        transport: "http",
+      });
+
+      expect(challenge).toMatchObject({
+        raw: `Bearer scope="mcp.read" resource_metadata="${resourceMetadataUrl}"`,
+        scope: "mcp.read",
+      });
+      expect(challenge?.resourceMetadataUrl?.toString()).toBe(resourceMetadataUrl);
+      expect(seenMethods).toEqual(["POST"]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("falls back to GET for auto servers when POST has no challenge", async () => {
+    let resourceMetadataUrl = "";
+    const seenMethods: string[] = [];
+
+    const server = createServer((req, res) => {
+      seenMethods.push(req.method ?? "UNKNOWN");
+      if (req.method === "POST") {
+        res.statusCode = 405;
+        res.end("Method Not Allowed");
+        return;
+      }
+
+      res.statusCode = 401;
+      res.setHeader(
+        "WWW-Authenticate",
+        `Bearer scope="mcp.read" resource_metadata="${resourceMetadataUrl}"`
+      );
+      res.end("Unauthorized");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to bind auto probe test server");
+      }
+
+      const baseUrl = `http://127.0.0.1:${address.port}/mcp`;
+      resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+
+      const challenge = await probeServerForBearerChallenge({
+        serverUrl: baseUrl,
+        transport: "auto",
+      });
+
+      expect(challenge).toMatchObject({
+        raw: `Bearer scope="mcp.read" resource_metadata="${resourceMetadataUrl}"`,
+        scope: "mcp.read",
+      });
+      expect(challenge?.resourceMetadataUrl?.toString()).toBe(resourceMetadataUrl);
+      expect(seenMethods).toEqual(["POST", "GET"]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });
 

--- a/src/node/services/mcpOauthService.ts
+++ b/src/node/services/mcpOauthService.ts
@@ -203,38 +203,83 @@ export function parseBearerWwwAuthenticate(header: string): BearerChallenge | nu
   };
 }
 
-async function probeServerForBearerChallenge(serverUrl: string): Promise<BearerChallenge | null> {
-  const requestUrl = sanitizeServerUrlForRequest(serverUrl);
+type BearerChallengeProbeTransport = OAuthFlowBase["transport"];
+
+interface BearerChallengeProbeRequest {
+  method: "GET" | "POST";
+  headers: Record<string, string>;
+  body?: string;
+}
+
+function getWwwAuthenticateHeader(response: Response): string | null {
+  return response.headers.get("www-authenticate") ?? response.headers.get("WWW-Authenticate");
+}
+
+function getBearerChallengeProbeRequests(
+  transport: BearerChallengeProbeTransport
+): BearerChallengeProbeRequest[] {
+  const sseRequest: BearerChallengeProbeRequest = {
+    method: "GET",
+    headers: {
+      Accept: "text/event-stream",
+    },
+  };
+
+  const httpRequest: BearerChallengeProbeRequest = {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+    },
+    // Mirror the HTTP transport's verb so POST-only MCP endpoints still emit their
+    // Bearer challenge, but keep the payload tiny because we only need auth hints.
+    body: "{}",
+  };
+
+  // Prefer the configured transport's verb first, then fall back to the other
+  // remote verb so challenge discovery stays resilient across mixed deployments.
+  return transport === "sse" ? [sseRequest, httpRequest] : [httpRequest, sseRequest];
+}
+
+export async function probeServerForBearerChallenge(options: {
+  serverUrl: string;
+  transport: BearerChallengeProbeTransport;
+}): Promise<BearerChallenge | null> {
+  const requestUrl = sanitizeServerUrlForRequest(options.serverUrl);
   if (!requestUrl) {
     return null;
   }
 
-  // Best-effort probe: do a simple unauthenticated request and parse WWW-Authenticate.
-  //
-  // We intentionally avoid sending MCP-specific headers here because the probe is
-  // only used to extract OAuth hints (scope/resource_metadata) and must not be
-  // protocol-version coupled.
   const abortController = new AbortController();
   const timeout = setTimeout(() => abortController.abort(), 5_000);
 
   try {
-    const response = await fetch(requestUrl, {
-      method: "GET",
-      headers: {
-        Accept: "text/event-stream",
-      },
-      redirect: "manual",
-      signal: abortController.signal,
-    });
+    for (const request of getBearerChallengeProbeRequests(options.transport)) {
+      try {
+        const response = await fetch(requestUrl, {
+          method: request.method,
+          headers: request.headers,
+          ...(request.body ? { body: request.body } : {}),
+          redirect: "manual",
+          signal: abortController.signal,
+        });
 
-    const header =
-      response.headers.get("www-authenticate") ?? response.headers.get("WWW-Authenticate");
-    if (!header) {
-      return null;
+        const header = getWwwAuthenticateHeader(response);
+        if (!header) {
+          continue;
+        }
+
+        const challenge = parseBearerWwwAuthenticate(header);
+        if (challenge) {
+          return challenge;
+        }
+      } catch {
+        if (abortController.signal.aborted) {
+          break;
+        }
+      }
     }
 
-    return parseBearerWwwAuthenticate(header);
-  } catch {
     return null;
   } finally {
     clearTimeout(timeout);
@@ -671,7 +716,10 @@ export class McpOauthService {
 
     // Best-effort probe for OAuth hints (scope/resource_metadata). If it fails,
     // @ai-sdk/mcp can still fall back to well-known discovery.
-    const challenge = await probeServerForBearerChallenge(serverUrlForDiscovery);
+    const challenge = await probeServerForBearerChallenge({
+      serverUrl: serverUrlForDiscovery,
+      transport,
+    });
 
     const flow: DesktopFlow = {
       flowId,
@@ -812,7 +860,10 @@ export class McpOauthService {
 
     // Best-effort probe for OAuth hints (scope/resource_metadata). If it fails,
     // @ai-sdk/mcp can still fall back to well-known discovery.
-    const challenge = await probeServerForBearerChallenge(serverUrlForDiscovery);
+    const challenge = await probeServerForBearerChallenge({
+      serverUrl: serverUrlForDiscovery,
+      transport,
+    });
 
     const flow: ServerFlow = {
       flowId,

--- a/src/node/services/mcpServerManager.test.ts
+++ b/src/node/services/mcpServerManager.test.ts
@@ -1033,6 +1033,63 @@ describe("MCPServerManager", () => {
     }
   });
 
+  test("test() includes oauthChallenge when auth is only advertised on POST", async () => {
+    let baseUrl = "";
+    let resourceMetadataUrl = "";
+
+    const server = createServer((req, res) => {
+      if (req.method === "POST") {
+        res.statusCode = 401;
+        res.setHeader(
+          "WWW-Authenticate",
+          `Bearer scope="mcp.read" resource_metadata="${resourceMetadataUrl}"`
+        );
+        res.setHeader("Content-Type", "application/json");
+        res.end(
+          JSON.stringify({
+            error: "invalid_token",
+            error_description: "Authentication failed.",
+          })
+        );
+        return;
+      }
+
+      res.statusCode = 405;
+      res.setHeader("Allow", "POST, DELETE");
+      res.end("Method Not Allowed");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Failed to bind POST-only OAuth challenge test server");
+      }
+
+      baseUrl = `http://127.0.0.1:${address.port}/mcp`;
+      resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
+
+      const result = await manager.test({
+        projectPath: PROJECT_PATH,
+        transport: "auto",
+        url: baseUrl,
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error("Expected test() to fail");
+      }
+
+      expect(result.oauthChallenge).toEqual({
+        scope: "mcp.read",
+        resourceMetadataUrl,
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   test("tool execution failure with closed-client error marks instance isClosed for restart", async () => {
     const workspaceId = "ws-tool-closed";
     configService.listServers = mock(() =>

--- a/src/node/services/mcpServerManager.ts
+++ b/src/node/services/mcpServerManager.ts
@@ -14,7 +14,11 @@ import type {
 import type { Runtime } from "@/node/runtime/Runtime";
 import type { PolicyService } from "@/node/services/policyService";
 import type { MCPConfigService } from "@/node/services/mcpConfigService";
-import { parseBearerWwwAuthenticate, type McpOauthService } from "@/node/services/mcpOauthService";
+import {
+  parseBearerWwwAuthenticate,
+  probeServerForBearerChallenge,
+  type McpOauthService,
+} from "@/node/services/mcpOauthService";
 import { createRuntime } from "@/node/runtime/runtimeFactory";
 import { transformMCPResult, type MCPCallToolResult } from "@/node/services/mcpResultTransform";
 import { buildMcpToolName } from "@/common/utils/tools/mcpToolName";
@@ -349,47 +353,52 @@ function extractWwwAuthenticateHeader(error: unknown): string | null {
   return null;
 }
 
-async function probeWwwAuthenticateHeader(url: string): Promise<string | null> {
-  const abortController = new AbortController();
-  const timeout = setTimeout(() => abortController.abort(), 3_000);
+function createWwwAuthenticateCaptureFetch() {
+  let capturedHeader: string | null = null;
 
-  try {
-    const response = await fetch(url, {
-      method: "GET",
-      headers: {
-        Accept: "text/event-stream",
-      },
-      redirect: "manual",
-      signal: abortController.signal,
-    });
+  // @ai-sdk/mcp expects a full fetch implementation (including static helpers like
+  // preconnect), so wrap the call path while preserving the original function shape.
+  const fetchWithCapture = Object.assign(async (...args: Parameters<typeof fetch>) => {
+    const response = await fetch(...args);
+    if (!capturedHeader && (response.status === 401 || response.status === 403)) {
+      capturedHeader = extractHeaderValue(response.headers, "www-authenticate");
+    }
+    return response;
+  }, fetch) as typeof fetch;
 
-    return response.headers.get("www-authenticate");
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timeout);
-  }
+  return {
+    fetch: fetchWithCapture,
+    getCapturedHeader: () => capturedHeader,
+  };
 }
 
 async function extractBearerOauthChallenge(options: {
   error: unknown;
   serverUrl: string | null;
+  transport: Extract<MCPServerTransport, "http" | "sse" | "auto"> | null;
+  capturedWwwAuthenticateHeader?: string | null;
 }): Promise<BearerChallenge | null> {
   const status = extractHttpStatusCode(options.error);
   if (status !== 401 && status !== 403) {
     return null;
   }
 
-  let header = extractWwwAuthenticateHeader(options.error);
-  if (!header && options.serverUrl) {
-    header = await probeWwwAuthenticateHeader(options.serverUrl);
+  let challenge = options.capturedWwwAuthenticateHeader
+    ? parseBearerWwwAuthenticate(options.capturedWwwAuthenticateHeader)
+    : null;
+
+  if (!challenge) {
+    const header = extractWwwAuthenticateHeader(options.error);
+    challenge = header ? parseBearerWwwAuthenticate(header) : null;
   }
 
-  if (!header) {
-    return null;
+  if (!challenge && options.serverUrl && options.transport) {
+    challenge = await probeServerForBearerChallenge({
+      serverUrl: options.serverUrl,
+      transport: options.transport,
+    });
   }
 
-  const challenge = parseBearerWwwAuthenticate(header);
   if (!challenge) {
     return null;
   }
@@ -425,6 +434,7 @@ async function runServerTest(
   const testPromise = (async (): Promise<MCPTestResult> => {
     let stdioTransport: MCPStdioTransport | null = null;
     let client: Awaited<ReturnType<typeof createMCPClient>> | null = null;
+    let getCapturedWwwAuthenticateHeader: (() => string | null) | null = null;
 
     try {
       if (server.transport === "stdio") {
@@ -442,9 +452,13 @@ async function runServerTest(
       } else {
         log.debug(`[MCP] Testing ${logContext}`, { transport: server.transport });
 
+        const challengeCapture = createWwwAuthenticateCaptureFetch();
+        getCapturedWwwAuthenticateHeader = challengeCapture.getCapturedHeader;
+
         const transportBase = {
           url: server.url,
           headers: server.headers,
+          fetch: challengeCapture.fetch,
           ...(server.authProvider ? { authProvider: server.authProvider } : {}),
         };
 
@@ -520,6 +534,8 @@ async function runServerTest(
       const oauthChallenge = await extractBearerOauthChallenge({
         error,
         serverUrl: server.transport === "stdio" ? null : server.url,
+        transport: server.transport === "stdio" ? null : server.transport,
+        capturedWwwAuthenticateHeader: getCapturedWwwAuthenticateHeader?.() ?? null,
       });
 
       return {


### PR DESCRIPTION
## Summary
Restore OAuth-required detection for MCP servers that only advertise `WWW-Authenticate` on POST responses, so Settings can offer the OAuth login callout instead of only surfacing the raw 401 error.

## Background
`@ai-sdk/mcp` collapses failed HTTP MCP requests into `MCPClientError` without preserving response headers. Mux previously fell back to a GET probe when that happened, but Streamable HTTP servers like Carta commonly reject GET on the MCP endpoint and only emit the Bearer challenge on POST.

## Implementation
- capture `WWW-Authenticate` headers from the actual MCP test transport fetch path before the SDK erases them
- make the shared OAuth hint probe transport-aware so HTTP/auto prefer POST first while SSE still prefers GET
- add regression coverage for POST-only auth challenges in both the manager test path and the standalone probe helper

## Validation
Focused MCP OAuth tests now cover the Carta-style POST-only challenge and the HTTP/auto probe ordering, alongside targeted ESLint and full typecheck coverage.

## Risks
Low. The behavior change is limited to OAuth challenge discovery during MCP connection tests and login hint probing, and still falls back across both remote verbs for mixed deployments.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh` • Cost: `$2.64`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh costs=2.64 -->
