### PR TITLE
🤖 fix: make blocked workflow pills red

### DIFF
--- a/src/browser/features/Tools/WorkflowActionListToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowActionListToolCall.test.tsx
@@ -140,7 +140,9 @@ describe("WorkflowActionListToolCall", () => {
 
     expect(view.getByText("git.changedFiles")).toBeTruthy();
     expect(view.getByText("read")).toBeTruthy();
-    expect(view.getByText("blocked")).toBeTruthy();
+    const blockedBadge = view.getByText("blocked");
+    expect(blockedBadge.classList.contains("text-danger")).toBe(true);
+    expect(blockedBadge.classList.contains("text-warning")).toBe(false);
     // Blocked actions surface their reason in the row description slot.
     expect(view.getByText("Project is not trusted")).toBeTruthy();
   });

--- a/src/browser/features/Tools/WorkflowActionListToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowActionListToolCall.tsx
@@ -126,7 +126,7 @@ function WorkflowActionListRow(props: { descriptor: WorkflowActionDescriptor }) 
               {action.metadata.effect}
             </WorkflowBadge>
           ) : (
-            <WorkflowBadge tone="warning">blocked</WorkflowBadge>
+            <WorkflowBadge tone="danger">blocked</WorkflowBadge>
           )}
         </span>
         <span

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.test.tsx
@@ -167,7 +167,9 @@ describe("WorkflowDefinitionToolCall", () => {
     clickToolHeader(view, "2 definitions");
 
     expect(view.queryByText("executable")).toBeNull();
-    expect(view.getByText("blocked")).toBeTruthy();
+    const blockedBadge = view.getByText("blocked");
+    expect(blockedBadge.classList.contains("text-danger")).toBe(true);
+    expect(blockedBadge.classList.contains("text-warning")).toBe(false);
     expect(view.getByText("Project is not trusted")).toBeTruthy();
   });
 });

--- a/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowDefinitionToolCall.tsx
@@ -58,7 +58,7 @@ export function WorkflowKindBadge() {
 
 export function WorkflowBadge(props: {
   children: React.ReactNode;
-  tone?: "normal" | "success" | "warning";
+  tone?: "normal" | "success" | "warning" | "danger";
 }) {
   return (
     <span
@@ -66,6 +66,8 @@ export function WorkflowBadge(props: {
         "border-border bg-background/40 rounded border px-1.5 py-0.5 text-[10px] font-medium whitespace-nowrap",
         props.tone === "success" && "border-success/30 text-success",
         props.tone === "warning" && "border-warning/30 text-warning",
+        // Blocked workflows/actions need to stand apart from yellow external-action warnings.
+        props.tone === "danger" && "border-danger/40 bg-danger-overlay text-danger",
         (props.tone == null || props.tone === "normal") && "text-muted"
       )}
     >
@@ -149,7 +151,7 @@ function WorkflowDefinitionListRow(props: { descriptor: WorkflowDefinitionDescri
       </span>
       <div className="flex items-center gap-1.5">
         <WorkflowBadge>{descriptor.scope}</WorkflowBadge>
-        {!descriptor.executable && <WorkflowBadge tone="warning">blocked</WorkflowBadge>}
+        {!descriptor.executable && <WorkflowBadge tone="danger">blocked</WorkflowBadge>}
       </div>
       <div className="min-w-0 [@container(max-width:640px)]:col-span-2">
         <div className="text-muted truncate text-[11px]" title={descriptor.description}>
@@ -193,7 +195,7 @@ export function WorkflowDefinitionCard(props: {
       <div className="flex flex-wrap items-center gap-2">
         <span className="text-foreground font-mono text-[12px] font-medium">{descriptor.name}</span>
         <WorkflowBadge>{descriptor.scope}</WorkflowBadge>
-        {!descriptor.executable && <WorkflowBadge tone="warning">blocked</WorkflowBadge>}
+        {!descriptor.executable && <WorkflowBadge tone="danger">blocked</WorkflowBadge>}
       </div>
       {!props.compact && (
         <div className="text-muted mt-1 text-[11px]">{descriptor.description}</div>


### PR DESCRIPTION
## Summary

Make blocked workflow and workflow-action pills use the danger/red tone so they stand out from yellow external-action warnings in workflow lookup lists.

## Background

Blocked entries were visually too similar to external actions in dense workflow/action lists, making them hard to spot at a glance.

## Implementation

- Added a `danger` tone to the shared `WorkflowBadge` helper.
- Switched blocked pills in workflow lists, workflow cards, and workflow action lists from `warning` to `danger`.
- Updated targeted UI tests to assert blocked pills are red (`text-danger`) and no longer warning-colored.

## Validation

- `bun test src/browser/features/Tools/WorkflowActionListToolCall.test.tsx src/browser/features/Tools/WorkflowDefinitionToolCall.test.tsx`
- `make static-check`
- `/workflow simplify --max-findings 10` reported no actionable simplify findings.
- Storybook dogfood via `agent-browser` verified the red blocked pill in both `WorkflowActionList` and `WorkflowList` stories; screenshots/video were captured locally.

## Risks

Low. This is a scoped presentation change to workflow lookup badges, backed by tests for the specific blocked badge color distinction.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `248472{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=7.48 -->
