### PR TITLE
🤖 fix: hydrate workflow cards from durable run attachments

### DIFF
--- a/src/browser/features/Messages/ToolMessage.tsx
+++ b/src/browser/features/Messages/ToolMessage.tsx
@@ -9,6 +9,7 @@ import {
   extractHookOutput,
   extractHookDuration,
 } from "../Tools/Shared/HookOutputDisplay";
+import { useWorkflowToolLiveRun } from "@/browser/stores/WorkspaceStore";
 import { ToolNameProvider } from "./ToolNameContext";
 
 interface ToolMessageProps {
@@ -48,6 +49,9 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   // Extract hook output if present (only shown when hook produced output)
   const hookOutput = extractHookOutput(result);
   const hookDuration = extractHookDuration(result);
+  const workflowToolCallId =
+    toolName === "workflow_run" || toolName === "workflow_resume" ? toolCallId : undefined;
+  const workflowRunHint = useWorkflowToolLiveRun(workspaceId, workflowToolCallId);
 
   return (
     <div className={className}>
@@ -62,6 +66,8 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
           // Identity props (used by bash for live output, ask_user_question for caching)
           workspaceId={workspaceId}
           toolCallId={toolCallId}
+          // Workflow-specific
+          workflowRunHint={workflowRunHint}
           // Bash-specific
           startedAt={message.timestamp}
           // FileEdit-specific

--- a/src/browser/features/Messages/ToolMessage.tsx
+++ b/src/browser/features/Messages/ToolMessage.tsx
@@ -9,7 +9,6 @@ import {
   extractHookOutput,
   extractHookDuration,
 } from "../Tools/Shared/HookOutputDisplay";
-import { useWorkflowToolLiveRun } from "@/browser/stores/WorkspaceStore";
 import { ToolNameProvider } from "./ToolNameContext";
 
 interface ToolMessageProps {
@@ -49,10 +48,6 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   // Extract hook output if present (only shown when hook produced output)
   const hookOutput = extractHookOutput(result);
   const hookDuration = extractHookDuration(result);
-  const workflowToolCallId =
-    toolName === "workflow_run" || toolName === "workflow_resume" ? toolCallId : undefined;
-  const workflowRunHint = useWorkflowToolLiveRun(workspaceId, workflowToolCallId);
-
   return (
     <div className={className}>
       {/* ToolNameProvider lets useStickyExpand key the auto-expand preference by tool name. */}
@@ -67,7 +62,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
           workspaceId={workspaceId}
           toolCallId={toolCallId}
           // Workflow-specific
-          workflowRunHint={workflowRunHint}
+          workflowRunHint={message.workflowRun}
           // Bash-specific
           startedAt={message.timestamp}
           // FileEdit-specific

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -1218,6 +1218,64 @@ describe("WorkflowRunToolCall", () => {
     expect(workflowHeader.textContent).not.toContain("pending");
   });
 
+  test("renders attached foreground workflow runs without heuristic discovery", async () => {
+    const attachedRun = {
+      id: "wfr_attached",
+      workspaceId: "workspace-1",
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:attached",
+      args: { topic: "workflow cards" },
+      status: "running" as const,
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        { sequence: 1, type: "phase" as const, at: "2026-05-29T00:00:02.000Z", name: "scope" },
+      ],
+      steps: [],
+    };
+    const listRuns = mock(async () => []);
+    const getRun = mock(async () => attachedRun);
+    const api = {
+      workflows: {
+        listRuns,
+        getRun,
+      },
+    };
+
+    const view = render(
+      <APIHarness client={api}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowRunToolCall
+              args={{
+                name: "deep-research",
+                args: { topic: "workflow cards" },
+                run_in_background: false,
+              }}
+              status="executing"
+              workspaceId="workspace-1"
+              startedAt={Date.parse("2026-05-29T00:00:00.500Z")}
+              workflowRunHint={{ runId: "wfr_attached", run: attachedRun }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    expect(view.getByText("wfr_attached")).toBeTruthy();
+    expect(view.getByText("scope")).toBeTruthy();
+    expect(listRuns).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(getRun).toHaveBeenCalledWith({ workspaceId: "workspace-1", runId: "wfr_attached" })
+    );
+  });
+
   test("discovers foreground workflow runs and renders live run details", async () => {
     const staleRun = {
       id: "wfr_stale",

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -1276,6 +1276,62 @@ describe("WorkflowRunToolCall", () => {
     );
   });
 
+  test("uses resume result status when the attachment run snapshot is stale", async () => {
+    const staleRun = {
+      ...createWorkflowRunForExpansionTest({ id: "wfr_resume_stale", status: "running" }),
+      status: "interrupted" as const,
+      updatedAt: "2026-05-29T00:00:03.000Z",
+      events: [
+        {
+          sequence: 1,
+          type: "status" as const,
+          at: "2026-05-29T00:00:03.000Z",
+          status: "interrupted" as const,
+        },
+      ],
+    };
+    const refreshedRun = {
+      ...staleRun,
+      status: "completed" as const,
+      updatedAt: "2026-05-29T00:00:04.000Z",
+      events: [
+        ...staleRun.events,
+        {
+          sequence: 2,
+          type: "status" as const,
+          at: "2026-05-29T00:00:04.000Z",
+          status: "completed" as const,
+        },
+      ],
+    };
+    const getRun = mock(async () => refreshedRun);
+
+    const view = render(
+      <APIHarness client={{ workflows: { getRun } }}>
+        <ThemeProvider forcedTheme="dark">
+          <TooltipProvider>
+            <WorkflowResumeToolCall
+              args={{ run_id: staleRun.id, run_in_background: true, mode: "resume" }}
+              result={{ status: "running", runId: staleRun.id, result: null, mode: "resume" }}
+              status="completed"
+              workspaceId={TEST_WORKSPACE_ID}
+              toolCallId="resume-call-1"
+              workflowRunHint={{ runId: staleRun.id, run: staleRun }}
+            />
+          </TooltipProvider>
+        </ThemeProvider>
+      </APIHarness>
+    );
+
+    const workflowHeader = getWorkflowHeader(view);
+    expect(workflowHeader.textContent).toContain("executing");
+    expect(workflowHeader.textContent).not.toContain("interrupted");
+    await waitFor(() =>
+      expect(getRun).toHaveBeenCalledWith({ workspaceId: TEST_WORKSPACE_ID, runId: staleRun.id })
+    );
+    await waitFor(() => expect(getWorkflowHeader(view).textContent).toContain("completed"));
+  });
+
   test("discovers foreground workflow runs and renders live run details", async () => {
     const staleRun = {
       id: "wfr_stale",

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -56,6 +56,7 @@ import {
   type WorkflowPromotionTarget,
 } from "./WorkflowDefinitionToolCall";
 import {
+  useWorkflowToolLiveRun,
   useWorkspaceStoreRaw,
   type WorkflowToolLiveRunState,
 } from "@/browser/stores/WorkspaceStore";
@@ -66,6 +67,7 @@ interface WorkflowRunToolCallProps {
   result?: WorkflowRunToolResult;
   status?: ToolStatus;
   workspaceId?: string;
+  toolCallId?: string;
   startedAt?: number;
   /** Which tool rendered this card; controls the header icon. */
   toolName?: "workflow_run" | "workflow_resume";
@@ -1030,16 +1032,19 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   result,
   status = "pending",
   workspaceId,
+  toolCallId,
   startedAt,
   toolName = "workflow_run",
   knownRunId,
-  workflowRunHint,
+  workflowRunHint: explicitWorkflowRunHint,
 }) => {
   const apiState = useContext(APIContext);
   const commandRegistry = useOptionalCommandRegistry();
   const registerCommandSource = commandRegistry?.registerSource;
   const errorResult = isToolErrorResult(result) ? result : null;
   const successResult = isWorkflowRunSuccessResult(result) ? result : null;
+  const liveWorkflowRunHint = useWorkflowToolLiveRun(workspaceId, toolCallId);
+  const workflowRunHint = explicitWorkflowRunHint ?? liveWorkflowRunHint;
   const [refreshedRun, setRefreshedRun] = useState<WorkflowRunRecord | null>(null);
   const [resumingRunId, setResumingRunId] = useState<string | null>(null);
   const [workflowActionInFlightRunId, setWorkflowActionInFlightRunId] = useState<string | null>(
@@ -1063,7 +1068,14 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   });
   const runId = selectedRun.runId;
   const run = selectedRun.run;
-  const displayStatus = run?.status ?? successResult?.status ?? status;
+  const hasRefreshedRunSnapshot =
+    refreshedRun != null && refreshedRun.id === runId && run === refreshedRun;
+  // workflow_resume can return a fresh dispatch status while intentionally omitting a stale
+  // pre-dispatch run snapshot. Trust that result status only until polling provides a fresher run.
+  const displayStatus =
+    successResult?.run == null && successResult?.status != null && !hasRefreshedRunSnapshot
+      ? successResult.status
+      : (run?.status ?? successResult?.status ?? status);
   const displayEventSequence = getLatestWorkflowEventSequence(run);
   const resultValue = successResult?.result ?? getLatestResultEvent(run);
   const reportMarkdown = getReportMarkdown(resultValue);
@@ -1639,6 +1651,7 @@ interface WorkflowResumeToolCallProps {
   result?: WorkflowResumeToolResult;
   status?: ToolStatus;
   workspaceId?: string;
+  toolCallId?: string;
   startedAt?: number;
   workflowRunHint?: WorkflowToolLiveRunState | null;
 }
@@ -1659,6 +1672,7 @@ export const WorkflowResumeToolCall: React.FC<WorkflowResumeToolCallProps> = (pr
       result={props.result}
       status={props.status}
       workspaceId={props.workspaceId}
+      toolCallId={props.toolCallId}
       startedAt={props.startedAt}
       toolName="workflow_resume"
       workflowRunHint={props.workflowRunHint}

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -55,7 +55,10 @@ import {
   formatWorkflowSavedMessage,
   type WorkflowPromotionTarget,
 } from "./WorkflowDefinitionToolCall";
-import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+import {
+  useWorkspaceStoreRaw,
+  type WorkflowToolLiveRunState,
+} from "@/browser/stores/WorkspaceStore";
 import { MarkdownRenderer } from "../Messages/MarkdownRenderer";
 
 interface WorkflowRunToolCallProps {
@@ -71,6 +74,7 @@ interface WorkflowRunToolCallProps {
    * direct getRun discovery while executing instead of name+args matching against listRuns.
    */
   knownRunId?: string;
+  workflowRunHint?: WorkflowToolLiveRunState | null;
 }
 
 type WorkflowRunAction = "interrupt" | "resume" | "retryFromCheckpoint";
@@ -1029,6 +1033,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
   startedAt,
   toolName = "workflow_run",
   knownRunId,
+  workflowRunHint,
 }) => {
   const apiState = useContext(APIContext);
   const commandRegistry = useOptionalCommandRegistry();
@@ -1045,11 +1050,14 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     workflowActionInFlightRunIdRef.current = nextRunId;
     setWorkflowActionInFlightRunId(nextRunId);
   };
-  const baseRun = successResult?.run;
+  const baseRun =
+    successResult?.run != null && workflowRunHint?.run != null
+      ? getNewestWorkflowRunSnapshot(successResult.run, workflowRunHint.run)
+      : (successResult?.run ?? workflowRunHint?.run);
   const selectedRun = selectWorkflowRunSnapshot({
-    // knownRunId (workflow_resume) provides exact identity before any result arrives, which
-    // also disables the heuristic name+args foreground discovery below.
-    runId: successResult?.runId ?? knownRunId,
+    // knownRunId (workflow_resume) and workflowRunHint provide exact identities before any
+    // result arrives, which also disables the heuristic name+args foreground discovery below.
+    runId: successResult?.runId ?? knownRunId ?? workflowRunHint?.runId,
     baseRun,
     refreshedRun,
   });
@@ -1109,11 +1117,16 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     workspaceId != null &&
     refreshedRun?.id === knownRunId &&
     refreshedRun.workspaceId === workspaceId;
+  const workflowRunHintConfirmed =
+    workflowRunHint?.runId != null &&
+    workspaceId != null &&
+    (workflowRunHint.run?.workspaceId == null || workflowRunHint.run.workspaceId === workspaceId);
   const runIdentityConfirmed =
     successResult?.runId != null ||
     baseRun?.id != null ||
     discoveredForegroundRunConfirmed ||
-    discoveredKnownRunConfirmed;
+    discoveredKnownRunConfirmed ||
+    workflowRunHintConfirmed;
   const canInterrupt =
     runIdentityConfirmed &&
     apiState?.api != null &&
@@ -1349,16 +1362,16 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     };
   }, [apiState?.api, args, runId, startedAt, status, workspaceId]);
 
+  const exactDiscoveryRunId = knownRunId ?? workflowRunHint?.runId;
+
   useEffect(() => {
-    // workflow_resume knows the exact run from its args, so fetch the live snapshot by ID
-    // while the tool call executes. Keep polling even after a snapshot loads: the first
-    // poll can race the backend's `running` append and capture the stale pre-resume
-    // status (interrupted/failed), which the regular refresh effect never polls. Hand off
-    // only once the snapshot reaches a status the regular refresh effect covers.
+    // workflow_resume args and workflowRunHint carry exact run identity, so fetch by ID while
+    // the tool call executes. Keep polling until the snapshot reaches a status the regular
+    // refresh effect covers; the first poll can race the backend's `running` append.
     if (
       apiState?.api == null ||
       workspaceId == null ||
-      knownRunId == null ||
+      exactDiscoveryRunId == null ||
       (run != null && REFRESHING_WORKFLOW_STATUSES.has(run.status)) ||
       status !== "executing"
     ) {
@@ -1368,7 +1381,10 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     let ignore = false;
     const discover = async () => {
       try {
-        const nextRun = await apiState.api.workflows.getRun({ workspaceId, runId: knownRunId });
+        const nextRun = await apiState.api.workflows.getRun({
+          workspaceId,
+          runId: exactDiscoveryRunId,
+        });
         if (!ignore && nextRun != null) {
           setRefreshedRun((current) => getNewestWorkflowRunSnapshot(current, nextRun));
         }
@@ -1385,7 +1401,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
       ignore = true;
       window.clearInterval(interval);
     };
-  }, [apiState?.api, knownRunId, run, status, workspaceId]);
+  }, [apiState?.api, exactDiscoveryRunId, run, status, workspaceId]);
 
   useEffect(() => {
     if (
@@ -1624,6 +1640,7 @@ interface WorkflowResumeToolCallProps {
   status?: ToolStatus;
   workspaceId?: string;
   startedAt?: number;
+  workflowRunHint?: WorkflowToolLiveRunState | null;
 }
 
 /**
@@ -1644,6 +1661,7 @@ export const WorkflowResumeToolCall: React.FC<WorkflowResumeToolCallProps> = (pr
       workspaceId={props.workspaceId}
       startedAt={props.startedAt}
       toolName="workflow_resume"
+      workflowRunHint={props.workflowRunHint}
       knownRunId={props.args.run_id}
     />
   );

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -4783,6 +4783,26 @@ describe("WorkspaceStore", () => {
       });
     });
 
+    it("retains an existing workflow run snapshot when a later attachment omits it", async () => {
+      const workspaceId = "workflow-run-attached-workspace-retain-run";
+      const run = createWorkflowRunRecord({ id: "wfr_retained", workspaceId });
+
+      mockChatScript([
+        caughtUpEvent(),
+        Promise.resolve(),
+        workflowRunAttachedEvent(workspaceId, "call-workflow-retain", run.id, 1, run),
+        workflowRunAttachedEvent(workspaceId, "call-workflow-retain", run.id, 2),
+      ]);
+
+      createAndAddWorkspace(store, workspaceId);
+      await tick(10);
+
+      expect(store.getWorkflowToolLiveRun(workspaceId, "call-workflow-retain")).toEqual({
+        runId: "wfr_retained",
+        run,
+      });
+    });
+
     it("replays pre-caught-up workflow run attachments after full replay catches up", async () => {
       const workspaceId = "workflow-run-attached-workspace-2";
       const run = createWorkflowRunRecord({ id: "wfr_replayed", workspaceId });
@@ -4798,6 +4818,36 @@ describe("WorkspaceStore", () => {
 
       expect(store.getWorkflowToolLiveRun(workspaceId, "call-workflow-2")).toEqual({
         runId: "wfr_replayed",
+        run,
+      });
+    });
+
+    it("keeps workflow run attachment hints when a background resume result omits the run", async () => {
+      const workspaceId = "workflow-run-attached-workspace-keep-after-result";
+      const run = createWorkflowRunRecord({
+        id: "wfr_keep_after_result",
+        workspaceId,
+        status: "interrupted",
+      });
+
+      mockChatScript([
+        caughtUpEvent(),
+        Promise.resolve(),
+        workflowRunAttachedEvent(workspaceId, "call-workflow-keep", run.id, 1, run),
+        toolCallEndEvent(
+          workspaceId,
+          "call-workflow-keep",
+          "workflow_resume",
+          { status: "running", runId: run.id, result: null, mode: "resume" },
+          { messageId: "m-workflow-keep", timestamp: 2 }
+        ),
+      ]);
+
+      createAndAddWorkspace(store, workspaceId);
+      await tick(10);
+
+      expect(store.getWorkflowToolLiveRun(workspaceId, "call-workflow-keep")).toEqual({
+        runId: run.id,
         run,
       });
     });

--- a/src/browser/stores/WorkspaceStore.test.ts
+++ b/src/browser/stores/WorkspaceStore.test.ts
@@ -12,6 +12,7 @@ import {
 } from "bun:test";
 import type { CompactionFollowUpRequest, DisplayedMessage } from "@/common/types/message";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import type { WorkflowRunRecord } from "@/common/types/workflow";
 import type { StreamStartEvent, ToolCallStartEvent } from "@/common/types/stream";
 import type { WorkspaceActivitySnapshot, WorkspaceChatMessage } from "@/common/orpc/types";
 import { DEFAULT_RUNTIME_CONFIG } from "@/common/constants/workspace";
@@ -545,12 +546,56 @@ const advisorReasoningOutputEvent = (
   timestamp,
 });
 
+function createWorkflowRunRecord(overrides: Partial<WorkflowRunRecord> = {}): WorkflowRunRecord {
+  return {
+    id: "wfr_live",
+    workspaceId: "workspace-1",
+    definition: {
+      name: "deep-research",
+      description: "Deep research",
+      scope: "built-in",
+      executable: true,
+    },
+    definitionSource: "export default function workflow() { return null; }",
+    definitionHash: "sha256:test",
+    args: {},
+    status: "running",
+    createdAt: "2026-05-29T00:00:00.000Z",
+    updatedAt: "2026-05-29T00:00:01.000Z",
+    events: [
+      {
+        sequence: 1,
+        type: "status",
+        at: "2026-05-29T00:00:01.000Z",
+        status: "running",
+      },
+    ],
+    steps: [],
+    ...overrides,
+  };
+}
+
 const taskCreatedEvent = (
   workspaceId: string,
   toolCallId: string,
   taskId: string,
   timestamp: number
 ): WorkspaceChatMessage => ({ type: "task-created", workspaceId, toolCallId, taskId, timestamp });
+
+const workflowRunAttachedEvent = (
+  workspaceId: string,
+  toolCallId: string,
+  runId: string,
+  timestamp: number,
+  run?: WorkflowRunRecord
+): WorkspaceChatMessage => ({
+  type: "workflow-run-attached",
+  workspaceId,
+  toolCallId,
+  runId,
+  timestamp,
+  ...(run != null ? { run } : {}),
+});
 
 const TEST_MODEL = "claude-sonnet-4";
 
@@ -4715,6 +4760,69 @@ describe("WorkspaceStore", () => {
         () => store.getAdvisorToolLiveReasoning(workspaceId, "call-advisor-reasoning-2") === null
       );
       expect(clearedLiveReasoning).toBe(true);
+    });
+  });
+
+  describe("workflow-run-attached events", () => {
+    it("exposes the exact workflow run while the workflow tool is running", async () => {
+      const workspaceId = "workflow-run-attached-workspace-1";
+      const run = createWorkflowRunRecord({ id: "wfr_live", workspaceId });
+
+      mockChatScript([
+        caughtUpEvent(),
+        Promise.resolve(),
+        workflowRunAttachedEvent(workspaceId, "call-workflow-1", run.id, 1, run),
+      ]);
+
+      createAndAddWorkspace(store, workspaceId);
+      await tick(10);
+
+      expect(store.getWorkflowToolLiveRun(workspaceId, "call-workflow-1")).toEqual({
+        runId: "wfr_live",
+        run,
+      });
+    });
+
+    it("replays pre-caught-up workflow run attachments after full replay catches up", async () => {
+      const workspaceId = "workflow-run-attached-workspace-2";
+      const run = createWorkflowRunRecord({ id: "wfr_replayed", workspaceId });
+
+      mockChatScript([
+        workflowRunAttachedEvent(workspaceId, "call-workflow-2", run.id, 1, run),
+        Promise.resolve(),
+        { type: "caught-up", replay: "full" },
+      ]);
+
+      createAndAddWorkspace(store, workspaceId);
+      await tick(10);
+
+      expect(store.getWorkflowToolLiveRun(workspaceId, "call-workflow-2")).toEqual({
+        runId: "wfr_replayed",
+        run,
+      });
+    });
+
+    it("clears workflow run attachment hints when the workflow tool result arrives", async () => {
+      const workspaceId = "workflow-run-attached-workspace-3";
+      const run = createWorkflowRunRecord({ id: "wfr_cleared", workspaceId });
+
+      mockChatScript([
+        caughtUpEvent(),
+        Promise.resolve(),
+        workflowRunAttachedEvent(workspaceId, "call-workflow-3", run.id, 1, run),
+        toolCallEndEvent(
+          workspaceId,
+          "call-workflow-3",
+          "workflow_run",
+          { status: "completed", runId: run.id, result: null, run },
+          { messageId: "m-workflow-3", timestamp: 2 }
+        ),
+      ]);
+
+      createAndAddWorkspace(store, workspaceId);
+      await tick(10);
+
+      expect(store.getWorkflowToolLiveRun(workspaceId, "call-workflow-3")).toBeNull();
     });
   });
 

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -90,6 +90,7 @@ import {
 import { DEFAULT_AUTO_COMPACTION_THRESHOLD_PERCENT } from "@/common/constants/ui";
 import { APPROX_CHARS_PER_TOKEN } from "@/constants/streaming";
 import { trackStreamCompleted } from "@/common/telemetry";
+import { isWorkflowRunEmittingToolName } from "@/common/utils/workflowRunMessages";
 
 /** Stable empty reference returned when a workspace has no assisted hunks; keeps useSyncExternalStore snapshot identity stable. */
 const EMPTY_ASSISTED_REVIEW: AssistedReviewHunk[] = [];
@@ -918,8 +919,20 @@ export class WorkspaceStore {
       if (toolCallEnd.toolName === "task") {
         transient?.liveTaskIds.delete(toolCallEnd.toolCallId);
       }
-      if (toolCallEnd.toolName === "workflow_run" || toolCallEnd.toolName === "workflow_resume") {
-        transient?.liveWorkflowRuns.delete(toolCallEnd.toolCallId);
+      if (isWorkflowRunEmittingToolName(toolCallEnd.toolName)) {
+        const result =
+          typeof toolCallEnd.result === "object" && toolCallEnd.result !== null
+            ? (toolCallEnd.result as { run?: unknown; status?: unknown })
+            : null;
+        // Background workflow_resume can return a fresh running/backgrounded status while omitting
+        // a stale pre-dispatch run. Keep the attachment hint so the card still has workspace/id
+        // context for polling until a fresh run snapshot arrives.
+        const shouldKeepRunHintForPolling =
+          result?.run == null &&
+          (result?.status === "running" || result?.status === "backgrounded");
+        if (!shouldKeepRunHintForPolling) {
+          transient?.liveWorkflowRuns.delete(toolCallEnd.toolCallId);
+        }
       }
       applyWorkspaceChatEventToAggregator(aggregator, data);
 
@@ -1697,7 +1710,7 @@ export class WorkspaceStore {
       if (msg.toolName === "advisor") {
         activeAdvisorToolCallIds.add(msg.toolCallId);
       }
-      if (msg.toolName === "workflow_run" || msg.toolName === "workflow_resume") {
+      if (isWorkflowRunEmittingToolName(msg.toolName)) {
         activeWorkflowToolCallIds.add(msg.toolCallId);
       }
     }
@@ -4338,13 +4351,14 @@ export class WorkspaceStore {
     if (isWorkflowRunAttachedEvent(data)) {
       const transient = this.assertChatTransientState(workspaceId);
       const current = transient.liveWorkflowRuns.get(data.toolCallId);
-      if (current?.runId === data.runId && current.run === data.run) {
+      const nextRun = data.run ?? (current?.runId === data.runId ? current.run : undefined);
+      if (current?.runId === data.runId && current.run === nextRun) {
         return;
       }
 
       transient.liveWorkflowRuns.set(data.toolCallId, {
         runId: data.runId,
-        ...(data.run != null ? { run: data.run } : {}),
+        ...(nextRun != null ? { run: nextRun } : {}),
       });
 
       this.states.bump(workspaceId);

--- a/src/browser/stores/WorkspaceStore.ts
+++ b/src/browser/stores/WorkspaceStore.ts
@@ -13,9 +13,7 @@ import type { RouterClient } from "@orpc/server";
 import type { AppRouter } from "@/node/orpc/router";
 import type { TodoItem } from "@/common/types/tools";
 import type { AssistedReviewHunk } from "@/common/types/review";
-
-/** Stable empty reference returned when a workspace has no assisted hunks; keeps useSyncExternalStore snapshot identity stable. */
-const EMPTY_ASSISTED_REVIEW: AssistedReviewHunk[] = [];
+import type { WorkflowRunRecord } from "@/common/types/workflow";
 import { applyWorkspaceChatEventToAggregator } from "@/browser/utils/messages/applyWorkspaceChatEventToAggregator";
 import {
   StreamingMessageAggregator,
@@ -48,6 +46,7 @@ import {
   isAdvisorPhaseEvent,
   isBashOutputEvent,
   isTaskCreatedEvent,
+  isWorkflowRunAttachedEvent,
   isMuxMessage,
   isQueuedMessageChanged,
   isRestoreToInput,
@@ -91,6 +90,9 @@ import {
 import { DEFAULT_AUTO_COMPACTION_THRESHOLD_PERCENT } from "@/common/constants/ui";
 import { APPROX_CHARS_PER_TOKEN } from "@/constants/streaming";
 import { trackStreamCompleted } from "@/common/telemetry";
+
+/** Stable empty reference returned when a workspace has no assisted hunks; keeps useSyncExternalStore snapshot identity stable. */
+const EMPTY_ASSISTED_REVIEW: AssistedReviewHunk[] = [];
 
 export type AutoRetryStatus = Extract<
   WorkspaceChatMessage,
@@ -241,6 +243,11 @@ export interface AdvisorLiveTextState {
 export type AdvisorLiveOutputState = AdvisorLiveTextState;
 export type AdvisorLiveReasoningState = AdvisorLiveTextState;
 
+export interface WorkflowToolLiveRunState {
+  runId: string;
+  run?: WorkflowRunRecord;
+}
+
 interface WorkspaceChatTransientState {
   caughtUp: boolean;
   isHydratingTranscript: boolean;
@@ -253,6 +260,7 @@ interface WorkspaceChatTransientState {
   liveAdvisorReasoning: Map<string, AdvisorLiveReasoningState>;
   liveAdvisorPhase: Map<string, AdvisorLivePhaseState>;
   liveTaskIds: Map<string, string[]>;
+  liveWorkflowRuns: Map<string, WorkflowToolLiveRunState>;
   autoRetryStatus: AutoRetryStatus | null;
 }
 
@@ -382,6 +390,7 @@ function createInitialChatTransientState(): WorkspaceChatTransientState {
     liveAdvisorReasoning: new Map(),
     liveAdvisorPhase: new Map(),
     liveTaskIds: new Map(),
+    liveWorkflowRuns: new Map(),
     autoRetryStatus: null,
   };
 }
@@ -908,6 +917,9 @@ export class WorkspaceStore {
       }
       if (toolCallEnd.toolName === "task") {
         transient?.liveTaskIds.delete(toolCallEnd.toolCallId);
+      }
+      if (toolCallEnd.toolName === "workflow_run" || toolCallEnd.toolName === "workflow_resume") {
+        transient?.liveWorkflowRuns.delete(toolCallEnd.toolCallId);
       }
       applyWorkspaceChatEventToAggregator(aggregator, data);
 
@@ -1667,13 +1679,15 @@ export class WorkspaceStore {
     if (
       transient.liveBashOutput.size === 0 &&
       transient.liveAdvisorOutput.size === 0 &&
-      transient.liveAdvisorReasoning.size === 0
+      transient.liveAdvisorReasoning.size === 0 &&
+      transient.liveWorkflowRuns.size === 0
     ) {
       return;
     }
 
     const activeBashToolCallIds = new Set<string>();
     const activeAdvisorToolCallIds = new Set<string>();
+    const activeWorkflowToolCallIds = new Set<string>();
     for (const msg of aggregator.getDisplayedMessages()) {
       if (msg.type !== "tool") continue;
 
@@ -1682,6 +1696,9 @@ export class WorkspaceStore {
       }
       if (msg.toolName === "advisor") {
         activeAdvisorToolCallIds.add(msg.toolCallId);
+      }
+      if (msg.toolName === "workflow_run" || msg.toolName === "workflow_resume") {
+        activeWorkflowToolCallIds.add(msg.toolCallId);
       }
     }
 
@@ -1700,6 +1717,12 @@ export class WorkspaceStore {
     for (const toolCallId of Array.from(transient.liveAdvisorOutput.keys())) {
       if (!activeAdvisorToolCallIds.has(toolCallId)) {
         transient.liveAdvisorOutput.delete(toolCallId);
+      }
+    }
+
+    for (const toolCallId of Array.from(transient.liveWorkflowRuns.keys())) {
+      if (!activeWorkflowToolCallIds.has(toolCallId)) {
+        transient.liveWorkflowRuns.delete(toolCallId);
       }
     }
   }
@@ -2324,6 +2347,10 @@ export class WorkspaceStore {
    */
   bumpState(workspaceId: string): void {
     this.states.bump(workspaceId);
+  }
+
+  getWorkflowToolLiveRun(workspaceId: string, toolCallId: string): WorkflowToolLiveRunState | null {
+    return this.chatTransientState.get(workspaceId)?.liveWorkflowRuns.get(toolCallId) ?? null;
   }
 
   /**
@@ -3984,7 +4011,8 @@ export class WorkspaceStore {
       data.type === "advisor-output" ||
       data.type === "advisor-reasoning-output" ||
       data.type === "advisor-phase" ||
-      data.type === "task-created"
+      data.type === "task-created" ||
+      data.type === "workflow-run-attached"
     );
   }
 
@@ -4065,6 +4093,7 @@ export class WorkspaceStore {
         transient.liveAdvisorOutput.clear();
         transient.liveAdvisorReasoning.clear();
         transient.liveAdvisorPhase.clear();
+        transient.liveWorkflowRuns.clear();
         transient.liveTaskIds.clear();
       }
 
@@ -4302,6 +4331,22 @@ export class WorkspaceStore {
       });
 
       // Low-frequency: bump immediately so advisor progress updates feel responsive.
+      this.states.bump(workspaceId);
+      return;
+    }
+
+    if (isWorkflowRunAttachedEvent(data)) {
+      const transient = this.assertChatTransientState(workspaceId);
+      const current = transient.liveWorkflowRuns.get(data.toolCallId);
+      if (current?.runId === data.runId && current.run === data.run) {
+        return;
+      }
+
+      transient.liveWorkflowRuns.set(data.toolCallId, {
+        runId: data.runId,
+        ...(data.run != null ? { run: data.run } : {}),
+      });
+
       this.states.bump(workspaceId);
       return;
     }
@@ -4629,6 +4674,27 @@ export function useTaskToolLiveTaskIds(
     () => {
       if (!workspaceId || !toolCallId) return null;
       return store.getTaskToolLiveTaskIds(workspaceId, toolCallId);
+    }
+  );
+}
+
+/**
+ * Hook to get the exact durable workflow run attached to a running workflow tool call.
+ */
+export function useWorkflowToolLiveRun(
+  workspaceId: string | undefined,
+  toolCallId: string | undefined
+): WorkflowToolLiveRunState | null {
+  const store = getStoreInstance();
+
+  return useSyncExternalStore(
+    (listener) => {
+      if (!workspaceId || !toolCallId) return () => undefined;
+      return store.subscribeKey(workspaceId, listener);
+    },
+    () => {
+      if (!workspaceId || !toolCallId) return null;
+      return store.getWorkflowToolLiveRun(workspaceId, toolCallId);
     }
   );
 }

--- a/src/browser/utils/messages/StreamingMessageAggregator.test.ts
+++ b/src/browser/utils/messages/StreamingMessageAggregator.test.ts
@@ -227,6 +227,7 @@ function historicalToolMessage(
     output?: unknown;
     historySequence?: number;
     partial?: boolean;
+    workflowRun?: { runId: string; timestamp: number };
   } = {}
 ) {
   const message = createMuxMessage(id, "assistant", "", {
@@ -241,6 +242,7 @@ function historicalToolMessage(
     toolName,
     state: "output-available",
     input,
+    ...(options.workflowRun != null ? { workflowRun: options.workflowRun } : {}),
     output: options.output ?? { success: true },
   });
   return message;
@@ -255,6 +257,31 @@ function historicalTodoMessage(
 }
 
 describe("StreamingMessageAggregator", () => {
+  describe("workflow run attachments", () => {
+    test("preserves persisted workflow run attachments on displayed tool rows", () => {
+      const aggregator = createTestAggregator();
+      const workflowRun = { runId: "wfr_partial", timestamp: 101 };
+      const message = historicalToolMessage(
+        "partial-workflow",
+        "workflow_run",
+        { name: "simplify", args: {} },
+        {
+          toolCallId: "workflow-call-1",
+          historySequence: 7,
+          partial: true,
+          workflowRun,
+        }
+      );
+
+      aggregator.loadHistoricalMessages([message], false);
+
+      const toolRow = aggregator
+        .getDisplayedMessages()
+        .find((row) => row.type === "tool" && row.toolCallId === "workflow-call-1");
+      expect(toolRow).toMatchObject({ workflowRun });
+    });
+  });
+
   describe("init state reference stability", () => {
     test("should return new array reference when state changes", async () => {
       const aggregator = new StreamingMessageAggregator(TEST_CREATED_AT);

--- a/src/browser/utils/messages/applyToolOutputRedaction.test.ts
+++ b/src/browser/utils/messages/applyToolOutputRedaction.test.ts
@@ -34,6 +34,36 @@ describe("applyToolOutputRedaction", () => {
     expect(part.output).toEqual({ success: true, answer: "continue" });
   });
 
+  it("strips workflow run attachment hints from provider-bound tool parts", () => {
+    const messages: MuxMessage[] = [
+      {
+        id: "assistant-workflow",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolCallId: "workflow-call-1",
+            toolName: "workflow_run",
+            input: { name: "deep-research", args: {} },
+            state: "input-available",
+            workflowRun: {
+              runId: "wfr_123",
+              timestamp: 123,
+            },
+          },
+        ],
+      },
+    ];
+
+    const result = applyToolOutputRedaction(messages);
+    const part = result[0]?.parts[0];
+    if (part?.type !== "dynamic-tool") {
+      throw new Error("Expected dynamic tool part");
+    }
+
+    expect("workflowRun" in part).toBe(false);
+  });
+
   it("scrubs legacy image tool payloads before replaying history to providers", () => {
     const imageResult = {
       success: true,

--- a/src/browser/utils/messages/applyToolOutputRedaction.ts
+++ b/src/browser/utils/messages/applyToolOutputRedaction.ts
@@ -39,6 +39,13 @@ function stripResolvedSourcePath(source: unknown): unknown {
   return stripped;
 }
 
+function stripWorkflowRunAttachment<P extends { workflowRun?: unknown }>(
+  part: P
+): Omit<P, "workflowRun"> {
+  const { workflowRun: _workflowRun, ...stripped } = part;
+  return stripped;
+}
+
 function stripLegacyImageToolOutputForModel(output: unknown): unknown {
   if (Array.isArray(output)) {
     return output.map(stripLegacyImageToolOutputForModel);
@@ -73,16 +80,17 @@ export function applyToolOutputRedaction(messages: MuxMessage[]): MuxMessage[] {
 
     const newParts = msg.parts.map((part) => {
       if (part.type !== "dynamic-tool") return part;
-      if (part.state !== "output-available") return part;
+      const providerPart = stripWorkflowRunAttachment(part);
+      if (providerPart.state !== "output-available") return providerPart;
 
       const outputWithoutUiOnly = stripWorkflowRunRecordForModel(
-        part.toolName,
-        stripToolOutputUiOnly(part.output)
+        providerPart.toolName,
+        stripToolOutputUiOnly(providerPart.output)
       );
       const sanitizedOutput = sanitizeUnknownForProviderOutput(
         stripLegacyImageToolOutputForModel(outputWithoutUiOnly)
       );
-      const nestedCalls = part.nestedCalls?.map((nestedCall) => {
+      const nestedCalls = providerPart.nestedCalls?.map((nestedCall) => {
         if (nestedCall.state !== "output-available") {
           return nestedCall;
         }
@@ -98,7 +106,7 @@ export function applyToolOutputRedaction(messages: MuxMessage[]): MuxMessage[] {
         };
       });
       return {
-        ...part,
+        ...providerPart,
         ...(nestedCalls ? { nestedCalls } : {}),
         output: sanitizedOutput,
       };

--- a/src/browser/utils/messages/applyToolOutputRedaction.ts
+++ b/src/browser/utils/messages/applyToolOutputRedaction.ts
@@ -2,7 +2,7 @@
  * Strip UI-only tool output before sending to providers.
  * Produces a cloned array safe for sending to providers without touching persisted history/UI.
  */
-import type { MuxMessage } from "@/common/types/message";
+import type { MuxMessage, MuxToolPart } from "@/common/types/message";
 import { sanitizeUnknownForProviderOutput } from "@/common/utils/providerOutputSanitization";
 import { stripToolOutputUiOnly } from "@/common/utils/tools/toolOutputUiOnly";
 import { stripWorkflowRunRecordForModel } from "@/common/utils/workflowRunMessages";
@@ -39,9 +39,20 @@ function stripResolvedSourcePath(source: unknown): unknown {
   return stripped;
 }
 
-function stripWorkflowRunAttachment<P extends { workflowRun?: unknown }>(
-  part: P
-): Omit<P, "workflowRun"> {
+function stripWorkflowRunAttachment(part: MuxToolPart): MuxToolPart {
+  if (part.workflowRun == null) {
+    return part;
+  }
+
+  if (part.state === "input-available") {
+    const { workflowRun: _workflowRun, ...stripped } = part;
+    return stripped;
+  }
+  if (part.state === "output-available") {
+    const { workflowRun: _workflowRun, ...stripped } = part;
+    return stripped;
+  }
+
   const { workflowRun: _workflowRun, ...stripped } = part;
   return stripped;
 }

--- a/src/browser/utils/messages/displayedMessageBuilder.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.ts
@@ -505,6 +505,7 @@ function appendToolRows(
     historySequence: options.historySequence,
     streamSequence: options.nextStreamSequence(),
     isLastPartOfMessage: options.isLastPartOfMessage,
+    ...(part.workflowRun != null ? { workflowRun: part.workflowRun } : {}),
     timestamp: part.timestamp ?? options.baseTimestamp,
     nestedCalls,
   });

--- a/src/common/orpc/schemas.ts
+++ b/src/common/orpc/schemas.ts
@@ -264,6 +264,7 @@ export {
   ToolCallStartEventSchema,
   BashOutputEventSchema,
   TaskCreatedEventSchema,
+  WorkflowRunAttachedEventSchema,
   AdvisorOutputEventSchema,
   AdvisorReasoningOutputEventSchema,
   AdvisorPhaseEventSchema,

--- a/src/common/orpc/schemas/message.ts
+++ b/src/common/orpc/schemas/message.ts
@@ -4,6 +4,7 @@ import { ThinkingLevelSchema } from "../../types/thinking";
 import { AgentIdSchema } from "./agentDefinition";
 import { StreamErrorTypeSchema } from "./errors";
 import { AgentSkillScopeSchema, SkillNameSchema } from "./agentSkill";
+import { WorkflowRunIdSchema, WorkflowRunRecordSchema } from "./workflow";
 
 export const FilePartSchema = z.object({
   url: z.string(),
@@ -23,6 +24,14 @@ export const MuxReasoningPartSchema = z.object({
   timestamp: z.number().optional(),
 });
 
+export const WorkflowRunToolAttachmentSchema = z.object({
+  runId: WorkflowRunIdSchema,
+  run: WorkflowRunRecordSchema.optional(),
+  timestamp: z.number(),
+});
+
+export type WorkflowRunToolAttachment = z.infer<typeof WorkflowRunToolAttachmentSchema>;
+
 // Base schema for tool parts - shared fields
 const MuxToolPartBase = z.object({
   type: z.literal("dynamic-tool"),
@@ -30,6 +39,7 @@ const MuxToolPartBase = z.object({
   toolName: z.string(),
   input: z.unknown(),
   timestamp: z.number().optional(),
+  workflowRun: WorkflowRunToolAttachmentSchema.optional(),
 });
 
 /**

--- a/src/common/orpc/schemas/stream.ts
+++ b/src/common/orpc/schemas/stream.ts
@@ -15,6 +15,7 @@ import {
 import type { MuxMessageMetadata } from "../../types/message";
 import { MuxProviderOptionsSchema } from "./providerOptions";
 import { RuntimeModeSchema } from "./runtime";
+import { WorkflowRunIdSchema, WorkflowRunRecordSchema } from "./workflow";
 
 // Chat Events
 
@@ -424,6 +425,20 @@ export const TaskCreatedEventSchema = z.object({
   timestamp: z.number().meta({ description: "When the task was created (Date.now())" }),
 });
 
+export const WorkflowRunAttachedEventSchema = z.object({
+  type: z.literal("workflow-run-attached"),
+  workspaceId: z.string(),
+  messageId: z.string().optional(),
+  replay: z
+    .boolean()
+    .optional()
+    .meta({ description: "True when this event is emitted during stream replay" }),
+  toolCallId: z.string(),
+  runId: WorkflowRunIdSchema,
+  run: WorkflowRunRecordSchema.optional(),
+  timestamp: z.number().meta({ description: "When the workflow run was attached (Date.now())" }),
+});
+
 export const ToolCallEndEventSchema = z.object({
   type: z.literal("tool-call-end"),
   workspaceId: z.string(),
@@ -623,6 +638,7 @@ export const WorkspaceChatMessageSchema = z.discriminatedUnion("type", [
   AdvisorOutputEventSchema,
   AdvisorReasoningOutputEventSchema,
   TaskCreatedEventSchema,
+  WorkflowRunAttachedEventSchema,
   AdvisorPhaseEventSchema,
   // Reasoning events
   ReasoningDeltaEventSchema,

--- a/src/common/orpc/types.ts
+++ b/src/common/orpc/types.ts
@@ -15,6 +15,7 @@ import type {
   AdvisorPhaseEvent,
   BashOutputEvent,
   TaskCreatedEvent,
+  WorkflowRunAttachedEvent,
   ReasoningDeltaEvent,
   ReasoningEndEvent,
   UsageDeltaEvent,
@@ -118,6 +119,12 @@ export function isAdvisorReasoningOutputEvent(
 
 export function isTaskCreatedEvent(msg: WorkspaceChatMessage): msg is TaskCreatedEvent {
   return (msg as { type?: string }).type === "task-created";
+}
+
+export function isWorkflowRunAttachedEvent(
+  msg: WorkspaceChatMessage
+): msg is WorkflowRunAttachedEvent {
+  return (msg as { type?: string }).type === "workflow-run-attached";
 }
 
 export function isAdvisorPhaseEvent(msg: WorkspaceChatMessage): msg is AdvisorPhaseEvent {

--- a/src/common/types/message.ts
+++ b/src/common/types/message.ts
@@ -777,6 +777,8 @@ export type DisplayedMessage =
       streamSequence?: number; // Local ordering within this assistant message
       isLastPartOfMessage?: boolean; // True if this is the last part of a multi-part message
       timestamp?: number;
+      /** Durable workflow run attachment recovered from partial history. */
+      workflowRun?: MuxToolPart["workflowRun"];
       // Nested tool calls for code_execution (from PTC streaming or reconstructed from result)
       nestedCalls?: Array<{
         toolCallId: string;

--- a/src/common/types/stream.ts
+++ b/src/common/types/stream.ts
@@ -28,6 +28,7 @@ import type {
   AdvisorOutputEventSchema,
   AdvisorReasoningOutputEventSchema,
   TaskCreatedEventSchema,
+  WorkflowRunAttachedEventSchema,
   AdvisorPhaseEventSchema,
   UsageDeltaEventSchema,
   RuntimeStatusEventSchema,
@@ -69,6 +70,7 @@ export type BashOutputEvent = z.infer<typeof BashOutputEventSchema>;
 export type AdvisorOutputEvent = z.infer<typeof AdvisorOutputEventSchema>;
 export type AdvisorReasoningOutputEvent = z.infer<typeof AdvisorReasoningOutputEventSchema>;
 export type TaskCreatedEvent = z.infer<typeof TaskCreatedEventSchema>;
+export type WorkflowRunAttachedEvent = z.infer<typeof WorkflowRunAttachedEventSchema>;
 export type AdvisorPhaseEvent = z.infer<typeof AdvisorPhaseEventSchema>;
 export type ToolCallStartEvent = z.infer<typeof ToolCallStartEventSchema>;
 export type ToolCallDeltaEvent = z.infer<typeof ToolCallDeltaEventSchema>;

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -170,6 +170,12 @@ export interface ToolConfiguration {
       workspaceId: string;
       projectTrusted: boolean;
       args: unknown;
+      onRunCreated?: (event: {
+        runId: string;
+        status: "pending";
+        result: null;
+        run: unknown;
+      }) => Promise<void> | void;
     }): Promise<{ runId: string; status: string; result: unknown }>;
     startNamedWorkflow(input: {
       name: string;
@@ -177,6 +183,12 @@ export interface ToolConfiguration {
       projectTrusted: boolean;
       args: unknown;
       abortSignal?: AbortSignal;
+      onRunCreated?: (event: {
+        runId: string;
+        status: "pending";
+        result: null;
+        run: unknown;
+      }) => Promise<void> | void;
     }): Promise<{ runId: string; status: string; result: unknown }>;
     interruptRun?(input: { workspaceId: string; runId: string }): Promise<unknown>;
     resumeRun?(input: {

--- a/src/common/utils/tools/tools.ts
+++ b/src/common/utils/tools/tools.ts
@@ -132,7 +132,7 @@ export interface ToolConfiguration {
    * Optional callback for emitting UI-only workspace chat events.
    * Used for streaming bash stdout/stderr to the UI without sending it to the model.
    */
-  emitChatEvent?: (event: WorkspaceChatMessage) => void;
+  emitChatEvent?: (event: WorkspaceChatMessage) => Promise<void> | void;
   /** Primary project path for workspace-scoped tools that need project-relative coordinates. */
   workspaceProjectPath?: string;
   /** Absolute cwd for workspace-scoped tools that accept execution-relative paths. */

--- a/src/node/acp/streamTranslator.ts
+++ b/src/node/acp/streamTranslator.ts
@@ -214,6 +214,7 @@ export class StreamTranslator {
       case "reasoning-end":
       case "delete":
       case "task-created":
+      case "workflow-run-attached":
       case "usage-delta":
       case "session-usage-delta":
       case "queued-message-changed":

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -641,7 +641,7 @@ export class AgentSession {
 
   private getStreamLastTimestamp(streamInfo: {
     startTime?: number;
-    parts: Array<{ timestamp?: number }>;
+    parts: Array<{ timestamp?: number; workflowRun?: { timestamp?: number } }>;
     toolCompletionTimestamps: Map<string, number>;
   }): number {
     // Use a nonzero floor so live-mode replay never sends afterTimestamp=0 when a
@@ -654,6 +654,13 @@ export class AgentSession {
       }
       streamLastTimestamp = timestamp;
       break;
+    }
+
+    for (const part of streamInfo.parts) {
+      const workflowRunTimestamp = part.workflowRun?.timestamp;
+      if (workflowRunTimestamp !== undefined && workflowRunTimestamp > streamLastTimestamp) {
+        streamLastTimestamp = workflowRunTimestamp;
+      }
     }
 
     for (const completionTimestamp of streamInfo.toolCompletionTimestamps.values()) {
@@ -4437,6 +4444,9 @@ export class AgentSession {
       this.emitChatEvent(payload);
     });
     forward("task-created", (payload) => {
+      this.emitChatEvent(payload);
+    });
+    forward("workflow-run-attached", (payload) => {
       this.emitChatEvent(payload);
     });
     forward("advisor-phase", (payload) => {

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -1949,6 +1949,11 @@ export class AIService extends EventEmitter {
           if ("workspaceId" in event && event.workspaceId !== workspaceId) {
             return;
           }
+          if (event.type === "workflow-run-attached") {
+            return this.streamManager.attachWorkflowRunToToolCall(event).then(() => {
+              this.emit(event.type, event as never);
+            });
+          }
           this.emit(event.type, event as never);
         },
         workspaceProjectPath: metadata.projectPath,

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -223,6 +223,51 @@ function createStreamInfoForTests(
   };
 }
 
+describe("StreamManager - workflow run attachments", () => {
+  test("persists attached workflow run metadata to partial immediately", async () => {
+    const streamManager = new StreamManager(historyService);
+    const workspaceId = "workflow-attachment-workspace";
+    const messageId = "workflow-attachment-message";
+    const timestamp = Date.now();
+    const streamInfo = createStreamInfoForTests({
+      messageId,
+      lastPartialWriteTime: timestamp,
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "workflow-call-1",
+          toolName: "workflow_run",
+          input: { name: "deep-research", args: {} },
+          state: "input-available",
+          timestamp,
+        },
+      ],
+    });
+
+    getWorkspaceStreamsForTests(streamManager).set(workspaceId, streamInfo);
+
+    const attached = await streamManager.attachWorkflowRunToToolCall({
+      type: "workflow-run-attached",
+      workspaceId,
+      messageId,
+      toolCallId: "workflow-call-1",
+      runId: "wfr_attached",
+      timestamp: timestamp + 1,
+    });
+
+    expect(attached).toBe(true);
+    const partial = await historyService.readPartial(workspaceId);
+    const part = partial?.parts[0];
+    if (part?.type !== "dynamic-tool") {
+      throw new Error("Expected workflow tool part in persisted partial");
+    }
+    expect(part.workflowRun).toEqual({
+      runId: "wfr_attached",
+      timestamp: timestamp + 1,
+    });
+  });
+});
+
 describe("StreamManager - createTempDirForStream", () => {
   test("creates ~/.mux-tmp/<token> under the runtime's home", async () => {
     using home = new DisposableTempDir("stream-home");

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -22,6 +22,7 @@ import type {
   UsageDeltaEvent,
   ToolCallEndEvent,
   CompletedMessagePart,
+  WorkflowRunAttachedEvent,
 } from "@/common/types/stream";
 
 import type { SendMessageError, StreamErrorType } from "@/common/types/errors";
@@ -645,6 +646,41 @@ export class StreamManager extends EventEmitter {
     streamInfo.toolModelUsages.push(clonePersistedToolModelUsage(event));
   }
 
+  async attachWorkflowRunToToolCall(event: WorkflowRunAttachedEvent): Promise<boolean> {
+    const workspaceId = event.workspaceId as WorkspaceId;
+    const streamInfo = this.workspaceStreams.get(workspaceId);
+    if (
+      streamInfo == null ||
+      (event.messageId != null && streamInfo.messageId !== event.messageId)
+    ) {
+      return false;
+    }
+
+    const partIndex = streamInfo.parts.findIndex(
+      (part) => part.type === "dynamic-tool" && part.toolCallId === event.toolCallId
+    );
+    if (partIndex === -1) {
+      return false;
+    }
+
+    const part = streamInfo.parts[partIndex];
+    if (part.type !== "dynamic-tool") {
+      return false;
+    }
+
+    streamInfo.parts[partIndex] = {
+      ...part,
+      workflowRun: {
+        runId: event.runId,
+        ...(event.run != null ? { run: event.run } : {}),
+        timestamp: event.timestamp,
+      },
+    };
+
+    await this.flushPartialWrite(workspaceId, streamInfo);
+    return true;
+  }
+
   /**
    * Write the current partial message to disk (throttled by mtime)
    * Ensures writes happen during rapid streaming (crash-resilient)
@@ -1083,6 +1119,19 @@ export class StreamManager extends EventEmitter {
         tokens,
         timestamp,
       });
+
+      if (part.workflowRun != null) {
+        this.emit("workflow-run-attached", {
+          type: "workflow-run-attached",
+          workspaceId: workspaceId as string,
+          messageId,
+          ...(isReplay ? { replay: true } : {}),
+          toolCallId: part.toolCallId,
+          runId: part.workflowRun.runId,
+          ...(part.workflowRun.run != null ? { run: part.workflowRun.run } : {}),
+          timestamp: part.workflowRun.timestamp,
+        } satisfies WorkflowRunAttachedEvent);
+      }
 
       // If tool has output, emit completion
       if (part.state === "output-available") {
@@ -3951,21 +4000,30 @@ export class StreamManager extends EventEmitter {
             // transition to output-available. Use the recorded tool completion timestamp
             // (from tool-call-end emission) to decide whether completion happened after
             // the reconnect cursor.
-            if (part.type === "dynamic-tool" && part.state === "output-available") {
-              const completionTimestamp = streamInfo.toolCompletionTimestamps.get(part.toolCallId);
-              if (completionTimestamp === undefined) {
-                log.warn(
-                  "[streamManager] Missing tool completion timestamp during replay; dropping replayed completion to avoid duplicate side effects",
-                  {
-                    workspaceId,
-                    messageId: streamInfo.messageId,
-                    toolCallId: part.toolCallId,
-                  }
-                );
-                return false;
+            if (part.type === "dynamic-tool") {
+              const workflowRunAttachedAt = part.workflowRun?.timestamp;
+              if (workflowRunAttachedAt !== undefined && workflowRunAttachedAt > afterTimestamp) {
+                return true;
               }
 
-              return completionTimestamp > afterTimestamp;
+              if (part.state === "output-available") {
+                const completionTimestamp = streamInfo.toolCompletionTimestamps.get(
+                  part.toolCallId
+                );
+                if (completionTimestamp === undefined) {
+                  log.warn(
+                    "[streamManager] Missing tool completion timestamp during replay; dropping replayed completion to avoid duplicate side effects",
+                    {
+                      workspaceId,
+                      messageId: streamInfo.messageId,
+                      toolCallId: part.toolCallId,
+                    }
+                  );
+                  return false;
+                }
+
+                return completionTimestamp > afterTimestamp;
+              }
             }
 
             return false;

--- a/src/node/services/tools/advisor.ts
+++ b/src/node/services/tools/advisor.ts
@@ -21,6 +21,7 @@ import type {
 import { AdvisorToolInputSchema, TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { AdvisorToolCallSnapshot, ToolConfiguration } from "@/common/utils/tools/tools";
 import { log } from "@/node/services/log";
+import { emitChatEventBestEffort } from "./toolUtils";
 
 type StreamTextProviderOptions = Parameters<typeof streamText>[0]["providerOptions"];
 
@@ -173,13 +174,17 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
           return;
         }
 
-        config.emitChatEvent({
-          type: "advisor-phase",
-          workspaceId: config.workspaceId,
-          toolCallId,
-          phase,
-          timestamp: Date.now(),
-        } satisfies AdvisorPhaseEvent);
+        emitChatEventBestEffort(
+          config,
+          {
+            type: "advisor-phase",
+            workspaceId: config.workspaceId,
+            toolCallId,
+            phase,
+            timestamp: Date.now(),
+          } satisfies AdvisorPhaseEvent,
+          "advisor"
+        );
       };
 
       const emitAdvisorOutput = (text: string): void => {
@@ -188,13 +193,17 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
           return;
         }
 
-        config.emitChatEvent({
-          type: "advisor-output",
-          workspaceId: config.workspaceId,
-          toolCallId,
-          text,
-          timestamp: Date.now(),
-        } satisfies AdvisorOutputEvent);
+        emitChatEventBestEffort(
+          config,
+          {
+            type: "advisor-output",
+            workspaceId: config.workspaceId,
+            toolCallId,
+            text,
+            timestamp: Date.now(),
+          } satisfies AdvisorOutputEvent,
+          "advisor"
+        );
       };
 
       const emitAdvisorReasoningOutput = (text: string): void => {
@@ -203,13 +212,17 @@ export function createAdvisorTool(config: ToolConfiguration): Tool {
           return;
         }
 
-        config.emitChatEvent({
-          type: "advisor-reasoning-output",
-          workspaceId: config.workspaceId,
-          toolCallId,
-          text,
-          timestamp: Date.now(),
-        } satisfies AdvisorReasoningOutputEvent);
+        emitChatEventBestEffort(
+          config,
+          {
+            type: "advisor-reasoning-output",
+            workspaceId: config.workspaceId,
+            toolCallId,
+            text,
+            timestamp: Date.now(),
+          } satisfies AdvisorReasoningOutputEvent,
+          "advisor"
+        );
       };
 
       emitAdvisorPhase("preparing_context");

--- a/src/node/services/tools/bash.ts
+++ b/src/node/services/tools/bash.ts
@@ -26,6 +26,7 @@ import { LocalBaseRuntime } from "@/node/runtime/LocalBaseRuntime";
 import { getToolEnvPath } from "@/node/services/hooks";
 import { GIT_NO_HOOKS_ENV } from "@/node/utils/gitNoHooksEnv";
 import { getErrorMessage } from "@/common/utils/errors";
+import { emitChatEventBestEffort } from "./toolUtils";
 
 const CAT_FILE_READ_NOTICE =
   "[IMPORTANT]\n\nDO NOT use `cat`, `rg`, or `grep` to read files. Use the `file_read` tool instead (supports offset/limit paging). Bash output may be truncated or auto-filtered, which can hide parts of the file.";
@@ -1112,14 +1113,18 @@ ${scriptWithEnv}`;
         if (liveOutputStopped) return;
         if (text.length === 0) return;
 
-        config.emitChatEvent({
-          type: "bash-output",
-          workspaceId: config.workspaceId,
-          toolCallId,
-          text,
-          isError,
-          timestamp: Date.now(),
-        } satisfies BashOutputEvent);
+        emitChatEventBestEffort(
+          config,
+          {
+            type: "bash-output",
+            workspaceId: config.workspaceId,
+            toolCallId,
+            text,
+            isError,
+            timestamp: Date.now(),
+          } satisfies BashOutputEvent,
+          "bash"
+        );
       };
 
       const flushLiveOutput = (): void => {

--- a/src/node/services/tools/task.ts
+++ b/src/node/services/tools/task.ts
@@ -20,7 +20,12 @@ import { log } from "@/node/services/log";
 import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
 
 import { buildTaskGroupLaunches, type TaskGroupKind } from "@/common/utils/tools/taskGroups";
-import { parseToolResult, requireTaskService, requireWorkspaceId } from "./toolUtils";
+import {
+  emitChatEventBestEffort,
+  parseToolResult,
+  requireTaskService,
+  requireWorkspaceId,
+} from "./toolUtils";
 import { getErrorMessage } from "@/common/utils/errors";
 import {
   coerceThinkingLevel,
@@ -160,13 +165,17 @@ function emitTaskCreatedEvent(params: {
     return;
   }
 
-  params.config.emitChatEvent({
-    type: "task-created",
-    workspaceId: params.workspaceId,
-    toolCallId: params.toolCallId,
-    taskId: params.taskId,
-    timestamp: Date.now(),
-  } satisfies TaskCreatedEvent);
+  emitChatEventBestEffort(
+    params.config,
+    {
+      type: "task-created",
+      workspaceId: params.workspaceId,
+      toolCallId: params.toolCallId,
+      taskId: params.taskId,
+      timestamp: Date.now(),
+    } satisfies TaskCreatedEvent,
+    "task"
+  );
 }
 
 function toAggregatePendingStatus(

--- a/src/node/services/tools/toolUtils.ts
+++ b/src/node/services/tools/toolUtils.ts
@@ -3,6 +3,9 @@ import assert from "node:assert/strict";
 import type { z } from "zod";
 
 import { getErrorMessage } from "@/common/utils/errors";
+import { WorkflowRunRecordSchema } from "@/common/orpc/schemas";
+import type { WorkflowRunAttachedEvent } from "@/common/types/stream";
+import type { WorkspaceChatMessage } from "@/common/orpc/types";
 import type { ToolConfiguration } from "@/common/utils/tools/tools";
 import { recordAgentWorkflowRunReference } from "@/node/services/agentWorkflowRunReferences";
 import { log } from "@/node/services/log";
@@ -32,6 +35,48 @@ export function parseToolResult<TSchema>(
 
 export function dedupeStrings(values: readonly string[]): string[] {
   return Array.from(new Set(values));
+}
+
+export function emitChatEventBestEffort(
+  config: ToolConfiguration,
+  event: WorkspaceChatMessage,
+  context: string
+): void {
+  const emitted = config.emitChatEvent?.(event);
+  if (emitted == null) {
+    return;
+  }
+
+  emitted.catch((error: unknown) => {
+    log.debug("Failed to emit tool chat event", {
+      context,
+      eventType: event.type,
+      error: getErrorMessage(error),
+    });
+  });
+}
+
+export async function emitWorkflowRunAttachedEvent(input: {
+  config: ToolConfiguration;
+  workspaceId: string;
+  toolCallId?: string;
+  runId: string;
+  run?: unknown;
+}): Promise<void> {
+  if (!input.config.emitChatEvent || !input.toolCallId) {
+    return;
+  }
+
+  const parsedRun = WorkflowRunRecordSchema.safeParse(input.run);
+  const event: WorkflowRunAttachedEvent = {
+    type: "workflow-run-attached",
+    workspaceId: input.workspaceId,
+    toolCallId: input.toolCallId,
+    runId: input.runId,
+    ...(parsedRun.success ? { run: parsedRun.data } : {}),
+    timestamp: Date.now(),
+  };
+  await input.config.emitChatEvent(event);
 }
 
 /**

--- a/src/node/services/tools/workflow_resume.test.ts
+++ b/src/node/services/tools/workflow_resume.test.ts
@@ -6,6 +6,7 @@ import { TestTempDir, createTestToolConfig } from "./testHelpers";
 import { readAgentWorkflowRunReferences } from "@/node/services/agentWorkflowRunReferences";
 import { WORKFLOW_CHECKPOINT_RETRY_ERROR_MESSAGE } from "@/common/utils/workflowRetryEligibility";
 import type { WorkflowRunRecord } from "@/common/types/workflow";
+import type { WorkflowRunAttachedEvent } from "@/common/types/stream";
 
 const mockToolCallOptions: ToolExecutionOptions = {
   toolCallId: "test-call-id",
@@ -129,6 +130,49 @@ describe("workflow_resume tool", () => {
       mode: "resume",
       run: expect.objectContaining({ id: "wfr_resume_me" }),
     });
+  });
+
+  test("emits a workflow run attachment before resuming", async () => {
+    using tempDir = new TestTempDir("test-workflow-resume-attached");
+    const run = buildRun({ id: "wfr_resume_attached" });
+    const emittedEvents: WorkflowRunAttachedEvent[] = [];
+    let emitChatEventSettled = false;
+    let resumeWaitedForEmission = false;
+    const workflowService = buildWorkflowService({
+      getRun: mock(async () => run),
+      resumeRun: mock(async () => {
+        resumeWaitedForEmission = emitChatEventSettled;
+        return { runId: run.id, status: "running" as const, result: null };
+      }),
+    });
+    const tool = createWorkflowResumeTool({
+      ...createTestToolConfig(tempDir.path, { workspaceId: "workspace-1" }),
+      trusted: true,
+      emitChatEvent: async (event) => {
+        await Promise.resolve();
+        if (event.type === "workflow-run-attached") {
+          emittedEvents.push(event);
+          emitChatEventSettled = true;
+        }
+      },
+      workflowService,
+    });
+
+    await tool.execute!(
+      { run_id: run.id, run_in_background: false, mode: null },
+      mockToolCallOptions
+    );
+
+    expect(resumeWaitedForEmission).toBe(true);
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0]).toMatchObject({
+      type: "workflow-run-attached",
+      workspaceId: "workspace-1",
+      toolCallId: "test-call-id",
+      runId: run.id,
+      run: expect.objectContaining({ id: run.id, status: "interrupted" }),
+    });
+    expect(typeof emittedEvents[0]?.timestamp).toBe("number");
   });
 
   test("resumes in background and records an agent workflow run reference", async () => {

--- a/src/node/services/tools/workflow_resume.ts
+++ b/src/node/services/tools/workflow_resume.ts
@@ -5,13 +5,13 @@ import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools"
 import type { WorkflowRunRecord } from "@/common/types/workflow";
 import { getWorkflowCheckpointRetryEligibility } from "@/common/utils/workflowRetryEligibility";
 import { WorkflowRunRecordSchema } from "@/common/orpc/schemas";
-import type { WorkflowRunAttachedEvent } from "@/common/types/stream";
 import {
   WorkflowResumeToolResultSchema,
   TOOL_DEFINITIONS,
 } from "@/common/utils/tools/toolDefinitions";
 import { isWorkflowRunTaskId } from "./taskId";
 import {
+  emitWorkflowRunAttachedEvent,
   parseToolResult,
   recordBackgroundWorkflowRunReference,
   requireWorkspaceId,
@@ -43,27 +43,6 @@ interface WorkflowResumeService {
     runId: string;
     projectTrusted: boolean;
   }): Promise<{ runId: string; status: string; result: unknown }>;
-}
-
-async function emitWorkflowRunAttachedEvent(input: {
-  config: ToolConfiguration;
-  workspaceId: string;
-  toolCallId?: string;
-  run: WorkflowRunRecord;
-}): Promise<void> {
-  if (!input.config.emitChatEvent || !input.toolCallId) {
-    return;
-  }
-
-  const event: WorkflowRunAttachedEvent = {
-    type: "workflow-run-attached",
-    workspaceId: input.workspaceId,
-    toolCallId: input.toolCallId,
-    runId: input.run.id,
-    run: input.run,
-    timestamp: Date.now(),
-  };
-  await input.config.emitChatEvent(event);
 }
 
 function requireWorkflowResumeService(config: ToolConfiguration): WorkflowResumeService {
@@ -198,6 +177,7 @@ export const createWorkflowResumeTool: ToolFactory = (config: ToolConfiguration)
         config,
         workspaceId,
         toolCallId: options.toolCallId,
+        runId: run.id,
         run,
       });
 

--- a/src/node/services/tools/workflow_resume.ts
+++ b/src/node/services/tools/workflow_resume.ts
@@ -5,6 +5,7 @@ import type { ToolConfiguration, ToolFactory } from "@/common/utils/tools/tools"
 import type { WorkflowRunRecord } from "@/common/types/workflow";
 import { getWorkflowCheckpointRetryEligibility } from "@/common/utils/workflowRetryEligibility";
 import { WorkflowRunRecordSchema } from "@/common/orpc/schemas";
+import type { WorkflowRunAttachedEvent } from "@/common/types/stream";
 import {
   WorkflowResumeToolResultSchema,
   TOOL_DEFINITIONS,
@@ -42,6 +43,27 @@ interface WorkflowResumeService {
     runId: string;
     projectTrusted: boolean;
   }): Promise<{ runId: string; status: string; result: unknown }>;
+}
+
+async function emitWorkflowRunAttachedEvent(input: {
+  config: ToolConfiguration;
+  workspaceId: string;
+  toolCallId?: string;
+  run: WorkflowRunRecord;
+}): Promise<void> {
+  if (!input.config.emitChatEvent || !input.toolCallId) {
+    return;
+  }
+
+  const event: WorkflowRunAttachedEvent = {
+    type: "workflow-run-attached",
+    workspaceId: input.workspaceId,
+    toolCallId: input.toolCallId,
+    runId: input.run.id,
+    run: input.run,
+    timestamp: Date.now(),
+  };
+  await input.config.emitChatEvent(event);
 }
 
 function requireWorkflowResumeService(config: ToolConfiguration): WorkflowResumeService {
@@ -171,6 +193,13 @@ export const createWorkflowResumeTool: ToolFactory = (config: ToolConfiguration)
       }
 
       assertRunStatusAllowsMode(run, mode);
+
+      await emitWorkflowRunAttachedEvent({
+        config,
+        workspaceId,
+        toolCallId: options.toolCallId,
+        run,
+      });
 
       const dispatchInput = {
         workspaceId,

--- a/src/node/services/tools/workflow_run.test.ts
+++ b/src/node/services/tools/workflow_run.test.ts
@@ -5,11 +5,42 @@ import { COMPLETED_REPORT_REFETCH_NOTE } from "@/common/utils/tools/toolDefiniti
 import { createWorkflowRunTool } from "./workflow_run";
 import { TestTempDir, createTestToolConfig } from "./testHelpers";
 import { readAgentWorkflowRunReferences } from "@/node/services/agentWorkflowRunReferences";
+import type { WorkflowRunAttachedEvent } from "@/common/types/stream";
+import type { WorkflowRunRecord } from "@/common/types/workflow";
 
 const mockToolCallOptions: ToolExecutionOptions = {
   toolCallId: "test-call-id",
   messages: [],
 };
+
+function createWorkflowRunRecord(overrides: Partial<WorkflowRunRecord> = {}): WorkflowRunRecord {
+  return {
+    id: "wfr_123",
+    workspaceId: "workspace-1",
+    definition: {
+      name: "deep-research",
+      description: "Deep research",
+      scope: "built-in",
+      executable: true,
+    },
+    definitionSource: "export default function workflow() { return null; }",
+    definitionHash: "sha256:test",
+    args: { topic: "workflow tools" },
+    status: "pending",
+    createdAt: "2026-05-29T00:00:00.000Z",
+    updatedAt: "2026-05-29T00:00:00.000Z",
+    events: [
+      {
+        sequence: 1,
+        type: "status",
+        at: "2026-05-29T00:00:00.000Z",
+        status: "pending",
+      },
+    ],
+    steps: [],
+    ...overrides,
+  };
+}
 
 describe("workflow_run tool", () => {
   test("starts a named workflow through WorkflowService", async () => {
@@ -82,13 +113,16 @@ describe("workflow_run tool", () => {
       { ...mockToolCallOptions, abortSignal: abortController.signal }
     );
 
-    expect(startNamedWorkflow).toHaveBeenCalledWith({
-      name: "deep-research",
-      workspaceId: "workspace-1",
-      projectTrusted: true,
-      args: { topic: "workflow tools" },
-      abortSignal: abortController.signal,
-    });
+    expect(startNamedWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "deep-research",
+        workspaceId: "workspace-1",
+        projectTrusted: true,
+        args: { topic: "workflow tools" },
+        abortSignal: abortController.signal,
+        onRunCreated: expect.any(Function),
+      })
+    );
     expect(getRun).toHaveBeenCalledWith({ workspaceId: "workspace-1", runId: "wfr_123" });
     expect(result).toEqual({
       status: "completed",
@@ -101,6 +135,79 @@ describe("workflow_run tool", () => {
       }),
       note: COMPLETED_REPORT_REFETCH_NOTE,
     });
+  });
+
+  test("emits a workflow run attachment when the durable run is created", async () => {
+    using tempDir = new TestTempDir("test-workflow-run-tool-attached");
+    const attachedRun = createWorkflowRunRecord({ id: "wfr_attached" });
+    const emittedEvents: WorkflowRunAttachedEvent[] = [];
+    let emitChatEventSettled = false;
+    let onRunCreatedWaitedForEmission = false;
+    const startNamedWorkflow = mock(
+      async (input: {
+        name: string;
+        workspaceId: string;
+        projectTrusted: boolean;
+        args: unknown;
+        abortSignal?: AbortSignal;
+        onRunCreated?: (event: {
+          runId: string;
+          status: "pending";
+          result: null;
+          run: unknown;
+        }) => Promise<void> | void;
+      }) => {
+        await input.onRunCreated?.({
+          runId: attachedRun.id,
+          status: "pending",
+          result: null,
+          run: attachedRun,
+        });
+        onRunCreatedWaitedForEmission = emitChatEventSettled;
+        return { runId: attachedRun.id, status: "completed" as const, result: null };
+      }
+    );
+    const tool = createWorkflowRunTool({
+      ...createTestToolConfig(tempDir.path, { workspaceId: "workspace-1" }),
+      trusted: true,
+      emitChatEvent: async (event) => {
+        await Promise.resolve();
+        if (event.type === "workflow-run-attached") {
+          emittedEvents.push(event);
+          emitChatEventSettled = true;
+        }
+      },
+      workflowService: {
+        listDefinitions: mock(async () => []),
+        readDefinition: mock(async () => ({
+          descriptor: {
+            name: "deep-research",
+            description: "Deep research",
+            scope: "built-in",
+            executable: true,
+          },
+          source: "export default function workflow() { return null; }",
+        })),
+        startNamedWorkflow,
+        getRun: mock(async () => attachedRun),
+      },
+    });
+
+    await tool.execute!(
+      { name: "deep-research", args: { topic: "workflow tools" }, run_in_background: false },
+      mockToolCallOptions
+    );
+
+    expect(onRunCreatedWaitedForEmission).toBe(true);
+    expect(emittedEvents).toHaveLength(1);
+    expect(emittedEvents[0]).toMatchObject({
+      type: "workflow-run-attached",
+      workspaceId: "workspace-1",
+      toolCallId: "test-call-id",
+      runId: "wfr_attached",
+      run: expect.objectContaining({ id: "wfr_attached", status: "pending" }),
+    });
+    expect(typeof emittedEvents[0]?.timestamp).toBe("number");
   });
 
   test("starts a workflow in background mode", async () => {
@@ -142,12 +249,15 @@ describe("workflow_run tool", () => {
     const references = await readAgentWorkflowRunReferences(tempDir.path);
     expect(references.map((reference) => reference.runId)).toContain("wfr_background");
 
-    expect(startNamedWorkflowInBackground).toHaveBeenCalledWith({
-      name: "deep-research",
-      workspaceId: "workspace-1",
-      projectTrusted: false,
-      args: { topic: "workflow tools" },
-    });
+    expect(startNamedWorkflowInBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "deep-research",
+        workspaceId: "workspace-1",
+        projectTrusted: false,
+        args: { topic: "workflow tools" },
+        onRunCreated: expect.any(Function),
+      })
+    );
     expect(startNamedWorkflow).not.toHaveBeenCalled();
     expect(result).toEqual({ status: "running", runId: "wfr_background", result: null });
   });

--- a/src/node/services/tools/workflow_run.ts
+++ b/src/node/services/tools/workflow_run.ts
@@ -6,6 +6,8 @@ import {
   WorkflowRunToolResultSchema,
   TOOL_DEFINITIONS,
 } from "@/common/utils/tools/toolDefinitions";
+import { WorkflowRunRecordSchema } from "@/common/orpc/schemas";
+import type { WorkflowRunAttachedEvent } from "@/common/types/stream";
 import {
   parseToolResult,
   recordBackgroundWorkflowRunReference,
@@ -35,6 +37,29 @@ function isBackgroundWorkflowResult(
   return args.run_in_background === true || status === "backgrounded";
 }
 
+async function emitWorkflowRunAttachedEvent(input: {
+  config: ToolConfiguration;
+  workspaceId: string;
+  toolCallId?: string;
+  runId: string;
+  run: unknown;
+}): Promise<void> {
+  if (!input.config.emitChatEvent || !input.toolCallId) {
+    return;
+  }
+
+  const parsedRun = WorkflowRunRecordSchema.safeParse(input.run);
+  const event: WorkflowRunAttachedEvent = {
+    type: "workflow-run-attached",
+    workspaceId: input.workspaceId,
+    toolCallId: input.toolCallId,
+    runId: input.runId,
+    ...(parsedRun.success ? { run: parsedRun.data } : {}),
+    timestamp: Date.now(),
+  };
+  await input.config.emitChatEvent(event);
+}
+
 export const createWorkflowRunTool: ToolFactory = (config: ToolConfiguration) => {
   return tool({
     description: TOOL_DEFINITIONS.workflow_run.description,
@@ -42,12 +67,22 @@ export const createWorkflowRunTool: ToolFactory = (config: ToolConfiguration) =>
     execute: async (args, options): Promise<unknown> => {
       const workspaceId = requireWorkspaceId(config, "workflow_run");
       const workflowService = requireWorkflowService(config);
+      const toolCallId = options.toolCallId;
 
       const startInput = {
         name: args.name,
         workspaceId,
         projectTrusted: config.trusted === true,
         args: args.args ?? {},
+        onRunCreated: async (event: { runId: string; run: unknown }) => {
+          await emitWorkflowRunAttachedEvent({
+            config,
+            workspaceId,
+            toolCallId,
+            runId: event.runId,
+            run: event.run,
+          });
+        },
       };
       const invocationStartedAtMs = Date.now();
       const result =

--- a/src/node/services/tools/workflow_run.ts
+++ b/src/node/services/tools/workflow_run.ts
@@ -6,9 +6,8 @@ import {
   WorkflowRunToolResultSchema,
   TOOL_DEFINITIONS,
 } from "@/common/utils/tools/toolDefinitions";
-import { WorkflowRunRecordSchema } from "@/common/orpc/schemas";
-import type { WorkflowRunAttachedEvent } from "@/common/types/stream";
 import {
+  emitWorkflowRunAttachedEvent,
   parseToolResult,
   recordBackgroundWorkflowRunReference,
   requireWorkspaceId,
@@ -35,29 +34,6 @@ function isBackgroundWorkflowResult(
   status: string
 ): boolean {
   return args.run_in_background === true || status === "backgrounded";
-}
-
-async function emitWorkflowRunAttachedEvent(input: {
-  config: ToolConfiguration;
-  workspaceId: string;
-  toolCallId?: string;
-  runId: string;
-  run: unknown;
-}): Promise<void> {
-  if (!input.config.emitChatEvent || !input.toolCallId) {
-    return;
-  }
-
-  const parsedRun = WorkflowRunRecordSchema.safeParse(input.run);
-  const event: WorkflowRunAttachedEvent = {
-    type: "workflow-run-attached",
-    workspaceId: input.workspaceId,
-    toolCallId: input.toolCallId,
-    runId: input.runId,
-    ...(parsedRun.success ? { run: parsedRun.data } : {}),
-    timestamp: Date.now(),
-  };
-  await input.config.emitChatEvent(event);
 }
 
 export const createWorkflowRunTool: ToolFactory = (config: ToolConfiguration) => {


### PR DESCRIPTION
## Summary

Hydrates `workflow_run` and `workflow_resume` tool cards from an exact durable workflow run attachment instead of waiting for heuristic run discovery. This removes the first-paint race where active foreground workflow cards could initially render as generic/empty before the run list poll found the matching workflow.

## Background

Foreground workflow tools block until completion/backgrounding, so the final tool result cannot hydrate the card while the workflow is actively running. The UI previously inferred the active run by matching workflow name, args, and timing against `listRuns`, which is fragile and can visibly lag or pick no run when reopening an active workspace.

## Implementation

- Added a `workflow-run-attached` chat event and `workflowRun` metadata on dynamic tool parts.
- Emitted exact run attachments from `workflow_run` when the durable run is created, and from `workflow_resume` before resuming/retrying a known run.
- Persisted attachments immediately into `partial.json`, replayed them on reconnect, and included their timestamps in stream cursors.
- Stored live attachment hints in `WorkspaceStore` and let workflow cards subscribe directly by `toolCallId`.
- Kept model/provider context clean by redacting UI-only workflow attachment metadata before provider replay.
- Ran the `simplify` workflow and applied its cleanup commit to centralize attachment emission, reduce generic tool subscriptions, and retain richer cached run snapshots on run-less attachment refreshes.

## Validation

- `bun test src/node/services/tools/workflow_run.test.ts src/node/services/tools/workflow_resume.test.ts src/node/services/streamManager.test.ts src/browser/stores/WorkspaceStore.test.ts src/browser/features/Tools/WorkflowRunToolCall.test.tsx src/browser/utils/messages/applyToolOutputRedaction.test.ts`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- Dogfooded the Storybook workflow-run card via `agent-browser`; captured screenshot/video evidence showing `wfr_story_foreground` and the `scope` phase rendered in the running workflow card.
- Ran project workflow: `workflow_run simplify --base origin/main --head HEAD --fix`, applied the generated cleanup commit.

## Risks

Medium risk because this touches streaming/replay, partial persistence, and workflow tool rendering. The new path is additive and UI-only; provider redaction ensures workflow attachment hints do not leak into model-bound messages.

## Pains

Storybook iframe rendering was intermittently slow during dogfood capture, so the final evidence used a retry loop that waited for the preview iframe to contain the workflow run ID before screenshot/video capture.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$76.30`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=76.30 -->
