### PR TITLE
🤖 fix: default slash workflow project path args

### DIFF
--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -801,11 +801,13 @@ export default function workflow({ args }) { return { reportMarkdown: args.proje
     );
   });
 
-  test("fills slash projectPath defaults from the active sub-project", async () => {
+  test("fills slash projectPath defaults from the active sub-project checkout", async () => {
+    const workspacePath = path.join(tempDir, "workspace-checkout");
     const subProjectPath = path.join(projectPath, "packages", "api");
-    fs.mkdirSync(subProjectPath, { recursive: true });
+    const workspaceSubProjectPath = path.join(workspacePath, "packages", "api");
+    fs.mkdirSync(path.join(workspacePath, ".mux", "workflows"), { recursive: true });
     fs.writeFileSync(
-      path.join(projectPath, ".mux", "workflows", "needs-active-project.js"),
+      path.join(workspacePath, ".mux", "workflows", "needs-active-project.js"),
       `const s = mux.schema;
 export const metadata = {
   description: "Needs active project",
@@ -815,7 +817,7 @@ export default function workflow({ args }) { return { reportMarkdown: args.proje
 `
     );
     const client = createRouterClient(router(), {
-      context: createContext({ enabled: true, subProjectPath }),
+      context: createContext({ enabled: true, workspacePath, subProjectPath }),
     });
 
     const result = await client.workflows.start({
@@ -827,7 +829,7 @@ export default function workflow({ args }) { return { reportMarkdown: args.proje
     });
 
     const run = await client.workflows.getRun({ workspaceId: "workspace-1", runId: result.runId });
-    expect(run?.args).toEqual({ projectPath: subProjectPath });
+    expect(run?.args).toEqual({ projectPath: workspaceSubProjectPath });
   });
 
   test("reports workflow argument validation as a bad request", async () => {

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -825,6 +825,37 @@ export default function workflow({ args }) { return { reportMarkdown: args.topic
     expect(thrown).toHaveProperty("message", "Workflow argument topic is required");
   });
 
+  test("reports malformed workflow argument schemas as a bad request", async () => {
+    fs.writeFileSync(
+      path.join(projectPath, ".mux", "workflows", "bad-args-schema.js"),
+      `export const metadata = {
+  description: "Bad args schema",
+  argsSchema: { type: "object", properties: { topic: "bad" } },
+};
+export default function workflow() { return { reportMarkdown: "should not run" }; }
+`
+    );
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    let thrown: unknown;
+    try {
+      await client.workflows.start({
+        workspaceId: "workspace-1",
+        name: "bad-args-schema",
+        args: { topic: "hello" },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ORPCError);
+    expect((thrown as { code?: string }).code).toBe("BAD_REQUEST");
+    expect(thrown).toHaveProperty(
+      "message",
+      "Workflow args property topic must be an object schema"
+    );
+  });
+
   test("waits for chat idle before starting slash workflow invocations", async () => {
     const context = createContext({ enabled: true });
     const workspaceService = context.workspaceService as unknown as {

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/await-thenable, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/require-await, @typescript-eslint/restrict-template-expressions, local/no-sync-fs-methods */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { createRouterClient } from "@orpc/server";
+import { ORPCError, createRouterClient } from "@orpc/server";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -756,6 +756,73 @@ describe("router workflow routes", () => {
       })
     );
     await waitForRouterWorkflowStatus(client, "workspace-1", result.runId, "completed");
+  });
+
+  test("fills projectPath defaults for slash workflow arg schemas", async () => {
+    fs.writeFileSync(
+      path.join(projectPath, ".mux", "workflows", "needs-project-path.js"),
+      `const s = mux.schema;
+export const metadata = {
+  description: "Needs project path",
+  argsSchema: s.object({
+    projectPath: s.string(),
+    input: s.optional(s.string()),
+  }),
+};
+export default function workflow({ args }) { return { reportMarkdown: args.projectPath + ":" + args.input }; }
+`
+    );
+    const context = createContext({ enabled: true });
+    const workspaceService = context.workspaceService as unknown as {
+      appendWorkflowRunInvocation: ReturnType<typeof mock>;
+    };
+    const client = createRouterClient(router(), { context });
+
+    const result = await client.workflows.start({
+      workspaceId: "workspace-1",
+      name: "needs-project-path",
+      runInBackground: true,
+      args: { input: "hello" },
+      rawCommand: "/workflow needs-project-path hello",
+    });
+
+    const run = await client.workflows.getRun({ workspaceId: "workspace-1", runId: result.runId });
+    expect(run?.args).toEqual({ projectPath, input: "hello" });
+    expect(workspaceService.appendWorkflowRunInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: { input: "hello" },
+        rawCommand: "/workflow needs-project-path hello",
+      })
+    );
+  });
+
+  test("reports workflow argument validation as a bad request", async () => {
+    fs.writeFileSync(
+      path.join(projectPath, ".mux", "workflows", "needs-topic.js"),
+      `const s = mux.schema;
+export const metadata = {
+  description: "Needs topic",
+  argsSchema: s.object({ topic: s.string() }),
+};
+export default function workflow({ args }) { return { reportMarkdown: args.topic }; }
+`
+    );
+    const client = createRouterClient(router(), { context: createContext({ enabled: true }) });
+
+    let thrown: unknown;
+    try {
+      await client.workflows.start({
+        workspaceId: "workspace-1",
+        name: "needs-topic",
+        args: {},
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ORPCError);
+    expect((thrown as { code?: string }).code).toBe("BAD_REQUEST");
+    expect(thrown).toHaveProperty("message", "Workflow argument topic is required");
   });
 
   test("waits for chat idle before starting slash workflow invocations", async () => {

--- a/src/node/orpc/router.test.ts
+++ b/src/node/orpc/router.test.ts
@@ -116,7 +116,11 @@ describe("router workflow routes", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  function createContext(options: { enabled: boolean; workspacePath?: string }): ORPCContext {
+  function createContext(options: {
+    enabled: boolean;
+    workspacePath?: string;
+    subProjectPath?: string;
+  }): ORPCContext {
     const workspacePath = options.workspacePath ?? projectPath;
     return {
       workflowSchedulerService: {
@@ -139,6 +143,7 @@ describe("router workflow routes", () => {
             name: "workspace-1",
             projectPath,
             namedWorkspacePath: workspacePath,
+            ...(options.subProjectPath != null ? { subProjectPath: options.subProjectPath } : {}),
             runtimeConfig: { type: "local", srcBaseDir: tempDir },
           },
         })),
@@ -794,6 +799,35 @@ export default function workflow({ args }) { return { reportMarkdown: args.proje
         rawCommand: "/workflow needs-project-path hello",
       })
     );
+  });
+
+  test("fills slash projectPath defaults from the active sub-project", async () => {
+    const subProjectPath = path.join(projectPath, "packages", "api");
+    fs.mkdirSync(subProjectPath, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectPath, ".mux", "workflows", "needs-active-project.js"),
+      `const s = mux.schema;
+export const metadata = {
+  description: "Needs active project",
+  argsSchema: s.object({ projectPath: s.string() }),
+};
+export default function workflow({ args }) { return { reportMarkdown: args.projectPath }; }
+`
+    );
+    const client = createRouterClient(router(), {
+      context: createContext({ enabled: true, subProjectPath }),
+    });
+
+    const result = await client.workflows.start({
+      workspaceId: "workspace-1",
+      name: "needs-active-project",
+      runInBackground: true,
+      args: {},
+      rawCommand: "/workflow needs-active-project",
+    });
+
+    const run = await client.workflows.getRun({ workspaceId: "workspace-1", runId: result.runId });
+    expect(run?.args).toEqual({ projectPath: subProjectPath });
   });
 
   test("reports workflow argument validation as a bad request", async () => {

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -129,6 +129,7 @@ import {
   type WorkflowBackgroundRunTerminalEvent,
 } from "@/node/services/workflows/WorkflowService";
 import { WorkflowTaskServiceAdapter } from "@/node/services/workflows/WorkflowTaskServiceAdapter";
+import { WorkflowArgsValidationError } from "@/node/services/workflows/workflowArgs";
 import { resolveWorkflowScratchRoots } from "@/node/services/workflows/workflowScratchRoots";
 import { WORKFLOW_SCHEDULE_DEFAULT_CONTEXT_MODE } from "@/constants/workflowSchedule";
 import { validateWorkspaceName } from "@/common/utils/validation/workspaceValidation";
@@ -297,6 +298,13 @@ function assertDynamicWorkflowsEnabled(context: ORPCContext): void {
   }
 }
 
+function throwWorkflowStartOrpcError(error: unknown): never {
+  if (error instanceof WorkflowArgsValidationError) {
+    throw new ORPCError("BAD_REQUEST", { message: error.message });
+  }
+  throw error;
+}
+
 /** Server-side enforcement: memory.* routes reject while the experiment is off. */
 function assertMemoryEnabled(context: ORPCContext): void {
   if (!context.experimentsService.isExperimentEnabled(EXPERIMENT_IDS.MEMORY)) {
@@ -350,7 +358,7 @@ export async function resolveWorkflowContext(
     notifyInterruptedBackgroundRunTerminal?: boolean;
     projectPath?: string;
   } = {}
-): Promise<{ service: WorkflowService; projectTrusted: boolean }> {
+): Promise<{ service: WorkflowService; projectTrusted: boolean; projectPath: string }> {
   assert(workspaceId.length > 0, "resolveWorkflowContext: workspaceId is required");
   assertDynamicWorkflowsEnabled(context);
   await context.aiService.waitForInit(workspaceId);
@@ -390,6 +398,7 @@ export async function resolveWorkflowContext(
   const workflowRuntimeTempDir = runtime.normalizePath(".mux/tmp", workspacePath);
 
   return {
+    projectPath: workflowProjectPath,
     projectTrusted,
     service: new WorkflowService({
       definitionStore: new WorkflowDefinitionStore({
@@ -2136,7 +2145,7 @@ export const router = (authToken?: string) => {
               manualFollowUp: true,
             });
           }
-          const { service, projectTrusted } = await resolveWorkflowContext(
+          const { service, projectPath, projectTrusted } = await resolveWorkflowContext(
             context,
             input.workspaceId,
             {
@@ -2146,11 +2155,14 @@ export const router = (authToken?: string) => {
           if (input.rawCommand != null) {
             await context.workspaceService.prepareManualWorkflowInvocation(input.workspaceId);
           }
+          // Slash workflow commands run from a workspace project; expose that server-resolved
+          // context as schema defaults without adding hidden fields to persisted command args.
           const workflowStartArgs = {
             name: input.name,
             workspaceId: input.workspaceId,
             projectTrusted,
             args: input.args ?? {},
+            ...(input.rawCommand != null ? { defaultArgs: { projectPath } } : {}),
           };
           const persistInvocation = async (details: {
             runId: string;
@@ -2175,15 +2187,20 @@ export const router = (authToken?: string) => {
               resolveInvocationPersistence(invocationMessagePersisted === true);
             }
           };
-          const result =
-            input.runInBackground === true
-              ? await service.startNamedWorkflowInBackground({
-                  ...workflowStartArgs,
-                  ...(input.rawCommand != null
-                    ? { onBackgroundRunCreated: persistInvocation }
-                    : {}),
-                })
-              : await service.startNamedWorkflow({ ...workflowStartArgs, abortSignal: signal });
+          let result: Awaited<ReturnType<typeof service.startNamedWorkflow>>;
+          try {
+            result =
+              input.runInBackground === true
+                ? await service.startNamedWorkflowInBackground({
+                    ...workflowStartArgs,
+                    ...(input.rawCommand != null
+                      ? { onBackgroundRunCreated: persistInvocation }
+                      : {}),
+                  })
+                : await service.startNamedWorkflow({ ...workflowStartArgs, abortSignal: signal });
+          } catch (error) {
+            throwWorkflowStartOrpcError(error);
+          }
           if (input.rawCommand == null) {
             return result;
           }

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -2148,9 +2148,7 @@ export const router = (authToken?: string) => {
           const { service, projectPath, projectTrusted } = await resolveWorkflowContext(
             context,
             input.workspaceId,
-            {
-              ...(onBackgroundRunTerminal != null ? { onBackgroundRunTerminal } : {}),
-            }
+            { onBackgroundRunTerminal }
           );
           if (input.rawCommand != null) {
             await context.workspaceService.prepareManualWorkflowInvocation(input.workspaceId);

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -374,26 +374,22 @@ export async function resolveWorkflowContext(
   const requestedWorkflowProjectPath = options.projectPath?.trim();
   const hasRequestedWorkflowProjectPath =
     requestedWorkflowProjectPath != null && requestedWorkflowProjectPath.length > 0;
-  const metadataSubProjectPath = metadata.subProjectPath?.trim();
   const workflowProjectPath = hasRequestedWorkflowProjectPath
     ? requestedWorkflowProjectPath
     : metadata.projectPath;
-  const workflowExecutionProjectPath = hasRequestedWorkflowProjectPath
-    ? requestedWorkflowProjectPath
-    : metadataSubProjectPath && metadataSubProjectPath.length > 0
-      ? metadataSubProjectPath
-      : metadata.projectPath;
   const projectTrusted = isTrustedProjectPath(context, workflowProjectPath);
   const runtime = createRuntimeForWorkspace(metadata);
   const workspaceRootPath = resolveWorkspaceRootPath(metadata, runtime);
-  const workspacePath =
-    options.projectPath != null
-      ? appendSubProjectRelativePath(
-          { ...metadata, subProjectPath: workflowProjectPath },
-          runtime,
-          workspaceRootPath
-        )
-      : workspaceRootPath;
+  const workflowExecutionProjectPath = hasRequestedWorkflowProjectPath
+    ? appendSubProjectRelativePath(
+        { ...metadata, subProjectPath: workflowProjectPath },
+        runtime,
+        workspaceRootPath
+      )
+    : appendSubProjectRelativePath(metadata, runtime, workspaceRootPath);
+  const workspacePath = hasRequestedWorkflowProjectPath
+    ? workflowExecutionProjectPath
+    : workspaceRootPath;
   const runtimeType = getRuntimeType(metadata.runtimeConfig);
   const useRuntimeProjectIO = shouldUseRuntimeWorkflowProjectIO(runtimeType);
   const disableHostWorkflowActions = shouldDisableHostWorkflowActions(runtimeType);

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -358,7 +358,11 @@ export async function resolveWorkflowContext(
     notifyInterruptedBackgroundRunTerminal?: boolean;
     projectPath?: string;
   } = {}
-): Promise<{ service: WorkflowService; projectTrusted: boolean; projectPath: string }> {
+): Promise<{
+  service: WorkflowService;
+  projectTrusted: boolean;
+  workflowExecutionProjectPath: string;
+}> {
   assert(workspaceId.length > 0, "resolveWorkflowContext: workspaceId is required");
   assertDynamicWorkflowsEnabled(context);
   await context.aiService.waitForInit(workspaceId);
@@ -368,9 +372,16 @@ export async function resolveWorkflowContext(
   }
   const metadata = metadataResult.data;
   const requestedWorkflowProjectPath = options.projectPath?.trim();
-  const workflowProjectPath =
-    requestedWorkflowProjectPath != null && requestedWorkflowProjectPath.length > 0
-      ? requestedWorkflowProjectPath
+  const hasRequestedWorkflowProjectPath =
+    requestedWorkflowProjectPath != null && requestedWorkflowProjectPath.length > 0;
+  const metadataSubProjectPath = metadata.subProjectPath?.trim();
+  const workflowProjectPath = hasRequestedWorkflowProjectPath
+    ? requestedWorkflowProjectPath
+    : metadata.projectPath;
+  const workflowExecutionProjectPath = hasRequestedWorkflowProjectPath
+    ? requestedWorkflowProjectPath
+    : metadataSubProjectPath && metadataSubProjectPath.length > 0
+      ? metadataSubProjectPath
       : metadata.projectPath;
   const projectTrusted = isTrustedProjectPath(context, workflowProjectPath);
   const runtime = createRuntimeForWorkspace(metadata);
@@ -398,7 +409,7 @@ export async function resolveWorkflowContext(
   const workflowRuntimeTempDir = runtime.normalizePath(".mux/tmp", workspacePath);
 
   return {
-    projectPath: workflowProjectPath,
+    workflowExecutionProjectPath,
     projectTrusted,
     service: new WorkflowService({
       definitionStore: new WorkflowDefinitionStore({
@@ -2145,22 +2156,22 @@ export const router = (authToken?: string) => {
               manualFollowUp: true,
             });
           }
-          const { service, projectPath, projectTrusted } = await resolveWorkflowContext(
-            context,
-            input.workspaceId,
-            { onBackgroundRunTerminal }
-          );
+          const { service, workflowExecutionProjectPath, projectTrusted } =
+            await resolveWorkflowContext(context, input.workspaceId, { onBackgroundRunTerminal });
           if (input.rawCommand != null) {
             await context.workspaceService.prepareManualWorkflowInvocation(input.workspaceId);
           }
-          // Slash workflow commands run from a workspace project; expose that server-resolved
-          // context as schema defaults without adding hidden fields to persisted command args.
+          // Slash workflow commands run from the active project/sub-project; expose that
+          // server-resolved context as schema defaults without adding hidden fields to
+          // persisted command args.
           const workflowStartArgs = {
             name: input.name,
             workspaceId: input.workspaceId,
             projectTrusted,
             args: input.args ?? {},
-            ...(input.rawCommand != null ? { defaultArgs: { projectPath } } : {}),
+            ...(input.rawCommand != null
+              ? { defaultArgs: { projectPath: workflowExecutionProjectPath } }
+              : {}),
           };
           const persistInvocation = async (details: {
             runId: string;

--- a/src/node/services/workflows/WorkflowService.test.ts
+++ b/src/node/services/workflows/WorkflowService.test.ts
@@ -471,6 +471,38 @@ export default function workflow() { return { reportMarkdown: "ok" }; }
     });
   });
 
+  test("applies invocation default args only for schema-declared missing fields", () => {
+    const source = `const s = mux.schema;
+export const metadata = {
+  argsSchema: s.object({
+    projectPath: s.string(),
+    topic: s.optional(s.string({ default: "schema topic" })),
+    input: s.optional(s.string()),
+  }),
+};
+export default function workflow() { return { reportMarkdown: "ok" }; }
+`;
+
+    expect(
+      normalizeWorkflowArgsForSource(
+        source,
+        { input: "hello" },
+        {
+          defaultArgs: { projectPath: "/repo", ignored: true },
+        }
+      ).args
+    ).toEqual({ projectPath: "/repo", topic: "schema topic", input: "hello" });
+    expect(
+      normalizeWorkflowArgsForSource(
+        source,
+        { projectPath: "/explicit" },
+        {
+          defaultArgs: { projectPath: "/repo" },
+        }
+      ).args
+    ).toEqual({ projectPath: "/explicit", topic: "schema topic" });
+  });
+
   test("normalizes exact short flag aliases before positional args", () => {
     const source = `const s = mux.schema;
 export const metadata = {

--- a/src/node/services/workflows/WorkflowService.ts
+++ b/src/node/services/workflows/WorkflowService.ts
@@ -713,7 +713,7 @@ export class WorkflowService {
     );
 
     const normalized = normalizeWorkflowArgsForSource(definition.source, input.args, {
-      ...(input.defaultArgs != null ? { defaultArgs: input.defaultArgs } : {}),
+      defaultArgs: input.defaultArgs,
     });
     return await this.runStore.createRun({
       id: runId,

--- a/src/node/services/workflows/WorkflowService.ts
+++ b/src/node/services/workflows/WorkflowService.ts
@@ -78,6 +78,8 @@ export interface StartNamedWorkflowInput {
   workspaceId: string;
   projectTrusted: boolean;
   args: unknown;
+  /** Server-resolved invocation context; applied only to schema-declared args that callers omit. */
+  defaultArgs?: Record<string, unknown>;
   /** Called after the durable run record exists but before the foreground runner can block. */
   onRunCreated?: (event: WorkflowRunCreatedEvent) => Promise<void> | void;
   onBackgroundRunCreated?: (event: WorkflowBackgroundRunCreatedEvent) => Promise<void> | void;
@@ -710,7 +712,9 @@ export class WorkflowService {
       "WorkflowService.createNamedWorkflowRun: generated run id is required"
     );
 
-    const normalized = normalizeWorkflowArgsForSource(definition.source, input.args);
+    const normalized = normalizeWorkflowArgsForSource(definition.source, input.args, {
+      ...(input.defaultArgs != null ? { defaultArgs: input.defaultArgs } : {}),
+    });
     return await this.runStore.createRun({
       id: runId,
       workspaceId: input.workspaceId,

--- a/src/node/services/workflows/workflowArgs.ts
+++ b/src/node/services/workflows/workflowArgs.ts
@@ -6,6 +6,17 @@ export interface WorkflowArgsNormalizationResult {
   metadata: WorkflowMetadata | null;
 }
 
+export class WorkflowArgsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkflowArgsValidationError";
+  }
+}
+
+export interface WorkflowArgsNormalizationOptions {
+  defaultArgs?: Record<string, unknown>;
+}
+
 interface WorkflowMetadata {
   argsSchema?: Record<string, unknown>;
 }
@@ -31,14 +42,18 @@ const RAW_INPUT_FIELD = "input";
 
 export function normalizeWorkflowArgsForSource(
   definitionSource: string,
-  rawArgs: unknown
+  rawArgs: unknown,
+  options: WorkflowArgsNormalizationOptions = {}
 ): WorkflowArgsNormalizationResult {
   const metadata = parseWorkflowMetadata(definitionSource);
   if (metadata?.argsSchema == null) {
     return { args: rawArgs, metadata };
   }
 
-  return { args: normalizeWorkflowArgs(metadata.argsSchema, rawArgs), metadata };
+  return {
+    args: normalizeWorkflowArgs(metadata.argsSchema, rawArgs, options.defaultArgs ?? {}),
+    metadata,
+  };
 }
 
 function parseWorkflowMetadata(source: string): WorkflowMetadata | null {
@@ -61,9 +76,14 @@ function parseWorkflowMetadata(source: string): WorkflowMetadata | null {
   return metadata;
 }
 
+function validationError(message: string): WorkflowArgsValidationError {
+  return new WorkflowArgsValidationError(message);
+}
+
 function normalizeWorkflowArgs(
   schema: Record<string, unknown>,
-  rawArgs: unknown
+  rawArgs: unknown,
+  defaultArgs: Record<string, unknown>
 ): Record<string, unknown> {
   assertObjectSchema(schema);
   const properties = propertySchemas(schema);
@@ -73,6 +93,12 @@ function normalizeWorkflowArgs(
   for (const property of properties) {
     if (property.defaultValue !== undefined) {
       normalized[property.name] = property.defaultValue;
+    }
+  }
+  // Invocation context should help only workflows that explicitly declare the field.
+  for (const property of properties) {
+    if (!(property.name in normalized) && property.name in defaultArgs) {
+      normalized[property.name] = defaultArgs[property.name];
     }
   }
 
@@ -188,7 +214,7 @@ function parseWorkflowInputString(
 ): Record<string, unknown> {
   const tokenized = tokenize(input);
   if (tokenized.error.length > 0) {
-    throw new Error(tokenized.error);
+    throw validationError(tokenized.error);
   }
 
   const parsed: Record<string, unknown> = {};
@@ -218,7 +244,7 @@ function parseWorkflowInputString(
       }
       const value = tokenized.tokens[index + 1];
       if (value == null || value.startsWith("--")) {
-        throw new Error(`${token} requires a value`);
+        throw validationError(`${token} requires a value`);
       }
       parsed[exactAliasProperty.name] = value;
       index += 2;
@@ -239,7 +265,7 @@ function parseWorkflowInputString(
         index += 1;
         continue;
       }
-      throw new Error(`Unknown workflow argument flag: ${flag.name}`);
+      throw validationError(`Unknown workflow argument flag: ${flag.name}`);
     }
 
     if (propertyAllowsType(property, "boolean")) {
@@ -252,7 +278,7 @@ function parseWorkflowInputString(
     const hasInlineValue = flag.inlineValue != null;
     const value = hasInlineValue ? flag.inlineValue : tokenized.tokens[index + 1];
     if (value == null || value.length === 0 || (!hasInlineValue && value.startsWith("--"))) {
-      throw new Error(`${flag.name} requires a value`);
+      throw validationError(`${flag.name} requires a value`);
     }
     parsed[property.name] = value;
     index += hasInlineValue ? 1 : 2;
@@ -262,7 +288,7 @@ function parseWorkflowInputString(
   if (positionalProperty != null && positional.length > 0) {
     parsed[positionalProperty.name] = positional.join(" ");
   } else if (positional.length > 0) {
-    throw new Error(`Unexpected workflow positional argument: ${positional[0]}`);
+    throw validationError(`Unexpected workflow positional argument: ${positional[0]}`);
   }
 
   return parsed;
@@ -316,14 +342,14 @@ function defaultNegatedFlagName(name: string): string {
 
 function assertBooleanProperty(property: ArgsPropertySchema, flagName: string): void {
   if (!propertyAllowsType(property, "boolean")) {
-    throw new Error(`${flagName} can only negate a boolean workflow argument`);
+    throw validationError(`${flagName} can only negate a boolean workflow argument`);
   }
 }
 
 function coerceProperty(property: ArgsPropertySchema, value: unknown): unknown {
   if (value === null) {
     if (propertyAllowsType(property, "null")) return null;
-    throw new Error(`Workflow argument ${property.name} must not be null`);
+    throw validationError(`Workflow argument ${property.name} must not be null`);
   }
 
   let lastError: Error | null = null;
@@ -364,7 +390,7 @@ function coercePropertyType(property: ArgsPropertySchema, value: unknown, type: 
 
 function coerceString(value: unknown, name: string): string {
   if (typeof value !== "string") {
-    throw new Error(`Workflow argument ${name} must be a string`);
+    throw validationError(`Workflow argument ${name} must be a string`);
   }
   return value.trim();
 }
@@ -378,13 +404,13 @@ function coerceBoolean(value: unknown, name: string): boolean {
     if (["true", "1", "yes", "on"].includes(normalized)) return true;
     if (["false", "0", "no", "off"].includes(normalized)) return false;
   }
-  throw new Error(`Workflow argument ${name} must be a boolean`);
+  throw validationError(`Workflow argument ${name} must be a boolean`);
 }
 
 function coerceInteger(value: unknown, name: string): number {
   const number = coerceNumber(value, name);
   if (!Number.isInteger(number)) {
-    throw new Error(`Workflow argument ${name} must be an integer`);
+    throw validationError(`Workflow argument ${name} must be an integer`);
   }
   return number;
 }
@@ -393,14 +419,14 @@ function coerceNumber(value: unknown, name: string): number {
   const number =
     typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
   if (!Number.isFinite(number)) {
-    throw new Error(`Workflow argument ${name} must be a number`);
+    throw validationError(`Workflow argument ${name} must be a number`);
   }
   return number;
 }
 
 function coerceArray(value: unknown, name: string): unknown[] {
   if (!Array.isArray(value)) {
-    throw new Error(`Workflow argument ${name} must be an array`);
+    throw validationError(`Workflow argument ${name} must be an array`);
   }
   return value;
 }
@@ -410,10 +436,10 @@ function validateBounds(property: ArgsPropertySchema, value: unknown): void {
     return;
   }
   if (property.minimum != null && value < property.minimum) {
-    throw new Error(`Workflow argument ${property.name} must be >= ${property.minimum}`);
+    throw validationError(`Workflow argument ${property.name} must be >= ${property.minimum}`);
   }
   if (property.maximum != null && value > property.maximum) {
-    throw new Error(`Workflow argument ${property.name} must be <= ${property.maximum}`);
+    throw validationError(`Workflow argument ${property.name} must be <= ${property.maximum}`);
   }
 }
 
@@ -422,7 +448,7 @@ function validateEnum(property: ArgsPropertySchema, value: unknown): void {
     return;
   }
   if (!property.enumValues.some((candidate) => Object.is(candidate, value))) {
-    throw new Error(
+    throw validationError(
       `Workflow argument ${property.name} must be one of: ${property.enumValues.join(", ")}`
     );
   }
@@ -435,7 +461,7 @@ function validateRequired(schema: Record<string, unknown>, value: Record<string,
       throw new Error("Workflow metadata.argsSchema.required entries must be strings");
     }
     if (!(property in value)) {
-      throw new Error(`Workflow argument ${property} is required`);
+      throw validationError(`Workflow argument ${property} is required`);
     }
   }
 }

--- a/src/node/services/workflows/workflowArgs.ts
+++ b/src/node/services/workflows/workflowArgs.ts
@@ -64,12 +64,12 @@ function parseWorkflowMetadata(source: string): WorkflowMetadata | null {
     return null;
   }
   if (!isPlainObject(rawMetadata)) {
-    throw new Error("Workflow metadata must be a static object literal");
+    throw validationError("Workflow metadata must be a static object literal");
   }
   const metadata: WorkflowMetadata = {};
   if (rawMetadata.argsSchema !== undefined) {
     if (!isPlainObject(rawMetadata.argsSchema)) {
-      throw new Error("Workflow metadata.argsSchema must be an object schema");
+      throw validationError("Workflow metadata.argsSchema must be an object schema");
     }
     metadata.argsSchema = rawMetadata.argsSchema;
   }
@@ -93,11 +93,8 @@ function normalizeWorkflowArgs(
   for (const property of properties) {
     if (property.defaultValue !== undefined) {
       normalized[property.name] = property.defaultValue;
-    }
-  }
-  // Invocation context should help only workflows that explicitly declare the field.
-  for (const property of properties) {
-    if (!(property.name in normalized) && property.name in defaultArgs) {
+    } else if (property.name in defaultArgs) {
+      // Invocation context should help only workflows that explicitly declare the field.
       normalized[property.name] = defaultArgs[property.name];
     }
   }
@@ -146,22 +143,22 @@ function normalizeWorkflowArgs(
 
 function assertObjectSchema(schema: Record<string, unknown>): void {
   if (schema.type !== "object") {
-    throw new Error('Workflow metadata.argsSchema must have type "object"');
+    throw validationError('Workflow metadata.argsSchema must have type "object"');
   }
   if (!isPlainObject(schema.properties)) {
-    throw new Error("Workflow metadata.argsSchema.properties must be an object");
+    throw validationError("Workflow metadata.argsSchema.properties must be an object");
   }
 }
 
 function propertySchemas(schema: Record<string, unknown>): ArgsPropertySchema[] {
   const rawProperties = schema.properties;
   if (!isPlainObject(rawProperties)) {
-    throw new Error("Workflow metadata.argsSchema.properties must be an object");
+    throw validationError("Workflow metadata.argsSchema.properties must be an object");
   }
 
   return Object.entries(rawProperties).map(([name, rawProperty]) => {
     if (!isPlainObject(rawProperty)) {
-      throw new Error(`Workflow args property ${name} must be an object schema`);
+      throw validationError(`Workflow args property ${name} must be an object schema`);
     }
     return {
       name,
@@ -367,7 +364,9 @@ function coerceProperty(property: ArgsPropertySchema, value: unknown): unknown {
 
   throw (
     lastError ??
-    new Error(`Unsupported workflow args type for ${property.name}: ${property.types.join(", ")}`)
+    validationError(
+      `Unsupported workflow args type for ${property.name}: ${property.types.join(", ")}`
+    )
   );
 }
 
@@ -384,7 +383,7 @@ function coercePropertyType(property: ArgsPropertySchema, value: unknown, type: 
     case "array":
       return coerceArray(value, property.name);
     default:
-      throw new Error(`Unsupported workflow args type for ${property.name}: ${type}`);
+      throw validationError(`Unsupported workflow args type for ${property.name}: ${type}`);
   }
 }
 
@@ -458,7 +457,7 @@ function validateRequired(schema: Record<string, unknown>, value: Record<string,
   const required = Array.isArray(schema.required) ? schema.required : [];
   for (const property of required) {
     if (typeof property !== "string") {
-      throw new Error("Workflow metadata.argsSchema.required entries must be strings");
+      throw validationError("Workflow metadata.argsSchema.required entries must be strings");
     }
     if (!(property in value)) {
       throw validationError(`Workflow argument ${property} is required`);


### PR DESCRIPTION
## Summary

Fix slash-command workflow starts so workflows that declare a `projectPath` argument receive the active workspace checkout path (including sub-project checkout paths) from the server-side workflow context instead of failing before a run is created.

## Background

Running a workflow from a slash command could hit `/workflows/start` with only the typed workflow args. Workflows whose `metadata.argsSchema` required `projectPath` then failed during argument normalization with `Workflow argument projectPath is required`, which surfaced as a 500.

## Implementation

- Added invocation-context defaults to workflow argument normalization, applied only to schema-declared missing fields.
- Passed the resolved active workflow execution checkout path as a slash-command-only `projectPath` default, including sub-project workspaces, without persisting hidden fields into command invocation metadata.
- Added `WorkflowArgsValidationError` so workflow argument/schema validation failures map to oRPC `BAD_REQUEST` instead of generic internal errors.
- Ran the `simplify` workflow and incorporated its small follow-up simplifications and malformed-schema validation coverage.

## Validation

- `bun test src/node/services/workflows/WorkflowService.test.ts --test-name-pattern "applies invocation default args|workflow args"`
- `bun test src/node/orpc/router.test.ts --test-name-pattern "router workflow routes"`
- `bun test src/node/orpc/router.test.ts --test-name-pattern "projectPath defaults|active sub-project|bad request"`
- `make static-check`
- `workflow_run simplify --base origin/main`

## Risks

Low. The default context only applies to workflow args declared in a workflow schema and only when the caller omitted that field. Explicit user args and schema defaults keep their existing precedence, persisted slash-command args remain unchanged, and sub-project workspaces now receive the same active checkout path that workflow execution should operate on.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$19.51`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=19.51 -->
