### PR TITLE
🤖 fix: keep workflow progress visible

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -1197,6 +1197,60 @@ describe("WorkflowRunToolCall", () => {
     });
   });
 
+  test("shows workflow events before invocation arguments", () => {
+    const runningRun = {
+      id: "wfr_event_priority",
+      workspaceId: TEST_WORKSPACE_ID,
+      definition: {
+        name: "deep-research",
+        description: "Deep research",
+        scope: "built-in" as const,
+        executable: true,
+      },
+      definitionSource: "export default function workflow() { return null; }",
+      definitionHash: "sha256:event-priority",
+      args: { topic: "workflow cards" },
+      status: "running" as const,
+      createdAt: "2026-05-29T00:00:00.000Z",
+      updatedAt: "2026-05-29T00:00:02.000Z",
+      events: [
+        {
+          sequence: 1,
+          type: "action" as const,
+          at: "2026-05-29T00:00:01.000Z",
+          stepId: "collect-sources",
+          name: "github.issue.get",
+          status: "completed" as const,
+          effect: "read" as const,
+          details: { issue: 149 },
+        },
+      ],
+      steps: [],
+    };
+
+    const view = renderWithStickyToolProviders(
+      <WorkflowRunToolCall
+        args={{
+          name: "deep-research",
+          args: { topic: "workflow cards" },
+          run_in_background: false,
+        }}
+        status="executing"
+        result={{
+          status: "running",
+          runId: runningRun.id,
+          result: null,
+          run: runningRun,
+        }}
+      />
+    );
+
+    const eventsTitle = view.getByText("Workflow events (1)");
+    const argumentsTitle = view.getByText("Arguments");
+    expect(Boolean(eventsTitle.compareDocumentPosition(argumentsTitle) & 4)).toBe(true);
+    expect(view.getByText("collect-sources / github.issue.get / completed")).toBeTruthy();
+  });
+
   test("renders executing foreground workflow status before the durable run is discovered", () => {
     const view = render(
       <ThemeProvider forcedTheme="dark">

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -1197,7 +1197,7 @@ describe("WorkflowRunToolCall", () => {
     });
   });
 
-  test("shows workflow events before invocation arguments", () => {
+  test("shows invocation arguments and definition source before workflow events", () => {
     const runningRun = {
       id: "wfr_event_priority",
       workspaceId: TEST_WORKSPACE_ID,
@@ -1245,9 +1245,11 @@ describe("WorkflowRunToolCall", () => {
       />
     );
 
-    const eventsTitle = view.getByText("Workflow events (1)");
     const argumentsTitle = view.getByText("Arguments");
-    expect(Boolean(eventsTitle.compareDocumentPosition(argumentsTitle) & 4)).toBe(true);
+    const definitionSourceTitle = view.getByText("Definition source");
+    const eventsTitle = view.getByText("Workflow events (1)");
+    expect(Boolean(argumentsTitle.compareDocumentPosition(eventsTitle) & 4)).toBe(true);
+    expect(Boolean(definitionSourceTitle.compareDocumentPosition(eventsTitle) & 4)).toBe(true);
     expect(view.getByText("collect-sources / github.issue.get / completed")).toBeTruthy();
   });
 

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1483,23 +1483,6 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
             </WorkflowSection>
           )}
 
-          {/* Large workflow payloads stay collapsed so completed runs remain scannable. */}
-          <WorkflowDisclosureSection title="Arguments">
-            <WorkflowJsonBlock value={invocationArgs} className="max-h-[180px]" />
-          </WorkflowDisclosureSection>
-
-          {run?.definitionSource && (
-            <WorkflowDisclosureSection title="Definition source">
-              <div className="border-border bg-code-bg max-h-[260px] overflow-auto rounded border p-2">
-                <HighlightedCode
-                  language="javascript"
-                  code={run.definitionSource.trimEnd()}
-                  showLineNumbers
-                />
-              </div>
-            </WorkflowDisclosureSection>
-          )}
-
           {(canInterrupt || canResume || canRetryFromCheckpoint || canPromote) && (
             <div className="mb-2 flex flex-wrap gap-2 text-[10px]">
               {canInterrupt && (
@@ -1625,6 +1608,23 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                 </ol>
               </div>
             </WorkflowSection>
+          )}
+
+          {/* Keep detailed workflow payloads below live progress so short viewports show actions first. */}
+          <WorkflowDisclosureSection title="Arguments">
+            <WorkflowJsonBlock value={invocationArgs} className="max-h-[180px]" />
+          </WorkflowDisclosureSection>
+
+          {run?.definitionSource && (
+            <WorkflowDisclosureSection title="Definition source">
+              <div className="border-border bg-code-bg max-h-[260px] overflow-auto rounded border p-2">
+                <HighlightedCode
+                  language="javascript"
+                  code={run.definitionSource.trimEnd()}
+                  showLineNumbers
+                />
+              </div>
+            </WorkflowDisclosureSection>
           )}
 
           {structuredOutput !== undefined && (

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -1483,6 +1483,23 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
             </WorkflowSection>
           )}
 
+          {/* Large workflow payloads stay collapsed so completed runs remain scannable. */}
+          <WorkflowDisclosureSection title="Arguments">
+            <WorkflowJsonBlock value={invocationArgs} className="max-h-[180px]" />
+          </WorkflowDisclosureSection>
+
+          {run?.definitionSource && (
+            <WorkflowDisclosureSection title="Definition source">
+              <div className="border-border bg-code-bg max-h-[260px] overflow-auto rounded border p-2">
+                <HighlightedCode
+                  language="javascript"
+                  code={run.definitionSource.trimEnd()}
+                  showLineNumbers
+                />
+              </div>
+            </WorkflowDisclosureSection>
+          )}
+
           {(canInterrupt || canResume || canRetryFromCheckpoint || canPromote) && (
             <div className="mb-2 flex flex-wrap gap-2 text-[10px]">
               {canInterrupt && (
@@ -1608,23 +1625,6 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                 </ol>
               </div>
             </WorkflowSection>
-          )}
-
-          {/* Keep detailed workflow payloads below live progress so short viewports show actions first. */}
-          <WorkflowDisclosureSection title="Arguments">
-            <WorkflowJsonBlock value={invocationArgs} className="max-h-[180px]" />
-          </WorkflowDisclosureSection>
-
-          {run?.definitionSource && (
-            <WorkflowDisclosureSection title="Definition source">
-              <div className="border-border bg-code-bg max-h-[260px] overflow-auto rounded border p-2">
-                <HighlightedCode
-                  language="javascript"
-                  code={run.definitionSource.trimEnd()}
-                  showLineNumbers
-                />
-              </div>
-            </WorkflowDisclosureSection>
           )}
 
           {structuredOutput !== undefined && (

--- a/src/node/services/aiService.test.ts
+++ b/src/node/services/aiService.test.ts
@@ -52,6 +52,7 @@ import type {
   RuntimeStatusEvent,
   StreamAbortEvent,
   StreamEndEvent,
+  WorkflowRunAttachedEvent,
 } from "@/common/types/stream";
 import { log } from "./log";
 import type { SessionUsageService } from "./sessionUsageService";
@@ -678,6 +679,28 @@ describe("AIService.setupStreamEventForwarding", () => {
     expect(await forwardedAbortPromise).toEqual(abortEvent);
     expect(clearPendingRunMetadataSpy).not.toHaveBeenCalled();
     expect(internals.pendingDevToolsRunMetadataByMessageId.has("message-1")).toBe(true);
+  });
+
+  it("forwards workflow-run-attached events", async () => {
+    using harness = createForwardingHarness("ai-service-workflow-run-attached-forwarding");
+    const { service, internals } = harness;
+    const event: WorkflowRunAttachedEvent = {
+      type: "workflow-run-attached",
+      workspaceId: "workspace-1",
+      messageId: "message-1",
+      toolCallId: "workflow-call-1",
+      runId: "wfr_forwarded",
+      timestamp: Date.now(),
+    };
+
+    const forwardedPromise = new Promise<WorkflowRunAttachedEvent>((resolve) => {
+      service.once("workflow-run-attached", (forwarded) =>
+        resolve(forwarded as WorkflowRunAttachedEvent)
+      );
+    });
+    internals.streamManager.emit("workflow-run-attached", event);
+
+    expect(await forwardedPromise).toEqual(event);
   });
 
   it.each([

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -631,6 +631,7 @@ export class AIService extends EventEmitter {
       "tool-call-end",
       "reasoning-delta",
       "reasoning-end",
+      "workflow-run-attached",
       "usage-delta",
     ] as const) {
       this.streamManager.on(event, (data) => this.emit(event, data));

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { StreamEndEventSchema } from "@/common/orpc/schemas/stream";
+import type { CompletedMessagePart } from "@/common/types/stream";
 import { Ok, Err } from "@/common/types/result";
 import type { ToolPolicy } from "@/common/utils/tools/toolPolicy";
 import {
@@ -200,6 +201,7 @@ function createStreamInfoForTests(
     startTime: now,
     lastPartTimestamp: now,
     toolCompletionTimestamps: new Map<string, number>(),
+    pendingWorkflowRunAttachments: new Map<string, unknown>(),
     model,
     metadataModel: overrides.metadataModel ?? model,
     historySequence: 1,
@@ -263,6 +265,66 @@ describe("StreamManager - workflow run attachments", () => {
     }
     expect(part.workflowRun).toEqual({
       runId: "wfr_attached",
+      timestamp: timestamp + 1,
+    });
+  });
+
+  test("persists workflow attachments that arrive before the tool part", async () => {
+    const streamManager = new StreamManager(historyService);
+    const workspaceId = "workflow-attachment-race-workspace";
+    const messageId = "workflow-attachment-race-message";
+    const timestamp = Date.now();
+    const streamInfo = createStreamInfoForTests({
+      messageId,
+      lastPartialWriteTime: timestamp,
+      parts: [],
+    });
+
+    getWorkspaceStreamsForTests(streamManager).set(workspaceId, streamInfo);
+
+    const attached = await streamManager.attachWorkflowRunToToolCall({
+      type: "workflow-run-attached",
+      workspaceId,
+      messageId,
+      toolCallId: "workflow-call-race",
+      runId: "wfr_race",
+      timestamp: timestamp + 1,
+    });
+
+    expect(attached).toBe(true);
+    expect(await historyService.readPartial(workspaceId)).toBeNull();
+
+    const appendPartAndEmit = getPrivateMethodForTests<
+      (
+        workspaceId: string,
+        streamInfo: Record<string, unknown>,
+        part: CompletedMessagePart,
+        schedulePartialWrite?: boolean
+      ) => Promise<void>
+    >(streamManager, "appendPartAndEmit");
+
+    await appendPartAndEmit.call(
+      streamManager,
+      workspaceId,
+      streamInfo,
+      {
+        type: "dynamic-tool",
+        toolCallId: "workflow-call-race",
+        toolName: "workflow_run",
+        input: { name: "deep-research", args: {} },
+        state: "input-available",
+        timestamp: timestamp + 2,
+      },
+      false
+    );
+
+    const partial = await historyService.readPartial(workspaceId);
+    const part = partial?.parts[0];
+    if (part?.type !== "dynamic-tool") {
+      throw new Error("Expected workflow tool part in persisted partial");
+    }
+    expect(part.workflowRun).toEqual({
+      runId: "wfr_race",
       timestamp: timestamp + 1,
     });
   });

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -234,6 +234,7 @@ describe("StreamManager - workflow run attachments", () => {
     const streamInfo = createStreamInfoForTests({
       messageId,
       lastPartialWriteTime: timestamp,
+      pendingWorkflowRunAttachments: undefined,
       parts: [
         {
           type: "dynamic-tool",

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs/promises";
 
 import { KNOWN_MODELS } from "@/common/constants/knownModels";
 import { StreamEndEventSchema } from "@/common/orpc/schemas/stream";
-import type { CompletedMessagePart } from "@/common/types/stream";
+import type { CompletedMessagePart, WorkflowRunAttachedEvent } from "@/common/types/stream";
 import { Ok, Err } from "@/common/types/result";
 import type { ToolPolicy } from "@/common/utils/tools/toolPolicy";
 import {
@@ -303,6 +303,11 @@ describe("StreamManager - workflow run attachments", () => {
       ) => Promise<void>
     >(streamManager, "appendPartAndEmit");
 
+    const replayedAttachments: WorkflowRunAttachedEvent[] = [];
+    streamManager.on("workflow-run-attached", (event: WorkflowRunAttachedEvent) => {
+      replayedAttachments.push(event);
+    });
+
     await appendPartAndEmit.call(
       streamManager,
       workspaceId,
@@ -317,6 +322,17 @@ describe("StreamManager - workflow run attachments", () => {
       },
       false
     );
+
+    expect(replayedAttachments).toEqual([
+      {
+        type: "workflow-run-attached",
+        workspaceId,
+        messageId,
+        toolCallId: "workflow-call-race",
+        runId: "wfr_race",
+        timestamp: timestamp + 1,
+      },
+    ]);
 
     const partial = await historyService.readPartial(workspaceId);
     const part = partial?.parts[0];

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -672,6 +672,23 @@ export class StreamManager extends EventEmitter {
     return attachment;
   }
 
+  private emitWorkflowRunAttachedFromAttachment(input: {
+    workspaceId: WorkspaceId;
+    messageId: string;
+    toolCallId: string;
+    attachment: WorkflowRunToolAttachment;
+  }): void {
+    this.emit("workflow-run-attached", {
+      type: "workflow-run-attached",
+      workspaceId: input.workspaceId as string,
+      messageId: input.messageId,
+      toolCallId: input.toolCallId,
+      runId: input.attachment.runId,
+      ...(input.attachment.run != null ? { run: input.attachment.run } : {}),
+      timestamp: input.attachment.timestamp,
+    } satisfies WorkflowRunAttachedEvent);
+  }
+
   async attachWorkflowRunToToolCall(event: WorkflowRunAttachedEvent): Promise<boolean> {
     const workspaceId = event.workspaceId as WorkspaceId;
     const streamInfo = this.workspaceStreams.get(workspaceId);
@@ -1190,20 +1207,22 @@ export class StreamManager extends EventEmitter {
     } finally {
       // Always persist the part in-memory (and to partial.json, if enabled), even if emit fails.
       let partToPersist = part;
-      let attachedWorkflowRun = false;
+      let pendingAttachment: WorkflowRunToolAttachment | undefined;
       if (part.type === "dynamic-tool") {
-        const pendingAttachment = this.takePendingWorkflowRunAttachment(
-          streamInfo,
-          part.toolCallId
-        );
+        pendingAttachment = this.takePendingWorkflowRunAttachment(streamInfo, part.toolCallId);
         if (pendingAttachment != null) {
           partToPersist = { ...part, workflowRun: pendingAttachment };
-          attachedWorkflowRun = true;
         }
       }
       streamInfo.parts.push(partToPersist);
-      if (attachedWorkflowRun) {
+      if (pendingAttachment != null && part.type === "dynamic-tool") {
         await this.flushPartialWrite(workspaceId, streamInfo);
+        this.emitWorkflowRunAttachedFromAttachment({
+          workspaceId,
+          messageId: streamInfo.messageId,
+          toolCallId: part.toolCallId,
+          attachment: pendingAttachment,
+        });
       } else if (schedulePartialWrite) {
         void this.schedulePartialWrite(workspaceId, streamInfo);
       }
@@ -1695,6 +1714,14 @@ export class StreamManager extends EventEmitter {
     // read partial.json via commitPartial. Without this await, there's a race condition
     // where the partial is read before the tool result is written, causing "amnesia".
     await this.flushPartialWrite(workspaceId, streamInfo);
+    if (pendingAttachment != null) {
+      this.emitWorkflowRunAttachedFromAttachment({
+        workspaceId,
+        messageId: streamInfo.messageId,
+        toolCallId,
+        attachment: pendingAttachment,
+      });
+    }
 
     // Emit tool-call-end event (listeners can now safely read partial)
     const completionTimestamp = nextPartTimestamp(streamInfo);

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -463,6 +463,9 @@ function hasIncompleteToolCallPart(parts: CompletedMessagePart[]): boolean {
   return parts.some((part) => part.type === "dynamic-tool" && part.state !== "output-available");
 }
 
+type DynamicToolCompletedMessagePart = Extract<CompletedMessagePart, { type: "dynamic-tool" }>;
+type WorkflowRunToolAttachment = NonNullable<DynamicToolCompletedMessagePart["workflowRun"]>;
+
 // Comprehensive stream info
 interface WorkspaceStreamInfo {
   state: StreamState;
@@ -483,6 +486,10 @@ interface WorkspaceStreamInfo {
   // Needed for reconnect replay filtering because dynamic-tool parts keep their
   // original start timestamp even after they gain output.
   toolCompletionTimestamps: Map<string, number>;
+
+  // Workflow tools can create the durable run before their stream part is stored. Keep the exact
+  // attachment and apply it as soon as the matching dynamic-tool part lands.
+  pendingWorkflowRunAttachments: Map<string, WorkflowRunToolAttachment>;
 
   model: string;
   /** Metadata model resolved from provider mapping for cost/token metadata lookups. */
@@ -646,6 +653,25 @@ export class StreamManager extends EventEmitter {
     streamInfo.toolModelUsages.push(clonePersistedToolModelUsage(event));
   }
 
+  private getWorkflowRunAttachment(event: WorkflowRunAttachedEvent): WorkflowRunToolAttachment {
+    return {
+      runId: event.runId,
+      ...(event.run != null ? { run: event.run } : {}),
+      timestamp: event.timestamp,
+    };
+  }
+
+  private takePendingWorkflowRunAttachment(
+    streamInfo: WorkspaceStreamInfo,
+    toolCallId: string
+  ): WorkflowRunToolAttachment | undefined {
+    const attachment = streamInfo.pendingWorkflowRunAttachments.get(toolCallId);
+    if (attachment != null) {
+      streamInfo.pendingWorkflowRunAttachments.delete(toolCallId);
+    }
+    return attachment;
+  }
+
   async attachWorkflowRunToToolCall(event: WorkflowRunAttachedEvent): Promise<boolean> {
     const workspaceId = event.workspaceId as WorkspaceId;
     const streamInfo = this.workspaceStreams.get(workspaceId);
@@ -656,11 +682,13 @@ export class StreamManager extends EventEmitter {
       return false;
     }
 
+    const attachment = this.getWorkflowRunAttachment(event);
     const partIndex = streamInfo.parts.findIndex(
       (part) => part.type === "dynamic-tool" && part.toolCallId === event.toolCallId
     );
     if (partIndex === -1) {
-      return false;
+      streamInfo.pendingWorkflowRunAttachments.set(event.toolCallId, attachment);
+      return true;
     }
 
     const part = streamInfo.parts[partIndex];
@@ -668,13 +696,10 @@ export class StreamManager extends EventEmitter {
       return false;
     }
 
+    streamInfo.pendingWorkflowRunAttachments.delete(event.toolCallId);
     streamInfo.parts[partIndex] = {
       ...part,
-      workflowRun: {
-        runId: event.runId,
-        ...(event.run != null ? { run: event.run } : {}),
-        timestamp: event.timestamp,
-      },
+      workflowRun: attachment,
     };
 
     await this.flushPartialWrite(workspaceId, streamInfo);
@@ -1164,8 +1189,22 @@ export class StreamManager extends EventEmitter {
       await this.emitPartAsEvent(workspaceId, streamInfo.messageId, part);
     } finally {
       // Always persist the part in-memory (and to partial.json, if enabled), even if emit fails.
-      streamInfo.parts.push(part);
-      if (schedulePartialWrite) {
+      let partToPersist = part;
+      let attachedWorkflowRun = false;
+      if (part.type === "dynamic-tool") {
+        const pendingAttachment = this.takePendingWorkflowRunAttachment(
+          streamInfo,
+          part.toolCallId
+        );
+        if (pendingAttachment != null) {
+          partToPersist = { ...part, workflowRun: pendingAttachment };
+          attachedWorkflowRun = true;
+        }
+      }
+      streamInfo.parts.push(partToPersist);
+      if (attachedWorkflowRun) {
+        await this.flushPartialWrite(workspaceId, streamInfo);
+      } else if (schedulePartialWrite) {
         void this.schedulePartialWrite(workspaceId, streamInfo);
       }
     }
@@ -1563,6 +1602,7 @@ export class StreamManager extends EventEmitter {
       startTime,
       lastPartTimestamp: startTime,
       toolCompletionTimestamps: new Map(),
+      pendingWorkflowRunAttachments: new Map(),
       model: modelString,
       metadataModel,
       thinkingLevel,
@@ -1626,8 +1666,13 @@ export class StreamManager extends EventEmitter {
     if (existingPartIndex !== -1) {
       const existingPart = streamInfo.parts[existingPartIndex];
       if (existingPart.type === "dynamic-tool") {
+        const pendingAttachment = this.takePendingWorkflowRunAttachment(
+          streamInfo,
+          existingPart.toolCallId
+        );
         streamInfo.parts[existingPartIndex] = {
           ...existingPart,
+          ...(pendingAttachment != null ? { workflowRun: pendingAttachment } : {}),
           state: "output-available" as const,
           output,
         };
@@ -1636,6 +1681,7 @@ export class StreamManager extends EventEmitter {
       // Fallback: if the matching tool-call part is missing, still persist output so the UI
       // does not stay stuck in input-available. Input may be missing for provider-native tools.
       const toolCall = toolCalls.get(toolCallId);
+      const pendingAttachment = this.takePendingWorkflowRunAttachment(streamInfo, toolCallId);
       streamInfo.parts.push({
         type: "dynamic-tool" as const,
         toolCallId,
@@ -1644,6 +1690,7 @@ export class StreamManager extends EventEmitter {
         input: toolCall?.input ?? null,
         output,
         timestamp: nextPartTimestamp(streamInfo),
+        ...(pendingAttachment != null ? { workflowRun: pendingAttachment } : {}),
       });
     }
 

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -665,9 +665,10 @@ export class StreamManager extends EventEmitter {
     streamInfo: WorkspaceStreamInfo,
     toolCallId: string
   ): WorkflowRunToolAttachment | undefined {
-    const attachment = streamInfo.pendingWorkflowRunAttachments.get(toolCallId);
+    const pendingAttachments = (streamInfo.pendingWorkflowRunAttachments ??= new Map());
+    const attachment = pendingAttachments.get(toolCallId);
     if (attachment != null) {
-      streamInfo.pendingWorkflowRunAttachments.delete(toolCallId);
+      pendingAttachments.delete(toolCallId);
     }
     return attachment;
   }
@@ -704,7 +705,7 @@ export class StreamManager extends EventEmitter {
       (part) => part.type === "dynamic-tool" && part.toolCallId === event.toolCallId
     );
     if (partIndex === -1) {
-      streamInfo.pendingWorkflowRunAttachments.set(event.toolCallId, attachment);
+      (streamInfo.pendingWorkflowRunAttachments ??= new Map()).set(event.toolCallId, attachment);
       return true;
     }
 

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -1662,14 +1662,11 @@ export class StreamManager extends EventEmitter {
     const existingPartIndex = streamInfo.parts.findIndex(
       (p) => p.type === "dynamic-tool" && p.toolCallId === toolCallId
     );
+    const pendingAttachment = this.takePendingWorkflowRunAttachment(streamInfo, toolCallId);
 
     if (existingPartIndex !== -1) {
       const existingPart = streamInfo.parts[existingPartIndex];
       if (existingPart.type === "dynamic-tool") {
-        const pendingAttachment = this.takePendingWorkflowRunAttachment(
-          streamInfo,
-          existingPart.toolCallId
-        );
         streamInfo.parts[existingPartIndex] = {
           ...existingPart,
           ...(pendingAttachment != null ? { workflowRun: pendingAttachment } : {}),
@@ -1681,7 +1678,6 @@ export class StreamManager extends EventEmitter {
       // Fallback: if the matching tool-call part is missing, still persist output so the UI
       // does not stay stuck in input-available. Input may be missing for provider-native tools.
       const toolCall = toolCalls.get(toolCallId);
-      const pendingAttachment = this.takePendingWorkflowRunAttachment(streamInfo, toolCallId);
       streamInfo.parts.push({
         type: "dynamic-tool" as const,
         toolCallId,

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -714,7 +714,7 @@ export class StreamManager extends EventEmitter {
       return false;
     }
 
-    streamInfo.pendingWorkflowRunAttachments.delete(event.toolCallId);
+    streamInfo.pendingWorkflowRunAttachments?.delete(event.toolCallId);
     streamInfo.parts[partIndex] = {
       ...part,
       workflowRun: attachment,


### PR DESCRIPTION
## Summary

Fix workflow run cards that could show only invocation arguments instead of the live workflow action/task list. The card now preserves the preferred `Arguments` / `Definition source` ordering while stream attachment persistence hydrates the durable workflow run as soon as the backend creates or replays it.

## Background

Foreground workflow tools can create a durable workflow run before the streamed dynamic tool part is stored. When that attachment races ahead of the tool part, the renderer can miss the exact `runId` hint and render an arguments-only card instead of the useful list of workflow actions/tasks.

## Implementation

- Buffer pending workflow-run attachments in `StreamManager` when the attachment event races ahead of the tool part, then apply the exact run attachment when the matching tool part is persisted or completed.
- Re-emit queued workflow attachments after the tool part is persisted/completed and forward `workflow-run-attached` through `AIService`, so reconnect/full-replay renderers rebuild exact workflow hints.
- Keep `Arguments` and `Definition source` before `Workflow events`, with large payloads still collapsed for scanability.
- Add regressions for UI section ordering, attachment-before-tool-part persistence/re-emission, and AIService forwarding.
- Ran the `simplify` workflow and applied its cleanup commit to dedupe workflow attachment lookup in `completeToolCall`.

## Validation

- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `bun test src/node/services/streamManager.test.ts -t "workflow run attachments"`
- `bun test src/node/services/aiService.test.ts -t "forwards workflow-run-attached events"`
- `make static-check`
- Dogfooded Storybook `App/Chat/Tools/WorkflowRun/RunningBackgroundWithRun` at a 375×667 viewport with `agent-browser`; verified `Arguments` and `Definition source` render above `Workflow events` and captured screenshot/video evidence locally.
- `workflow_run simplify --base origin/main --head HEAD --fix`

## Risks

Medium risk: this touches streaming partial persistence/forwarding and workflow card rendering. The stream-manager change is scoped to workflow-run attachment metadata, and the UI change preserves existing section content while restoring the preferred details-before-events order.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$63.70`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=63.70 -->
