### PR TITLE
🤖 fix: highlight scheduled workflow trigger names

### DIFF
--- a/src/browser/features/Messages/MessageRenderer.stories.tsx
+++ b/src/browser/features/Messages/MessageRenderer.stories.tsx
@@ -14,6 +14,7 @@ import {
   createUserMessage,
 } from "@/browser/stories/mocks/messages";
 import {
+  SCHEDULED_WORKFLOW_TRIGGER_LABEL,
   WORKFLOW_RESULT_METADATA_TYPE,
   WORKFLOW_RUN_CARD_DISPLAY_METADATA_TYPE,
   WORKFLOW_TRIGGER_DISPLAY_METADATA_TYPE,
@@ -281,6 +282,76 @@ export const WorkflowTriggeredCommand: AppStory = {
                 },
               }
             ),
+          ],
+        });
+      }}
+    />
+  ),
+};
+
+export const ScheduledWorkflowTrigger: AppStory = {
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: () => (
+    <AppWithMocks
+      setup={() => {
+        collapseLeftSidebar();
+        const rawCommand = `${SCHEDULED_WORKFLOW_TRIGGER_LABEL} github-issue-triage`;
+        const workflowName = "github-issue-triage";
+        const runId = "wfr_scheduled_workflow_trigger_story";
+        const workflowRun = {
+          id: runId,
+          workspaceId: "ws-scheduled-workflow-trigger",
+          definition: {
+            name: workflowName,
+            description: "Triage GitHub issues",
+            scope: "project" as const,
+            sourcePath: "/tmp/mux/project/.mux/workflows/github-issue-triage.js",
+            executable: true,
+          },
+          definitionSource: "export default function workflow() { return null; }",
+          definitionHash: "sha256:scheduled-workflow-trigger-story",
+          args: {},
+          status: "running" as const,
+          createdAt: "2026-05-29T00:00:00.000Z",
+          updatedAt: "2026-05-29T00:00:01.000Z",
+          events: [
+            {
+              sequence: 1,
+              type: "status" as const,
+              at: "2026-05-29T00:00:00.000Z",
+              status: "running" as const,
+            },
+          ],
+          steps: [],
+        };
+        const workflowCard = buildWorkflowRunCardMessage(
+          { name: workflowName, args: workflowRun.args },
+          { runId, status: workflowRun.status, result: null, run: workflowRun },
+          STABLE_TIMESTAMP - 295000
+        ) as ChatMuxMessage;
+        workflowCard.type = "message";
+        workflowCard.metadata = {
+          historySequence: 2,
+          timestamp: STABLE_TIMESTAMP - 295000,
+          synthetic: true,
+          uiVisible: true,
+          muxMetadata: { type: WORKFLOW_RUN_CARD_DISPLAY_METADATA_TYPE, runId },
+        };
+
+        return setupSimpleChatStory({
+          workspaceId: "ws-scheduled-workflow-trigger",
+          messages: [
+            createUserMessage("scheduled-workflow-command", rawCommand, {
+              historySequence: 1,
+              timestamp: STABLE_TIMESTAMP - 300000,
+              muxMetadata: {
+                type: WORKFLOW_TRIGGER_DISPLAY_METADATA_TYPE,
+                rawCommand,
+                commandPrefix: SCHEDULED_WORKFLOW_TRIGGER_LABEL,
+                runId,
+              },
+            }),
+            workflowCard,
           ],
         });
       }}

--- a/src/browser/features/Messages/UserMessageContent.inline-skill.test.tsx
+++ b/src/browser/features/Messages/UserMessageContent.inline-skill.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
+import { SCHEDULED_WORKFLOW_TRIGGER_LABEL } from "@/common/utils/workflowRunMessages";
 import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import type { DisplayedUserMessage, InlineSkillSnapshotMap } from "@/common/types/message";
 import type { EditingMessageState } from "@/browser/utils/chatEditing";
@@ -81,6 +82,36 @@ describe("UserMessageContent inline skill rendering", () => {
     expect(
       view.getByRole("region", { name: "Source for workflow deep-review-workflow" }).tabIndex
     ).toBe(0);
+  });
+
+  test("highlights the scheduled workflow name instead of the automation label", () => {
+    const view = render(
+      <UserMessageContent
+        content={`${SCHEDULED_WORKFLOW_TRIGGER_LABEL} github-issue-triage`}
+        commandPrefix={SCHEDULED_WORKFLOW_TRIGGER_LABEL}
+        workflowDefinitionPreview={{
+          descriptor: {
+            name: "github-issue-triage",
+            description: "Triage GitHub issues",
+            scope: "project",
+            executable: true,
+          },
+          source: "export default function workflow() {}",
+        }}
+        variant="sent"
+      />
+    );
+
+    const trigger = view.getByRole("button", {
+      name: "Show workflow definition preview for github-issue-triage",
+    });
+    expect(trigger.textContent).toBe("github-issue-triage");
+    expect(getSkillBadges(view.container).map((badge) => badge.textContent)).toEqual([
+      "github-issue-triage",
+    ]);
+    expect(view.container.textContent?.replace(/\u00a0/g, " ")).toContain(
+      "Automation: github-issue-triage"
+    );
   });
 
   test("opens the slash workflow preview from the focusable command badge", async () => {

--- a/src/browser/features/Messages/UserMessageContent.tsx
+++ b/src/browser/features/Messages/UserMessageContent.tsx
@@ -6,6 +6,7 @@ import type {
   WorkflowDefinitionPreviewForDisplay,
 } from "@/common/types/message";
 import type { FilePart } from "@/common/orpc/schemas";
+import { SCHEDULED_WORKFLOW_TRIGGER_LABEL } from "@/common/utils/workflowRunMessages";
 import { ReviewBlockFromData } from "../Shared/ReviewBlock";
 import {
   HoverCard,
@@ -101,6 +102,55 @@ const imageContainerStyles = {
 
 const markdownClassName = "user-message-markdown";
 
+interface ScheduledWorkflowTriggerDisplay {
+  label: string;
+  workflowName: string;
+  remainingContent: string;
+}
+
+function getScheduledWorkflowTriggerDisplay(options: {
+  textContent: string;
+  commandPrefix?: string;
+  workflowDefinitionPreview?: WorkflowDefinitionPreviewForDisplay;
+}): ScheduledWorkflowTriggerDisplay | null {
+  if (
+    options.commandPrefix !== SCHEDULED_WORKFLOW_TRIGGER_LABEL ||
+    !options.textContent.startsWith(SCHEDULED_WORKFLOW_TRIGGER_LABEL)
+  ) {
+    return null;
+  }
+
+  const contentAfterLabel = options.textContent
+    .slice(SCHEDULED_WORKFLOW_TRIGGER_LABEL.length)
+    .trimStart();
+  if (contentAfterLabel.length === 0) {
+    return null;
+  }
+
+  const previewName = options.workflowDefinitionPreview?.descriptor.name;
+  if (previewName && contentAfterLabel.startsWith(previewName)) {
+    const nextChar = contentAfterLabel.charAt(previewName.length);
+    if (nextChar === "" || /\s/u.test(nextChar)) {
+      return {
+        label: SCHEDULED_WORKFLOW_TRIGGER_LABEL,
+        workflowName: previewName,
+        remainingContent: contentAfterLabel.slice(previewName.length),
+      };
+    }
+  }
+
+  const workflowName = contentAfterLabel.trim();
+  if (workflowName.length === 0 || workflowName.includes("\n")) {
+    return null;
+  }
+
+  return {
+    label: SCHEDULED_WORKFLOW_TRIGGER_LABEL,
+    workflowName,
+    remainingContent: "",
+  };
+}
+
 function dataUrlToBlob(dataUrl: string): Blob | null {
   if (!dataUrl.startsWith("data:")) return null;
 
@@ -190,6 +240,62 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
     const snapshotMarkdown = buildAgentSkillSnapshotMarkdown(props.agentSkillSnapshot);
     const workflowDefinitionPreview = props.workflowDefinitionPreview;
 
+    const renderWorkflowDefinitionBadge = (label: string) => {
+      if (!workflowDefinitionPreview) {
+        return <AgentSkillBadge>{label}</AgentSkillBadge>;
+      }
+
+      return (
+        <HoverClickPopover
+          align="start"
+          content={<WorkflowDefinitionPreviewCard preview={workflowDefinitionPreview} />}
+          contentClassName="border-border-medium bg-modal-bg z-[1600] max-h-[360px] w-[560px] max-w-[80vw] overflow-auto border-2 p-3"
+          interactiveContent
+          side="top"
+        >
+          {/* Workflow previews use the run record snapshot so old invocations show what actually ran. */}
+          <AgentSkillBadge
+            as="button"
+            aria-label={`Show workflow definition preview for ${workflowDefinitionPreview.descriptor.name}`}
+            className="cursor-help"
+          >
+            {label}
+          </AgentSkillBadge>
+        </HoverClickPopover>
+      );
+    };
+
+    const scheduledWorkflowDisplay = getScheduledWorkflowTriggerDisplay({
+      textContent,
+      commandPrefix: shouldHighlightPrefix,
+      workflowDefinitionPreview,
+    });
+    if (scheduledWorkflowDisplay) {
+      const charAfterWorkflow = scheduledWorkflowDisplay.remainingContent.charAt(0);
+      const hasSpaceAfterWorkflow = charAfterWorkflow === " ";
+      const hasNewlineAfterWorkflow = charAfterWorkflow === "\n";
+
+      return (
+        <div className={hasNewlineAfterWorkflow ? "" : "flex flex-wrap items-baseline"}>
+          {/* Scheduled triggers start with an automation label; color the workflow name instead. */}
+          <span className="font-mono text-[13px] font-medium" style={markdownStyles[props.variant]}>
+            {scheduledWorkflowDisplay.label}&nbsp;
+          </span>
+          {renderWorkflowDefinitionBadge(scheduledWorkflowDisplay.workflowName)}
+          {hasSpaceAfterWorkflow && <span>&nbsp;</span>}
+          {scheduledWorkflowDisplay.remainingContent.trim() && (
+            <MarkdownRenderer
+              content={scheduledWorkflowDisplay.remainingContent.trim()}
+              className={markdownClassName}
+              style={markdownStyles[props.variant]}
+              inlineSkillSnapshots={props.inlineSkillSnapshots}
+              preserveLineBreaks
+            />
+          )}
+        </div>
+      );
+    }
+
     const badge = snapshotMarkdown ? (
       <HoverCard openDelay={150}>
         <HoverCardTrigger asChild>
@@ -213,22 +319,7 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
         </HoverCardPortal>
       </HoverCard>
     ) : workflowDefinitionPreview ? (
-      <HoverClickPopover
-        align="start"
-        content={<WorkflowDefinitionPreviewCard preview={workflowDefinitionPreview} />}
-        contentClassName="border-border-medium bg-modal-bg z-[1600] max-h-[360px] w-[560px] max-w-[80vw] overflow-auto border-2 p-3"
-        interactiveContent
-        side="top"
-      >
-        {/* Workflow previews use the run record snapshot so old invocations show what actually ran. */}
-        <AgentSkillBadge
-          as="button"
-          aria-label={`Show workflow definition preview for ${workflowDefinitionPreview.descriptor.name}`}
-          className="cursor-help"
-        >
-          {shouldHighlightPrefix}
-        </AgentSkillBadge>
-      </HoverClickPopover>
+      renderWorkflowDefinitionBadge(shouldHighlightPrefix)
     ) : (
       <AgentSkillBadge>{shouldHighlightPrefix}</AgentSkillBadge>
     );

--- a/src/common/utils/workflowRunMessages.ts
+++ b/src/common/utils/workflowRunMessages.ts
@@ -2,6 +2,7 @@ import type { MuxMessage } from "@/common/types/message";
 import type { WorkflowRunRecord } from "@/common/types/workflow";
 import assert from "@/common/utils/assert";
 
+export const SCHEDULED_WORKFLOW_TRIGGER_LABEL = "Automation:";
 export const WORKFLOW_TRIGGER_DISPLAY_METADATA_TYPE = "workflow-trigger-display";
 export const WORKFLOW_RUN_CARD_DISPLAY_METADATA_TYPE = "workflow-run-card-display";
 export const WORKFLOW_RESULT_METADATA_TYPE = "workflow-result";

--- a/src/node/services/serviceContainer.ts
+++ b/src/node/services/serviceContainer.ts
@@ -74,6 +74,7 @@ import { DesktopSessionManager } from "@/node/services/desktop/DesktopSessionMan
 import { DesktopTokenManager } from "@/node/services/desktop/DesktopTokenManager";
 import type { ORPCContext } from "@/node/orpc/context";
 import type { ExternalSecretResolver } from "@/common/types/secrets";
+import { SCHEDULED_WORKFLOW_TRIGGER_LABEL } from "@/common/utils/workflowRunMessages";
 import {
   getRuntimeConfigForScheduledNewWorkspaceTarget,
   getSupportedWorkflowScheduleNewWorkspaceTemplate,
@@ -392,7 +393,7 @@ export class ServiceContainer {
         // Same construction as the workflows.* ORPC routes so scheduled runs
         // behave identically to manual ones (run store, trust, host actions).
         const context = this.toORPCContext();
-        const rawCommand = `Automation: ${input.name}`;
+        const rawCommand = `${SCHEDULED_WORKFLOW_TRIGGER_LABEL} ${input.name}`;
         let createdRunId: string | null = null;
         const sendTerminalContinuation = async (
           event: Parameters<typeof sendWorkflowRunTerminalContinuation>[0]["event"]


### PR DESCRIPTION
## Summary

Render scheduled workflow trigger messages so the `Automation:` label stays in the normal user-message color while the workflow name receives the blue workflow badge styling.

## Background

Scheduled workflow invocations display as synthetic user messages like `Automation: github-issue-triage`. The UI previously highlighted `Automation:` because it was treated as the command prefix, but the visually important workflow identity is the workflow name.

## Implementation

- Added a shared scheduled-workflow trigger label constant used by backend message construction and frontend rendering.
- Special-cased scheduled workflow trigger rendering to keep `Automation:` unbadged and badge/color the workflow name instead.
- Kept existing workflow definition popover behavior attached to the workflow-name badge.
- Added a Storybook dogfood scenario and a regression component test for the scheduled-trigger rendering.

## Validation

- `bun test src/browser/features/Messages/UserMessageContent.inline-skill.test.tsx`
- `bun test src/node/services/serviceContainer.test.ts`
- `make typecheck`
- `make lint`
- `make fmt-check`
- `make static-check`
- Storybook dogfood via `agent-browser` at desktop and mobile widths with screenshots and WebM recording captured locally.

## Risks

Low. The change is scoped to user-message rendering for the scheduled workflow trigger label and reuses the existing workflow badge/popover path for workflow names.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$10.82`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=10.82 -->
