### PR TITLE
🤖 fix: distinguish plan Copy file path button icon

### DIFF
--- a/src/browser/features/Tools/ProposePlanToolCall.tsx
+++ b/src/browser/features/Tools/ProposePlanToolCall.tsx
@@ -61,9 +61,11 @@ import type { ReviewActionCallbacks } from "../Shared/InlineReviewNote";
 import { isPlanFilePath, normalizePlanFilePath } from "@/common/types/review";
 import type { ThinkingLevel } from "@/common/types/thinking";
 import {
+  Check,
   Clipboard,
   ClipboardCheck,
   ClipboardList,
+  Copy,
   FileText,
   ListStart,
   MessageSquareOff,
@@ -655,11 +657,13 @@ export const ProposePlanToolCall: React.FC<ProposePlanToolCallProps> = (props) =
   const actionButtons: ButtonConfig[] = [copyButton];
 
   // Copy the plan's on-disk file path (replaces the former mux.md "Share" link action).
+  // Use the Copy/Check icons (the repo's copy-a-value idiom, see RuntimeBadge) so this
+  // button is visually distinct from the Clipboard "Copy" button that copies plan content.
   if (planPath) {
     actionButtons.push({
       label: copiedPath ? "Copied" : "Copy file path",
       onClick: () => void copyPathToClipboard(planPath),
-      icon: copiedPath ? <ClipboardCheck /> : <Clipboard />,
+      icon: copiedPath ? <Check /> : <Copy />,
       tooltip: planPath,
     });
   }


### PR DESCRIPTION
## Summary

Differentiate the plan-file display's two copy buttons. Follow-up to #3568, which replaced the removed mux.md "Share" link action with a "Copy file path" action — but both that button and the existing "Copy" (content) button used the same `Clipboard`/`ClipboardCheck` icons, making them visually indistinguishable.

## Background

#3568 removed mux.md link support and, in the plan display, swapped the "Share" link for a "Copy file path" action. Because the new button reused the content button's `Clipboard`/`ClipboardCheck` icons, the two adjacent actions looked identical and only differed by label.

## Implementation

The "Copy file path" button now uses lucide's `Copy`/`Check` icons — the repo's existing copy-a-value idiom (see `RuntimeBadge`, which copies workspace paths) — while the content "Copy" button keeps `Clipboard`/`ClipboardCheck`. The two buttons now read as distinct actions at rest and in their copied state.

## Risks

Minimal — icon-only change in `ProposePlanToolCall.tsx`. No behavior, props, or copy-to-clipboard logic changed.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$25.12`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=25.12 -->
