### PR TITLE
🤖 fix: request OAuth scopes from protected resource metadata

### DIFF
--- a/src/node/services/mcpOauthService.test.ts
+++ b/src/node/services/mcpOauthService.test.ts
@@ -9,6 +9,7 @@ import {
   McpOauthService,
   parseBearerWwwAuthenticate,
   probeServerForBearerChallenge,
+  resolveOAuthScope,
 } from "./mcpOauthService";
 
 function getStoreFilePath(muxHome: string): string {
@@ -580,6 +581,57 @@ describe("McpOauthService.startDesktopFlow", () => {
       await service.cancelDesktopFlow(startResult.data.flowId);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+describe("resolveOAuthScope", () => {
+  async function startMetadataServer(
+    body: unknown
+  ): Promise<{ url: URL; close: () => Promise<void> }> {
+    const server = createServer((_req, res) => {
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(body));
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Failed to bind metadata server");
+    }
+    return {
+      url: new URL(`http://127.0.0.1:${address.port}/.well-known/oauth-protected-resource`),
+      close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+    };
+  }
+
+  test("uses the challenge scope when present", async () => {
+    expect(await resolveOAuthScope({ raw: "", scope: "mcp.read" })).toBe("mcp.read");
+  });
+
+  test("falls back to all advertised PRM scopes when the challenge omits scope", async () => {
+    // Carta advertises read_* and readwrite_* scopes but omits scope= from its
+    // 401. Cap-table reads require the readwrite_* scopes, so request every
+    // advertised scope rather than dropping readwrite_* as redundant.
+    const metadata = await startMetadataServer({
+      scopes_supported: ["openid", "cuid", "read_mcp_companies", "readwrite_mcp_companies"],
+    });
+    try {
+      expect(await resolveOAuthScope({ raw: "", resourceMetadataUrl: metadata.url })).toBe(
+        "openid cuid read_mcp_companies readwrite_mcp_companies"
+      );
+    } finally {
+      await metadata.close();
+    }
+  });
+
+  test("returns undefined when PRM advertises no scopes", async () => {
+    const metadata = await startMetadataServer({ resource: "https://example.com" });
+    try {
+      expect(
+        await resolveOAuthScope({ raw: "", resourceMetadataUrl: metadata.url })
+      ).toBeUndefined();
+    } finally {
+      await metadata.close();
     }
   });
 });

--- a/src/node/services/mcpOauthService.ts
+++ b/src/node/services/mcpOauthService.ts
@@ -286,6 +286,49 @@ export async function probeServerForBearerChallenge(options: {
   }
 }
 
+/**
+ * Resolve the OAuth scope to request for an authorization flow.
+ *
+ * The Bearer challenge's `scope=` wins when present. Otherwise we fall back to
+ * the Protected Resource Metadata's `scopes_supported` (RFC 9728). @ai-sdk/mcp
+ * fetches this same metadata to locate the authorization server but ignores its
+ * advertised scopes, so without this a server that omits `scope=` from its 401
+ * (e.g. Carta) grants only identity scopes and every resource call then fails
+ * with a permission error.
+ *
+ * ponytail: re-fetches the PRM the SDK already fetched internally; the SDK does
+ * not expose it, and this is one extra GET during an interactive flow.
+ */
+export async function resolveOAuthScope(
+  challenge: BearerChallenge | null
+): Promise<string | undefined> {
+  if (challenge?.scope) {
+    return challenge.scope;
+  }
+  if (!challenge?.resourceMetadataUrl) {
+    return undefined;
+  }
+  const scopes = await fetchProtectedResourceScopes(challenge.resourceMetadataUrl);
+  return scopes.length > 0 ? scopes.join(" ") : undefined;
+}
+
+async function fetchProtectedResourceScopes(url: URL): Promise<string[]> {
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) {
+      return [];
+    }
+    const json: unknown = await response.json();
+    const scopes = isPlainObject(json) ? json.scopes_supported : undefined;
+    return Array.isArray(scopes) ? scopes.filter((s): s is string => typeof s === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
 function parseStoredCredentials(value: unknown): MCPOAuthStoredCredentials | null {
   if (!isPlainObject(value)) {
     return null;
@@ -732,7 +775,7 @@ export class McpOauthService {
       clientInformation: null,
       authorizeUrl: "",
       redirectUri,
-      scope: challenge?.scope,
+      scope: await resolveOAuthScope(challenge),
       resourceMetadataUrl: challenge?.resourceMetadataUrl,
       codeVerifier: null,
       server: serverListener,
@@ -876,7 +919,7 @@ export class McpOauthService {
       clientInformation: null,
       authorizeUrl: "",
       redirectUri: redirectUri.toString(),
-      scope: challenge?.scope,
+      scope: await resolveOAuthScope(challenge),
       resourceMetadataUrl: challenge?.resourceMetadataUrl,
       codeVerifier: null,
       timeout: setTimeout(() => {


### PR DESCRIPTION
## Summary

Request OAuth scopes from protected resource metadata when an MCP server omits `scope=` in its Bearer challenge.

## Background

Some remote MCP servers advertise their available scopes in protected resource metadata but do not repeat them in the initial 401 challenge. In that case the SDK still discovers the authorization server correctly, but the authorization request can end up narrower than the server expects for subsequent tool calls.

## Implementation

Keep the existing challenge probe, but when the challenge has no `scope`, fetch the protected resource metadata URL from the same challenge and use its `scopes_supported` as the requested OAuth scope string. If the challenge already includes `scope`, keep that behavior unchanged.

## Validation

Validated locally with `make static-check` and the focused OAuth service test file covering both the challenge-scope path and the protected-resource-metadata fallback path.

## Risks

Low and isolated to MCP OAuth startup for remote servers. If the metadata fetch fails or advertises no scopes, the flow falls back to the previous behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.4` • Thinking: `xhigh`_

<!-- mux-attribution: model=openai:gpt-5.4 thinking=xhigh -->
