### PR TITLE
🤖 fix: retry workflow validation failures immediately

### DIFF
--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -1487,6 +1487,61 @@ describe("WorkflowRunner", () => {
     expect(interruptRunCalls).toBe(0);
   });
 
+  test("does not complete parallelAgents when abort prevents queued tasks from launching", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-parallel-abort-queued");
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
+    await store.createRun({
+      id: "wfr_parallel_abort_queued",
+      workspaceId: "workspace-1",
+      definition,
+      definitionSource: `export default function workflow({ parallelAgents }) {
+        parallelAgents([
+          { id: "source-a", prompt: "Read source A" },
+          { id: "source-b", prompt: "Read source B" },
+        ]);
+        return { reportMarkdown: "must not complete" };
+      }`,
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    const abortController = new AbortController();
+    let interruptRunCalls = 0;
+    const runner = createRunner(store, {
+      async runAgent() {
+        throw new Error("queued agents should not start after abort");
+      },
+      async createAgentTasks(
+        specs,
+        lifecycle?: { onTaskCreated?: (index: number, taskId: string) => Promise<void> | void }
+      ) {
+        for (const [index, spec] of specs.entries()) {
+          await lifecycle?.onTaskCreated?.(index, `task_${spec.id}`);
+        }
+        abortController.abort();
+        return specs.map((spec) => ({ taskId: `task_${spec.id}`, status: "starting" as const }));
+      },
+      async waitForAgentTask() {
+        throw new Error("queued agents should not be waited after abort");
+      },
+      async interruptRun() {
+        interruptRunCalls += 1;
+      },
+    });
+
+    await expect(
+      runner.run("wfr_parallel_abort_queued", { abortSignal: abortController.signal })
+    ).rejects.toThrow(
+      /Execution aborted|parallelAgents aborted before launching 2 queued step\(s\)/
+    );
+
+    const run = await store.getRun("wfr_parallel_abort_queued");
+    expect(interruptRunCalls).toBe(1);
+    expect(run.status).not.toBe("completed");
+  });
+
   test("retries parallelAgents validation failures before slower siblings finish", async () => {
     using tmp = new DisposableTempDir("workflow-runner-parallel-validation-incremental");
     const store = new WorkflowRunStore({

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -1130,10 +1130,13 @@ describe("WorkflowRunner", () => {
       workspaceId: "workspace-1",
       definition,
       definitionSource: `export default function workflow({ parallelAgents }) {
-        const results = parallelAgents([
-          { id: "source-a", title: "Read source 1", prompt: "Read source A" },
-          { id: "source-b", title: "Read source 2", prompt: "Read source B" },
-        ]);
+        const results = parallelAgents(
+          [
+            { id: "source-a", title: "Read source 1", prompt: "Read source A" },
+            { id: "source-b", title: "Read source 2", prompt: "Read source B" },
+          ],
+          { maxParallel: 2 }
+        );
         return { reportMarkdown: results.map((result) => result.reportMarkdown).join(" + ") };
       }`,
       args: {},
@@ -1428,6 +1431,57 @@ describe("WorkflowRunner", () => {
     });
 
     await expect(runner.run("wfr_parallel_failure")).rejects.toThrow("source-a failed");
+
+    expect(calls).toEqual(["source-a", "source-b"]);
+    expect(interruptRunCalls).toBe(1);
+  });
+
+  test("preserves the original parallelAgents child failure when queued specs remain", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-parallel-window-failure");
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
+    await store.createRun({
+      id: "wfr_parallel_window_failure",
+      workspaceId: "workspace-1",
+      definition,
+      definitionSource: `export default function workflow({ parallelAgents }) {
+        parallelAgents(
+          [
+            { id: "source-a", prompt: "Read source A" },
+            { id: "source-b", prompt: "Read source B" },
+            { id: "source-c", prompt: "Read source C" },
+          ],
+          { maxParallel: 2 }
+        );
+        return { reportMarkdown: "unreachable" };
+      }`,
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    const releaseSourceA = createDeferred();
+    const calls: string[] = [];
+    let interruptRunCalls = 0;
+    const runner = createRunner(store, {
+      async runAgent(spec) {
+        calls.push(spec.id);
+        if (spec.id === "source-a") {
+          await releaseSourceA.promise;
+          return { taskId: "task_source-a", reportMarkdown: "source-a" };
+        }
+        if (spec.id === "source-b") {
+          throw new Error("source-b failed");
+        }
+        throw new Error("source-c should stay queued after source-b fails");
+      },
+      async interruptRun() {
+        interruptRunCalls += 1;
+        releaseSourceA.resolve();
+      },
+    });
+
+    await expect(runner.run("wfr_parallel_window_failure")).rejects.toThrow("source-b failed");
 
     expect(calls).toEqual(["source-a", "source-b"]);
     expect(interruptRunCalls).toBe(1);

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -1487,7 +1487,7 @@ describe("WorkflowRunner", () => {
     expect(interruptRunCalls).toBe(0);
   });
 
-  test("records parallelAgents validation failures before slower siblings finish", async () => {
+  test("retries parallelAgents validation failures before slower siblings finish", async () => {
     using tmp = new DisposableTempDir("workflow-runner-parallel-validation-incremental");
     const store = new WorkflowRunStore({
       sessionDir: tmp.path,
@@ -1519,50 +1519,74 @@ describe("WorkflowRunner", () => {
     const sourceABlocked = new Promise<void>((resolve) => {
       releaseSourceA = resolve;
     });
-    const calls: string[] = [];
     const sourceBFailureRecorded = createDeferred();
+    const sourceBRetryStarted = createDeferred();
     const recordFailed = store.recordStepFailedAndAppendTaskEvent.bind(store);
     spyOn(store, "recordStepFailedAndAppendTaskEvent").mockImplementation(
       async (runId, input, options) => {
         try {
           await recordFailed(runId, input, options);
         } catch (error) {
-          if (input.stepId === "source-b" && input.taskId === "task_source-b_bad") {
+          if (input.stepId === "source-b" && input.taskId === "task_source-b") {
             sourceBFailureRecorded.reject(error);
           }
           throw error;
         }
-        if (input.stepId === "source-b" && input.taskId === "task_source-b_bad") {
+        if (input.stepId === "source-b" && input.taskId === "task_source-b") {
           sourceBFailureRecorded.resolve();
         }
       }
     );
+    const createAgentTasks = mock(
+      async (
+        specs: Array<{ id: string }>,
+        lifecycle?: { onTaskCreated?: (index: number, taskId: string) => Promise<void> | void }
+      ) => {
+        for (const [index, spec] of specs.entries()) {
+          await lifecycle?.onTaskCreated?.(index, `task_${spec.id}`);
+        }
+        return specs.map((spec) => ({ taskId: `task_${spec.id}`, status: "starting" as const }));
+      }
+    );
+    const waitForAgentTask = mock(async (taskId: string) => {
+      if (taskId === "task_source-a") {
+        await sourceABlocked;
+        return {
+          taskId,
+          reportMarkdown: "source-a",
+          structuredOutput: { summary: "source-a" },
+        };
+      }
+      if (taskId === "task_source-b") {
+        return { taskId, reportMarkdown: "bad" };
+      }
+      throw new Error(`unexpected waitForAgentTask call for ${taskId}`);
+    });
+    const retryPrompts: string[] = [];
     const runner = createRunner(store, {
-      async runAgent(spec) {
-        calls.push(spec.id);
-        if (spec.id === "source-a") {
-          await sourceABlocked;
-          return {
-            taskId: `task_${spec.id}`,
-            reportMarkdown: spec.id,
-            structuredOutput: { summary: spec.id },
-          };
-        }
-        if (calls.filter((id) => id === "source-b").length === 1) {
-          return { taskId: "task_source-b_bad", reportMarkdown: "bad" };
-        }
+      async runAgent(spec, lifecycle) {
+        expect(spec.id).toBe("source-b");
+        retryPrompts.push(spec.prompt);
+        await lifecycle?.onTaskCreated?.("task_source-b_retry");
+        sourceBRetryStarted.resolve();
         return {
           taskId: "task_source-b_retry",
           reportMarkdown: "source-b",
           structuredOutput: { summary: "source-b" },
         };
       },
+      createAgentTasks,
+      waitForAgentTask,
     });
 
     const runPromise = runner.run("wfr_parallel_validation_incremental");
     await sourceBFailureRecorded.promise;
+    await sourceBRetryStarted.promise;
     const runDuringSlowSibling = await store.getRun("wfr_parallel_validation_incremental");
 
+    expect(createAgentTasks).toHaveBeenCalledTimes(1);
+    expect(retryPrompts).toHaveLength(1);
+    expect(retryPrompts[0]).toContain("Previous workflow attempt 1 failed output validation");
     const validationEvent = runDuringSlowSibling.events.find(
       (event) => event.type === "validation" && event.stepId === "source-b"
     );
@@ -1575,24 +1599,125 @@ describe("WorkflowRunner", () => {
       (event) =>
         event.type === "task" &&
         event.stepId === "source-b" &&
-        event.taskId === "task_source-b_bad" &&
+        event.taskId === "task_source-b" &&
         event.status === "failed"
     );
     expect(failedTaskEvent).toMatchObject({
       type: "task",
       stepId: "source-b",
-      taskId: "task_source-b_bad",
+      taskId: "task_source-b",
       status: "failed",
     });
+    expect(runDuringSlowSibling.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stepId: "source-b",
+          status: "started",
+          taskId: "task_source-b_retry",
+        }),
+      ])
+    );
     expect(
       runDuringSlowSibling.steps.some(
-        (step) => step.stepId === "source-b" && step.status === "completed"
+        (step) => step.stepId === "source-a" && step.status === "completed"
       )
     ).toBe(false);
 
     releaseSourceA();
     await expect(runPromise).resolves.toEqual({ reportMarkdown: "source-a + source-b" });
-    expect(calls).toEqual(["source-a", "source-b", "source-b"]);
+  });
+
+  test("prioritizes validation retries over queued parallelAgents specs", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-parallel-validation-priority");
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
+    await store.createRun({
+      id: "wfr_parallel_validation_priority",
+      workspaceId: "workspace-1",
+      definition,
+      definitionSource: `export default function workflow({ parallelAgents }) {
+        const results = parallelAgents(
+          [
+            {
+              id: "source-a",
+              prompt: "Summarize A",
+              outputSchema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+            },
+            {
+              id: "source-b",
+              prompt: "Summarize B",
+              outputSchema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+            },
+            {
+              id: "source-c",
+              prompt: "Summarize C",
+              outputSchema: { type: "object", required: ["summary"], properties: { summary: { type: "string" } } },
+            },
+          ],
+          { maxParallel: 2 }
+        );
+        return { reportMarkdown: results.map((result) => result.structuredOutput.summary).join(" + ") };
+      }`,
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    const releaseSourceA = createDeferred();
+    const releaseSourceBRetry = createDeferred();
+    const sourceBRetryStarted = createDeferred();
+    const sourceCStarted = createDeferred();
+    const entered: string[] = [];
+    const runner = createRunner(store, {
+      async runAgent(spec, lifecycle) {
+        entered.push(spec.id);
+        if (spec.id === "source-a") {
+          await lifecycle?.onTaskCreated?.("task_source-a");
+          await releaseSourceA.promise;
+          return {
+            taskId: "task_source-a",
+            reportMarkdown: "source-a",
+            structuredOutput: { summary: "source-a" },
+          };
+        }
+        if (spec.id === "source-b" && entered.filter((id) => id === "source-b").length === 1) {
+          await lifecycle?.onTaskCreated?.("task_source-b_bad");
+          return { taskId: "task_source-b_bad", reportMarkdown: "bad" };
+        }
+        if (spec.id === "source-b") {
+          await lifecycle?.onTaskCreated?.("task_source-b_retry");
+          sourceBRetryStarted.resolve();
+          await releaseSourceBRetry.promise;
+          return {
+            taskId: "task_source-b_retry",
+            reportMarkdown: "source-b",
+            structuredOutput: { summary: "source-b" },
+          };
+        }
+        if (spec.id === "source-c") {
+          await lifecycle?.onTaskCreated?.("task_source-c");
+          sourceCStarted.resolve();
+          return {
+            taskId: "task_source-c",
+            reportMarkdown: "source-c",
+            structuredOutput: { summary: "source-c" },
+          };
+        }
+        throw new Error(`unexpected spec ${spec.id}`);
+      },
+    });
+
+    const runPromise = runner.run("wfr_parallel_validation_priority");
+    await sourceBRetryStarted.promise;
+
+    expect(entered).toEqual(["source-a", "source-b", "source-b"]);
+
+    releaseSourceBRetry.resolve();
+    await sourceCStarted.promise;
+    expect(entered).toEqual(["source-a", "source-b", "source-b", "source-c"]);
+
+    releaseSourceA.resolve();
+    await expect(runPromise).resolves.toEqual({ reportMarkdown: "source-a + source-b + source-c" });
   });
 
   test("retries only failed parallelAgents steps after structured output validation errors", async () => {

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -1917,7 +1917,9 @@ export class WorkflowRunner {
           }
           try {
             results[settled.step.index] = await this.recordAgentResult(runId, sequence, {
-              ...settled.step,
+              spec: settled.step.spec,
+              inputHash: settled.step.inputHash,
+              startedAt: settled.step.startedAt,
               leaseGuard: options.leaseGuard,
               rawResult: settled.rawResult,
             });

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -1749,7 +1749,7 @@ export class WorkflowRunner {
     }
 
     while (pending.length > 0) {
-      const currentPending = pending;
+      const queued = pending;
       pending = [];
       const batchAbortController = new AbortController();
       const upstreamAbortSignal = options.waitOptions?.abortSignal;
@@ -1773,37 +1773,27 @@ export class WorkflowRunner {
         ...options.waitOptions,
         abortSignal: batchAbortController.signal,
       };
-      const effectivePending = currentPending.map((step) => ({
-        ...step,
-        runSpec:
-          step.attempt === 1
-            ? step.spec
-            : buildRetryAgentSpec(
-                step.spec,
-                step.attempt - 1,
-                step.retryMessage ?? "previous attempt failed"
-              ),
-      }));
       // maxParallel caps live child tasks with a sliding window: the next spec
-      // starts as soon as any running one finishes, instead of waiting for a
-      // whole fixed-size batch to drain.
-      const windowSemaphore =
-        maxParallel != null && maxParallel < effectivePending.length
-          ? new AsyncSemaphore(maxParallel)
-          : undefined;
+      // starts as soon as any running one finishes. Validation retries are
+      // requeued at the front so a schema-only failure immediately uses the
+      // freed slot instead of waiting for unrelated slow siblings to drain.
+      const maxActive = maxParallel ?? queued.length;
+      assert(maxActive > 0, "WorkflowRunner.parallelAgents maxActive must be positive");
+
       // Under a window, tasks must be created lazily when a slot frees;
       // bulk-creating the whole wave up front would start every child at once.
-      const bulkCreatableSteps = windowSemaphore
-        ? []
-        : effectivePending.filter((step) => step.taskId == null);
-      if (
-        bulkCreatableSteps.length > 0 &&
+      const createAgentTasks =
+        maxParallel == null &&
         this.taskAdapter.createAgentTasks != null &&
         this.taskAdapter.waitForAgentTask != null
-      ) {
+          ? this.taskAdapter.createAgentTasks.bind(this.taskAdapter)
+          : undefined;
+      const bulkCreatableSteps =
+        createAgentTasks != null ? queued.filter((step) => step.taskId == null) : [];
+      if (createAgentTasks != null && bulkCreatableSteps.length > 0) {
         try {
-          const createdTasks = await this.taskAdapter.createAgentTasks(
-            bulkCreatableSteps.map((step) => step.runSpec),
+          const createdTasks = await createAgentTasks(
+            bulkCreatableSteps.map((step) => step.spec),
             {
               onTaskCreated: async (index, taskId) => {
                 const step = bulkCreatableSteps[index];
@@ -1844,47 +1834,80 @@ export class WorkflowRunner {
           throw error;
         }
       }
-      // Any settled sibling failure dooms the whole batch (the settle loop
-      // below rethrows it), so window-queued steps that have not started yet
-      // must not spawn fresh child tasks once a sibling has failed.
+
       let batchFailed = false;
-      const guardedRuns = effectivePending.map(async (step, pendingIndex) => {
-        const slot = windowSemaphore ? await windowSemaphore.acquire() : undefined;
-        try {
-          if (batchFailed || batchAbortController.signal.aborted) {
-            throw new Error(
-              `parallelAgents step ${step.spec.id} canceled before it started: a sibling task failed or the batch was aborted`
-            );
+      let nextRunIndex = 0;
+      const unsettledRuns = new Map<
+        number,
+        Promise<
+          | {
+              runIndex: number;
+              step: (typeof queued)[number];
+              rawResult: WorkflowAgentResult;
+            }
+          | { runIndex: number; step: (typeof queued)[number]; error: unknown }
+        >
+      >();
+
+      const startRun = (step: (typeof queued)[number]): void => {
+        const runIndex = nextRunIndex;
+        nextRunIndex += 1;
+        const runSpec =
+          step.attempt === 1
+            ? step.spec
+            : buildRetryAgentSpec(
+                step.spec,
+                step.attempt - 1,
+                step.retryMessage ?? "previous attempt failed"
+              );
+        const run = (async () => {
+          try {
+            if (batchFailed || batchAbortController.signal.aborted) {
+              throw new Error(
+                `parallelAgents step ${step.spec.id} canceled before it started: a sibling task failed or the batch was aborted`
+              );
+            }
+            const rawResult = await this.runOrResumeAgentStep(runId, sequence, {
+              spec: runSpec,
+              inputHash: step.inputHash,
+              startedAt: step.startedAt,
+              taskId: step.taskId,
+              leaseGuard: options.leaseGuard,
+              waitOptions: batchWaitOptions,
+            });
+            return { runIndex, step, rawResult };
+          } catch (error) {
+            batchFailed = true;
+            if (isForegroundWaitBackgroundedError(error)) {
+              foregroundBackgrounded = true;
+              abortBatch();
+            } else if (!foregroundBackgrounded) {
+              await interruptRemainingTasks();
+            }
+            return { runIndex, step, error };
           }
-          const rawResult = await this.runOrResumeAgentStep(runId, sequence, {
-            spec: step.runSpec,
-            inputHash: step.inputHash,
-            startedAt: step.startedAt,
-            taskId: step.taskId,
-            leaseGuard: options.leaseGuard,
-            waitOptions: batchWaitOptions,
-          });
-          return { pendingIndex, step, rawResult };
-        } catch (error) {
-          // Set before the slot is released (finally below) so the next
-          // admitted waiter deterministically observes the failure.
-          batchFailed = true;
-          if (isForegroundWaitBackgroundedError(error)) {
-            foregroundBackgrounded = true;
-            abortBatch();
-          } else if (!foregroundBackgrounded) {
-            await interruptRemainingTasks();
-          }
-          return { pendingIndex, step, error };
-        } finally {
-          slot?.release();
+        })();
+        unsettledRuns.set(runIndex, run);
+      };
+
+      const launchAvailable = (): void => {
+        while (
+          !batchFailed &&
+          !batchAbortController.signal.aborted &&
+          unsettledRuns.size < maxActive &&
+          queued.length > 0
+        ) {
+          const step = queued.shift();
+          assert(step != null, "WorkflowRunner.parallelAgents queued step is required");
+          startRun(step);
         }
-      });
-      const unsettledRuns = new Map(guardedRuns.map((run, index) => [index, run]));
+      };
+
       try {
+        launchAvailable();
         while (unsettledRuns.size > 0) {
           const settled = await Promise.race(unsettledRuns.values());
-          unsettledRuns.delete(settled.pendingIndex);
+          unsettledRuns.delete(settled.runIndex);
           if ("error" in settled) {
             await Promise.allSettled(unsettledRuns.values());
             if (foregroundBackgrounded) {
@@ -1903,6 +1926,7 @@ export class WorkflowRunner {
               !isRetryableAgentOutputError(error) ||
               settled.step.attempt >= WORKFLOW_AGENT_MAX_ATTEMPTS
             ) {
+              batchFailed = true;
               await interruptRemainingTasks();
               await Promise.allSettled(unsettledRuns.values());
               throw error;
@@ -1915,7 +1939,7 @@ export class WorkflowRunner {
               settled.step.attempt,
               error
             );
-            pending.push({
+            queued.unshift({
               ...settled.step,
               startedAt: this.clock.nowIso(),
               taskId: undefined,
@@ -1923,6 +1947,7 @@ export class WorkflowRunner {
               retryMessage: getErrorMessage(error),
             });
           }
+          launchAvailable();
         }
       } finally {
         upstreamAbortSignal?.removeEventListener("abort", abortBatch);

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -1779,27 +1779,24 @@ export class WorkflowRunner {
       // freed slot instead of waiting for unrelated slow siblings to drain.
       const maxActive = maxParallel ?? queued.length;
       assert(maxActive > 0, "WorkflowRunner.parallelAgents maxActive must be positive");
+      const usesWindow = maxParallel != null && maxParallel < queued.length;
 
       let batchFailed = false;
-      const throwIfQueuedWorkCannotLaunch = async (): Promise<void> => {
-        if (queued.length === 0 || (!batchFailed && !batchAbortController.signal.aborted)) {
+      const throwIfAbortPreventsQueuedWork = async (): Promise<void> => {
+        if (queued.length === 0 || !batchAbortController.signal.aborted) {
           return;
         }
         if (foregroundBackgrounded) {
           throw createForegroundWaitBackgroundedError();
         }
         await interruptRemainingTasks();
-        throw new Error(
-          batchAbortController.signal.aborted
-            ? `parallelAgents aborted before launching ${queued.length} queued step(s)`
-            : `parallelAgents stopped before launching ${queued.length} queued step(s)`
-        );
+        throw new Error(`parallelAgents aborted before launching ${queued.length} queued step(s)`);
       };
 
       // Under a window, tasks must be created lazily when a slot frees;
       // bulk-creating the whole wave up front would start every child at once.
       const createAgentTasks =
-        maxParallel == null &&
+        !usesWindow &&
         this.taskAdapter.createAgentTasks != null &&
         this.taskAdapter.waitForAgentTask != null
           ? this.taskAdapter.createAgentTasks.bind(this.taskAdapter)
@@ -1874,7 +1871,7 @@ export class WorkflowRunner {
       };
 
       try {
-        await throwIfQueuedWorkCannotLaunch();
+        await throwIfAbortPreventsQueuedWork();
         if (createAgentTasks != null && bulkCreatableSteps.length > 0) {
           try {
             const createdTasks = await createAgentTasks(
@@ -1928,9 +1925,9 @@ export class WorkflowRunner {
           }
         }
 
-        await throwIfQueuedWorkCannotLaunch();
+        await throwIfAbortPreventsQueuedWork();
         launchAvailable();
-        await throwIfQueuedWorkCannotLaunch();
+        await throwIfAbortPreventsQueuedWork();
         while (unsettledRuns.size > 0) {
           const settled = await Promise.race(unsettledRuns.values());
           unsettledRuns.delete(settled.runIndex);
@@ -1976,7 +1973,7 @@ export class WorkflowRunner {
             });
           }
           launchAvailable();
-          await throwIfQueuedWorkCannotLaunch();
+          await throwIfAbortPreventsQueuedWork();
         }
       } finally {
         upstreamAbortSignal?.removeEventListener("abort", abortBatch);

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -1780,6 +1780,22 @@ export class WorkflowRunner {
       const maxActive = maxParallel ?? queued.length;
       assert(maxActive > 0, "WorkflowRunner.parallelAgents maxActive must be positive");
 
+      let batchFailed = false;
+      const throwIfQueuedWorkCannotLaunch = async (): Promise<void> => {
+        if (queued.length === 0 || (!batchFailed && !batchAbortController.signal.aborted)) {
+          return;
+        }
+        if (foregroundBackgrounded) {
+          throw createForegroundWaitBackgroundedError();
+        }
+        await interruptRemainingTasks();
+        throw new Error(
+          batchAbortController.signal.aborted
+            ? `parallelAgents aborted before launching ${queued.length} queued step(s)`
+            : `parallelAgents stopped before launching ${queued.length} queued step(s)`
+        );
+      };
+
       // Under a window, tasks must be created lazily when a slot frees;
       // bulk-creating the whole wave up front would start every child at once.
       const createAgentTasks =
@@ -1790,52 +1806,6 @@ export class WorkflowRunner {
           : undefined;
       const bulkCreatableSteps =
         createAgentTasks != null ? queued.filter((step) => step.taskId == null) : [];
-      if (createAgentTasks != null && bulkCreatableSteps.length > 0) {
-        try {
-          const createdTasks = await createAgentTasks(
-            bulkCreatableSteps.map((step) => step.spec),
-            {
-              onTaskCreated: async (index, taskId) => {
-                const step = bulkCreatableSteps[index];
-                assert(step != null, "WorkflowRunner.parallelAgents bulk lifecycle index mismatch");
-                assert(taskId.length > 0, "WorkflowRunner.parallelAgents bulk taskId is required");
-                options.leaseGuard.throwIfLost();
-                await this.recordStepStarted(runId, {
-                  stepId: step.spec.id,
-                  inputHash: step.inputHash,
-                  taskId,
-                  startedAt: step.startedAt,
-                });
-                await this.recordTaskStartedEventIfMissing(runId, sequence, {
-                  stepId: step.spec.id,
-                  taskId,
-                  title: step.spec.title,
-                });
-              },
-            }
-          );
-          if (createdTasks.length !== bulkCreatableSteps.length) {
-            throw new Error("parallelAgents bulk task creation returned the wrong number of tasks");
-          }
-          for (const [index, createdTask] of createdTasks.entries()) {
-            assert(
-              createdTask.taskId.length > 0,
-              "WorkflowRunner.parallelAgents created taskId is required"
-            );
-            bulkCreatableSteps[index].taskId = createdTask.taskId;
-          }
-        } catch (error) {
-          if (isForegroundWaitBackgroundedError(error)) {
-            foregroundBackgrounded = true;
-            abortBatch();
-          } else if (!foregroundBackgrounded) {
-            await interruptRemainingTasks();
-          }
-          throw error;
-        }
-      }
-
-      let batchFailed = false;
       let nextRunIndex = 0;
       const unsettledRuns = new Map<
         number,
@@ -1904,7 +1874,63 @@ export class WorkflowRunner {
       };
 
       try {
+        await throwIfQueuedWorkCannotLaunch();
+        if (createAgentTasks != null && bulkCreatableSteps.length > 0) {
+          try {
+            const createdTasks = await createAgentTasks(
+              bulkCreatableSteps.map((step) => step.spec),
+              {
+                onTaskCreated: async (index, taskId) => {
+                  const step = bulkCreatableSteps[index];
+                  assert(
+                    step != null,
+                    "WorkflowRunner.parallelAgents bulk lifecycle index mismatch"
+                  );
+                  assert(
+                    taskId.length > 0,
+                    "WorkflowRunner.parallelAgents bulk taskId is required"
+                  );
+                  options.leaseGuard.throwIfLost();
+                  await this.recordStepStarted(runId, {
+                    stepId: step.spec.id,
+                    inputHash: step.inputHash,
+                    taskId,
+                    startedAt: step.startedAt,
+                  });
+                  await this.recordTaskStartedEventIfMissing(runId, sequence, {
+                    stepId: step.spec.id,
+                    taskId,
+                    title: step.spec.title,
+                  });
+                },
+              }
+            );
+            if (createdTasks.length !== bulkCreatableSteps.length) {
+              throw new Error(
+                "parallelAgents bulk task creation returned the wrong number of tasks"
+              );
+            }
+            for (const [index, createdTask] of createdTasks.entries()) {
+              assert(
+                createdTask.taskId.length > 0,
+                "WorkflowRunner.parallelAgents created taskId is required"
+              );
+              bulkCreatableSteps[index].taskId = createdTask.taskId;
+            }
+          } catch (error) {
+            if (isForegroundWaitBackgroundedError(error)) {
+              foregroundBackgrounded = true;
+              abortBatch();
+            } else if (!foregroundBackgrounded) {
+              await interruptRemainingTasks();
+            }
+            throw error;
+          }
+        }
+
+        await throwIfQueuedWorkCannotLaunch();
         launchAvailable();
+        await throwIfQueuedWorkCannotLaunch();
         while (unsettledRuns.size > 0) {
           const settled = await Promise.race(unsettledRuns.values());
           unsettledRuns.delete(settled.runIndex);
@@ -1950,6 +1976,7 @@ export class WorkflowRunner {
             });
           }
           launchAvailable();
+          await throwIfQueuedWorkCannotLaunch();
         }
       } finally {
         upstreamAbortSignal?.removeEventListener("abort", abortBatch);


### PR DESCRIPTION
## Summary

Updates the workflow runner's `parallelAgents` scheduler so structured-output validation failures retry immediately when a slot is available instead of waiting for unrelated sibling tasks to finish.

## Background

The deep-review workflow fans out lane/review tasks in parallel. When one lane returned invalid structured output, the runner recorded the validation failure but queued the retry for a later wave, so users could be left waiting on a slow sibling before the failed lane retried. This PR makes schema-validation retries opportunistic and concurrent with the rest of the fan-out.

## Implementation

- Replaced the fixed-wave `parallelAgents` settle loop with a dynamic queue that launches more work whenever a running task settles.
- Requeues retryable validation failures at the front of the queue, preserving the existing max-attempt limit and retry prompt behavior.
- Preserves terminal behavior for non-validation failures by interrupting active siblings and failing the batch.
- Propagates runtime/upstream aborts before returning from a partially launched queue, including interrupting any bulk-created children that can no longer be waited.
- Keeps bulk task creation for unconstrained first-attempt fan-outs, while retry attempts are launched through the normal single-task path so they can start immediately.

## Validation

- `bun test src/node/services/workflows/WorkflowRunner.test.ts --test-name-pattern "validation|parallelAgents"`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `workflow_run simplify --target HEAD --fix`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- `bun test src/node/services/workflows/WorkflowRunner.test.ts`

## Risks

This touches workflow runner scheduling for `parallelAgents`, which is central workflow infrastructure. The risk is bounded by focused regression coverage for immediate validation retry, retry priority under `maxParallel`, aborted queued work, existing sibling-interrupt behavior, and the full workflow runner test file.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `311517{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=7.92 -->
