### PR TITLE
🤖 feat: add simplify polish review lane

### DIFF
--- a/.mux/workflows/simplify.js
+++ b/.mux/workflows/simplify.js
@@ -2,7 +2,7 @@ const s = mux.schema;
 
 export const metadata = {
   description:
-    "Review current changes for reuse, quality, and efficiency, then fix actionable issues.",
+    "Review current changes for reuse, quality, efficiency, and polish, then fix actionable issues.",
   argsSchema: s.object({
     target: s.optional(s.string({ positional: true })),
     fix: s.optional(
@@ -77,6 +77,18 @@ const REVIEW_LANES = [
       "Find redundant computations, repeated file reads, duplicate network/API calls, N+1 patterns, and missed concurrency.",
       "Find hot-path bloat, recurring no-op updates, and updater wrappers that defeat same-reference no-op returns.",
       "Find TOCTOU existence pre-checks, unbounded memory, missing cleanup, and overly broad reads or loads.",
+    ],
+  },
+  {
+    id: "polish",
+    title: "Simplify: polish review",
+    instructions: [
+      "Inspect the diff for AI-generated slop introduced by the current changes.",
+      "Flag comments that restate the code, explain obvious behavior, or are inconsistent with nearby file style.",
+      "Flag defensive checks, try/catch blocks, or fallback paths that are abnormal for the surrounding trusted codepath.",
+      "Flag type escapes such as `as any` that bypass type issues instead of modeling them.",
+      "Flag style inconsistencies that make new code look generated rather than maintained.",
+      "Do not flag purposeful assertions, security checks, input validation, or comments that explain non-obvious rationale.",
     ],
   },
 ];
@@ -921,7 +933,7 @@ function usageResult(error) {
   const lines = [
     "# simplify workflow",
     "",
-    "Review current git changes for code reuse, quality, and efficiency, then fix actionable issues.",
+    "Review current git changes for code reuse, quality, efficiency, and polish, then fix actionable issues.",
     "",
     "## Usage",
     "",


### PR DESCRIPTION
## Summary

Adds a fourth `polish` lane to the simplify workflow so it reviews diffs for AI-generated code slop alongside reuse, quality, and efficiency.

## Background

The existing `$deslop` skill has a useful checklist for spotting generated-looking code, but simplify already owns review/fix orchestration. This PR folds that checklist into simplify as a read-only lane and keeps the existing synthesis/fixer stages responsible for deciding whether to act.

## Implementation

- Updates the simplify workflow description/help copy to include polish.
- Adds a `polish` review lane that flags obvious generated-code artifacts, abnormal defensive code for trusted codepaths, type escapes like `as any`, and style inconsistencies.
- Guards the lane against flagging intentional assertions, validation, security checks, or rationale comments.

## Validation

- `workflow_read` loaded the updated simplify workflow metadata successfully.
- `workflow_run` with `help: true` returned the updated help text successfully.
- `git diff --check -- .mux/workflows/simplify.js`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`

## Risks

Low. This only changes prompt instructions for a project workflow review lane, and the new lane is read-only until the existing synthesis/fixer stages select actionable findings.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$2.41`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=2.41 -->
