### PR TITLE
🤖 fix: keep optimistic goal visible during streaming

### DIFF
--- a/src/node/services/workspaceGoalService.ts
+++ b/src/node/services/workspaceGoalService.ts
@@ -439,6 +439,24 @@ export class WorkspaceGoalService {
     this.onActivityChange = listener;
   }
 
+  /**
+   * The optimistic goal published while a goal is set mid-stream, before
+   * stream-end persistence writes goal.json. Returns null when no mutation is
+   * queued for the workspace.
+   *
+   * Consumed by `WorkspaceService.emitWorkspaceActivity` to overlay the
+   * optimistic goal onto activity snapshots that are built from (still
+   * pre-stream) persisted metadata — e.g. `status_set`/`todo_write`/recency
+   * emits during the same stream. Without the overlay those snapshots replay
+   * the stale pre-stream goal and the Goal tab flickers back to it until the
+   * next goal read re-emits the optimistic one. This service clears the pending
+   * snapshot before emitting authoritative reverts (abort) or durable
+   * persistence (stream-end), so those transitions naturally win.
+   */
+  getPendingGoalSnapshot(workspaceId: string): GoalSnapshot | null {
+    return this.pendingGoalSnapshots.get(workspaceId) ?? null;
+  }
+
   setStreamInterrupter(interrupter: (workspaceId: string) => Promise<void>): void {
     this.streamInterrupter = interrupter;
   }

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1624,6 +1624,91 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
     }
   });
 
+  // A goal set mid-stream is held as optimistic state until stream-end
+  // persistence, so goal.json keeps the pre-stream goal. Non-goal activity
+  // emits (status_set/todo_write/recency) read that persisted goal and, before
+  // this overlay, replaced the activity snapshot with the stale goal — the Goal
+  // tab flickered back to the old goal until the next goal read. The overlay
+  // keeps the optimistic goal visible, and clears once the goal service drops
+  // the pending mutation (abort / stream-end).
+  test("mid-stream activity emits surface the optimistic goal, then revert on user abort", async () => {
+    const aiEmitter = new EventEmitter();
+    const aiService = Object.assign(aiEmitter, {
+      isStreaming: mock(() => false),
+    }) as unknown as AIService;
+    const { config, workspaceService, goalService, cleanup } = await createServices(aiService);
+    const workspaceId = "midstream-goal-overlay";
+    try {
+      await config.addWorkspace("/tmp/midstream-goal-overlay-project", {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath: "/tmp/midstream-goal-overlay-project",
+        runtimeConfig: { type: "local" },
+      });
+
+      const created = await setWorkspaceGoalOk(goalService, {
+        workspaceId,
+        objective: "Pre-stream goal",
+      });
+
+      // Queue a goal set mid-stream (publishes an optimistic, pendingPersistence
+      // snapshot without persisting goal.json).
+      const goalServiceAccess = goalService as unknown as {
+        isWorkspaceStreaming: (workspaceId: string) => Promise<boolean>;
+      };
+      const isStreamingOriginal = goalServiceAccess.isWorkspaceStreaming;
+      goalServiceAccess.isWorkspaceStreaming = () => Promise.resolve(true);
+      try {
+        const queued = await goalService.setGoal({
+          workspaceId,
+          objective: "Optimistic mid-stream goal",
+          expectedGoalId: created.goalId,
+        });
+        expect(queued.success).toBe(true);
+      } finally {
+        goalServiceAccess.isWorkspaceStreaming = isStreamingOriginal;
+      }
+
+      // The durable goal.json still holds the pre-stream goal.
+      expect((await goalService.getGoal(workspaceId))?.objective).toBe("Pre-stream goal");
+
+      const activityEvents: Array<{
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }> = [];
+      const listener = (event: {
+        workspaceId: string;
+        activity: WorkspaceActivitySnapshot | null;
+      }) => activityEvents.push(event);
+      workspaceService.on("activity", listener);
+      try {
+        // A non-goal activity emit reads persisted metadata (still the pre-stream
+        // goal) but must surface the optimistic goal so the Goal tab is stable.
+        await workspaceService.updateAgentStatus(workspaceId, { emoji: "🛠️", message: "Working" });
+        expect(activityEvents.at(-1)?.activity?.goal).toMatchObject({
+          objective: "Optimistic mid-stream goal",
+          pendingPersistence: true,
+        });
+
+        // User aborts: the goal service drops the queued mutation and reverts the
+        // panel to the persisted goal. Subsequent activity emits must show that
+        // reverted goal, not the discarded optimistic one.
+        await goalService.recordUserStoppedStream(workspaceId);
+        await workspaceService.updateAgentStatus(workspaceId, { emoji: "💤", message: "Idle" });
+        expect(activityEvents.at(-1)?.activity?.goal).toMatchObject({
+          goalId: created.goalId,
+          objective: "Pre-stream goal",
+        });
+        expect(activityEvents.at(-1)?.activity?.goal?.pendingPersistence).toBeUndefined();
+      } finally {
+        workspaceService.off("activity", listener);
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("WorkspaceService stream-abort listener leaves queued goal mutations for AgentSession", async () => {
     // Non-user abort goal mutation drains happen in AgentSession after abort
     // accounting. WorkspaceService must not drain here, or the aborted

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -1691,6 +1691,14 @@ describe("WorkspaceService truncateHistory goal acknowledgment", () => {
           pendingPersistence: true,
         });
 
+        // The bootstrap path (renderer reconnect/reload) builds straight from
+        // persisted metadata, so it must apply the same overlay.
+        const listed = await workspaceService.getActivityList();
+        expect(listed[workspaceId]?.goal).toMatchObject({
+          objective: "Optimistic mid-stream goal",
+          pendingPersistence: true,
+        });
+
         // User aborts: the goal service drops the queued mutation and reverts the
         // panel to the persisted goal. Subsequent activity emits must show that
         // reverted goal, not the discarded optimistic one.

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -7992,7 +7992,16 @@ export class WorkspaceService extends EventEmitter {
             }
             return [
               workspaceId,
-              mergeActiveWorkflowRunCount(snapshot, activeWorkflowRunCount),
+              // Overlay the optimistic mid-stream goal here too: the renderer
+              // bootstraps via this list (the subscription does not replay
+              // historical snapshots), and `getAllSnapshots()` returns the
+              // still-pre-stream persisted goal. Without this, a reconnect/reload
+              // during a mid-stream goal set would seed the UI with the stale
+              // goal until the next live emit or goal read.
+              mergeActiveWorkflowRunCount(
+                this.overlayPendingGoal(workspaceId, snapshot),
+                activeWorkflowRunCount
+              ),
             ] as const;
           }
         )

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -2076,8 +2076,40 @@ export class WorkspaceService extends EventEmitter {
   ): void {
     this.emit("activity", {
       workspaceId,
-      activity: this.mergeCachedActiveWorkflowRunCount(workspaceId, snapshot),
+      activity: this.mergeCachedActiveWorkflowRunCount(
+        workspaceId,
+        this.overlayPendingGoal(workspaceId, snapshot)
+      ),
     });
+  }
+
+  /**
+   * Overlay the optimistic mid-stream goal onto an activity snapshot.
+   *
+   * A goal set while the agent is streaming is held as optimistic state in the
+   * goal service until stream-end persistence; goal.json keeps the pre-stream
+   * goal. Activity snapshots built from persisted metadata (status_set,
+   * todo_write, recency, streaming) therefore still carry the pre-stream goal,
+   * and emitting them as-is makes the Goal tab flicker back to the stale goal
+   * mid-stream until the next goal read re-emits the optimistic one. Overlaying
+   * the pending snapshot here keeps the displayed goal stable across those
+   * emits. Authoritative goal emits authored by the goal service are left
+   * untouched: transient goal pushes already carry the optimistic goal
+   * (`transientGoalOnly`), and abort reverts / durable persistence clear the
+   * pending snapshot before emitting, so they win naturally.
+   */
+  private overlayPendingGoal(
+    workspaceId: string,
+    snapshot: WorkspaceActivitySnapshot | null
+  ): WorkspaceActivitySnapshot | null {
+    if (!snapshot || snapshot.transientGoalOnly === true) {
+      return snapshot;
+    }
+    const pending = this.workspaceGoalService?.getPendingGoalSnapshot(workspaceId);
+    if (!pending) {
+      return snapshot;
+    }
+    return { ...snapshot, goal: pending };
   }
 
   private async emitWorkspaceActivityUpdate(


### PR DESCRIPTION
## Summary

Fixes a transient UI bug where a goal set **while the agent is streaming** would briefly disappear from the Goal tab (it appears, vanishes, then comes back).

## Background

When a goal is set mid-stream, `WorkspaceGoalService` intentionally defers the durable `goal.json` write until stream-end and holds the new goal as **optimistic, transient state** (`pendingGoalSnapshots`, surfaced to the renderer as a `pendingPersistence` goal). `goal.json` (and the persisted activity metadata) keep the **pre-stream** goal.

The problem: the live stream keeps emitting *full* workspace activity snapshots — `status_set`, `todo_write`/`propose_plan`, recency bumps, streaming-status updates — each built from persisted metadata, so each still carries the stale pre-stream goal. In the renderer those non-transient snapshots fully replace the in-memory activity entry, dropping the optimistic goal. It only reappeared on the next goal read or at stream-end, producing the flicker:

```
set goal G  -> transient overlay shows G        (visible)
status_set  -> full snapshot carries old goal D  (G vanishes)
get_goal    -> transient overlay re-emits G      (G reappears)
```

## Implementation

The fix lives at the single activity-emit choke point, `WorkspaceService.emitWorkspaceActivity`. Before emitting, it overlays the goal service's pending optimistic snapshot (via the new `WorkspaceGoalService.getPendingGoalSnapshot`) onto the activity snapshot's `goal` field, so every mid-stream emit surfaces the optimistic goal instead of replaying the stale one.

This is robust because the goal service owns the pending state and clears it **before** emitting authoritative transitions:

- **Transient goal pushes** already carry the optimistic goal (`transientGoalOnly`) and are skipped by the overlay.
- **User abort** (`recordUserStoppedStream`) deletes the pending snapshot *before* pushing the reverted goal, so the overlay no longer fires and the discarded goal correctly disappears.
- **Stream-end persistence** (`applyPendingAfterStreamEnd`) likewise clears the pending snapshot before pushing the durable goal.

A frontend-only guard was considered but rejected: the renderer cannot distinguish a stale mid-stream emit from an authoritative abort-revert (both carry the persisted goal and can arrive while `streaming` is still `true`), so any renderer heuristic would wrongly pin a discarded goal after an Esc/abort. Anchoring the fix in the goal-state owner avoids that ambiguity.

## Validation

- New `WorkspaceService` test drives the real path: queue a goal mid-stream, fire a `status_set`-style activity emit, and assert the emitted snapshot surfaces the optimistic (`pendingPersistence`) goal — then `recordUserStoppedStream` and assert a subsequent emit reverts to the persisted goal with no lingering optimistic state.
- `make static-check` and the `workspaceService` / `workspaceGoalService` / `WorkspaceStore` suites pass.

## Risks

Low. The overlay is a narrow read-only lookup at emit time that only changes behavior while a goal mutation is queued (mid-stream). Authoritative goal emits are untouched, and the active-goal count already excludes pending goals. The main area to watch is goal-tab/sidebar display during streaming, which the new test exercises end-to-end including the abort path.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `n/a`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=n/a -->
