### PR TITLE
🤖 fix: background foreground waits for prequeued messages

### DIFF
--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3608,7 +3608,7 @@ export class AgentSession {
       workspaceGoalService: this.workspaceGoalService,
       experiments: options?.experiments,
       disableWorkspaceAgents: options?.disableWorkspaceAgents,
-      hasQueuedMessage: () => this.hasQueuedMessages("tool-end"),
+      hasQueuedMessages: this.hasQueuedMessages.bind(this),
       openaiTruncationModeOverride,
     });
 

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -3608,8 +3608,7 @@ export class AgentSession {
       workspaceGoalService: this.workspaceGoalService,
       experiments: options?.experiments,
       disableWorkspaceAgents: options?.disableWorkspaceAgents,
-      hasQueuedMessage: () =>
-        !this.messageQueue.isEmpty() && this.messageQueue.getQueueDispatchMode() === "tool-end",
+      hasQueuedMessage: () => this.hasQueuedMessages("tool-end"),
       openaiTruncationModeOverride,
     });
 
@@ -5022,8 +5021,11 @@ export class AgentSession {
     this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
   }
 
-  hasQueuedMessages(): boolean {
-    return !this.messageQueue.isEmpty();
+  hasQueuedMessages(dispatchMode?: "tool-end" | "turn-end"): boolean {
+    return (
+      !this.messageQueue.isEmpty() &&
+      (dispatchMode == null || this.messageQueue.getQueueDispatchMode() === dispatchMode)
+    );
   }
 
   async waitForPendingStreamErrorRecoveryDecision(): Promise<void> {

--- a/src/node/services/agentSession.waitForIdle.test.ts
+++ b/src/node/services/agentSession.waitForIdle.test.ts
@@ -70,6 +70,29 @@ describe("AgentSession.waitForIdle", () => {
     }
   });
 
+  test("tracks only tool-end queued messages for foreground wait backgrounding", async () => {
+    const { session, cleanup } = await createAgentSessionHarness({
+      workspaceId: "wait-for-idle-tool-end-queue",
+    });
+
+    try {
+      session.queueMessage("later", {
+        model: "anthropic:claude-sonnet-4-5",
+        agentId: "exec",
+        queueDispatchMode: "turn-end",
+      });
+      expect(session.hasQueuedMessages()).toBe(true);
+      expect(session.hasQueuedMessages("tool-end")).toBe(false);
+
+      session.clearQueue();
+      session.queueMessage("now");
+      expect(session.hasQueuedMessages("tool-end")).toBe(true);
+    } finally {
+      session.dispose();
+      await cleanup();
+    }
+  });
+
   test("removes repeated aborted idle waiters during one busy turn", async () => {
     const { session, cleanup } = await createAgentSessionHarness({
       workspaceId: "wait-for-idle-repeated-aborts",

--- a/src/node/services/aiService.ts
+++ b/src/node/services/aiService.ts
@@ -250,7 +250,7 @@ export interface StreamMessageOptions {
   allowAgentSetGoal?: boolean;
   workspaceGoalService?: WorkspaceGoalService;
   disableWorkspaceAgents?: boolean;
-  hasQueuedMessage?: () => boolean;
+  hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
   muxMetadata?: MuxMessageMetadata;
   openaiTruncationModeOverride?: "auto" | "disabled";
 }
@@ -1003,7 +1003,7 @@ export class AIService extends EventEmitter {
       allowAgentSetGoal,
       workspaceGoalService,
       disableWorkspaceAgents,
-      hasQueuedMessage,
+      hasQueuedMessages,
       openaiTruncationModeOverride,
       muxMetadata,
     } = opts;
@@ -2694,7 +2694,7 @@ export class AIService extends EventEmitter {
         maxOutputTokens,
         effectiveToolPolicy,
         streamToken, // Pass the pre-generated stream token
-        hasQueuedMessage,
+        hasQueuedMessages,
         metadata.name,
         effectiveThinkingLevel,
         requestHeaders,

--- a/src/node/services/streamManager.test.ts
+++ b/src/node/services/streamManager.test.ts
@@ -416,7 +416,7 @@ describe("StreamManager - cleanupStreamTempDir", () => {
 describe("StreamManager - stopWhen configuration", () => {
   type StopWhenCondition = (options: { steps: unknown[] }) => boolean;
   type BuildStopWhenCondition = (request: {
-    hasQueuedMessage?: () => boolean;
+    hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
     toolPolicy?: ToolPolicy;
   }) => StopWhenCondition[];
 
@@ -429,7 +429,7 @@ describe("StreamManager - stopWhen configuration", () => {
 
   function requiredToolConditionForTests(toolPolicy: ToolPolicy): StopWhenCondition {
     const [, , requiredToolCondition] = buildStopWhenForTests()({
-      hasQueuedMessage: () => false,
+      hasQueuedMessages: () => false,
       toolPolicy,
     });
     return requiredToolCondition;
@@ -441,7 +441,7 @@ describe("StreamManager - stopWhen configuration", () => {
 
   test("returns step-cap and queued-message conditions with no policy", () => {
     let queued = false;
-    const stopWhen = buildStopWhenForTests()({ hasQueuedMessage: () => queued });
+    const stopWhen = buildStopWhenForTests()({ hasQueuedMessages: () => queued });
     expect(stopWhen).toHaveLength(3);
 
     const [maxStepCondition, queuedMessageCondition, requiredToolCondition] = stopWhen;
@@ -666,7 +666,7 @@ describe("StreamManager - sequential tool execution", () => {
     headers?: Record<string, string | undefined>;
     maxOutputTokens?: number;
     streamCallSettings?: Record<string, unknown>;
-    hasQueuedMessage?: () => boolean;
+    hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
     toolPolicy?: ToolPolicy;
     toolChoice?: { type: "tool"; toolName: string };
   }

--- a/src/node/services/streamManager.ts
+++ b/src/node/services/streamManager.ts
@@ -156,7 +156,7 @@ interface StreamRequestConfig {
   headers?: Record<string, string | undefined>;
   maxOutputTokens?: number;
   streamCallSettings?: Omit<ResolvedCallSettingsOverrides, "maxOutputTokens">;
-  hasQueuedMessage?: () => boolean;
+  hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean;
   /** Optional hook for callers that need chunk-level visibility during streaming. */
   onChunk?: StreamTextOnChunk;
   /** Optional hook for callers that need the live prepared step transcript. */
@@ -1392,7 +1392,7 @@ export class StreamManager extends EventEmitter {
     maxOutputTokens?: number,
     callSettingsOverrides?: ResolvedCallSettingsOverrides,
     toolPolicy?: ToolPolicy,
-    hasQueuedMessage?: () => boolean,
+    hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean,
     headers?: Record<string, string | undefined>,
     anthropicCacheTtlOverride?: AnthropicCacheTtl,
     onChunk?: StreamTextOnChunk,
@@ -1449,7 +1449,7 @@ export class StreamManager extends EventEmitter {
       maxOutputTokens: effectiveMaxOutputTokens,
       streamCallSettings:
         Object.keys(streamCallSettings).length > 0 ? streamCallSettings : undefined,
-      hasQueuedMessage,
+      hasQueuedMessages,
       onChunk,
       onStepMessages,
       toolPolicy,
@@ -1457,7 +1457,7 @@ export class StreamManager extends EventEmitter {
   }
 
   private createStopWhenCondition(
-    request: Pick<StreamRequestConfig, "hasQueuedMessage" | "toolPolicy">
+    request: Pick<StreamRequestConfig, "hasQueuedMessages" | "toolPolicy">
   ): Array<ReturnType<typeof stepCountIs>> {
     // Completion-tool stop check: completion/routing tools use explicit
     // success/ok markers (agent_report, propose_plan).
@@ -1507,7 +1507,7 @@ export class StreamManager extends EventEmitter {
 
     return [
       stepCountIs(100000),
-      () => request.hasQueuedMessage?.() ?? false,
+      () => request.hasQueuedMessages?.("tool-end") ?? false,
       hasSuccessfulRequiredToolResult,
     ];
   }
@@ -1570,7 +1570,7 @@ export class StreamManager extends EventEmitter {
     maxOutputTokens?: number,
     toolPolicy?: ToolPolicy,
     callSettingsOverrides?: ResolvedCallSettingsOverrides,
-    hasQueuedMessage?: () => boolean,
+    hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean,
     workspaceName?: string,
     thinkingLevel?: string,
     headers?: Record<string, string | undefined>,
@@ -1593,7 +1593,7 @@ export class StreamManager extends EventEmitter {
       maxOutputTokens,
       callSettingsOverrides,
       toolPolicy,
-      hasQueuedMessage,
+      hasQueuedMessages,
       headers,
       anthropicCacheTtlOverride,
       onChunk,
@@ -2249,7 +2249,7 @@ export class StreamManager extends EventEmitter {
       fallbackState.original.maxOutputTokens,
       prepared.data.callSettingsOverrides,
       streamInfo.request.toolPolicy,
-      streamInfo.request.hasQueuedMessage,
+      streamInfo.request.hasQueuedMessages,
       prepared.data.headers,
       prepared.data.anthropicCacheTtl,
       streamInfo.request.onChunk,
@@ -3638,7 +3638,7 @@ export class StreamManager extends EventEmitter {
     maxOutputTokens?: number,
     toolPolicy?: ToolPolicy,
     providedStreamToken?: StreamToken,
-    hasQueuedMessage?: () => boolean,
+    hasQueuedMessages?: (dispatchMode?: "tool-end" | "turn-end") => boolean,
     workspaceName?: string,
     thinkingLevel?: string,
     headers?: Record<string, string | undefined>,
@@ -3723,7 +3723,7 @@ export class StreamManager extends EventEmitter {
           maxOutputTokens,
           toolPolicy,
           callSettingsOverrides,
-          hasQueuedMessage,
+          hasQueuedMessages,
           workspaceName,
           thinkingLevel,
           headers,

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -526,6 +526,7 @@ describe("TaskService", () => {
       sendMessage?: ReturnType<typeof mock>;
       remove?: ReturnType<typeof mock>;
       isStreaming?: ReturnType<typeof mock>;
+      hasQueuedMessages?: ReturnType<typeof mock>;
       hasPendingQueuedOrPreparingTurn?: ReturnType<typeof mock>;
       waitForPendingStreamErrorRecoveryDecision?: ReturnType<typeof mock>;
     } = {}
@@ -558,6 +559,9 @@ describe("TaskService", () => {
       create: createWorkspace,
       ...(options.sendMessage != null ? { sendMessage: options.sendMessage } : {}),
       ...(options.remove != null ? { remove: options.remove } : {}),
+      ...(options.hasQueuedMessages != null
+        ? { hasQueuedMessages: options.hasQueuedMessages }
+        : {}),
       ...(options.hasPendingQueuedOrPreparingTurn != null
         ? { hasPendingQueuedOrPreparingTurn: options.hasPendingQueuedOrPreparingTurn }
         : {}),
@@ -1893,6 +1897,23 @@ describe("TaskService", () => {
 
     expect(taskService.backgroundForegroundWaitsForWorkspace(parentId)).toBe(1);
     expect(await waitResult).toBeInstanceOf(ForegroundWaitBackgroundedError);
+    expect(taskService.backgroundForegroundWaitsForWorkspace(parentId)).toBe(0);
+  });
+
+  test("waitForWorkspaceTurn backgrounds when tool-end message was already queued", async () => {
+    const hasQueuedMessages = mock(() => true);
+    const { parentId, taskService } = await startWorkspaceTurnForTest({ hasQueuedMessages });
+
+    const waitError = await taskService
+      .waitForWorkspaceTurn("wst_handle", {
+        requestingWorkspaceId: parentId,
+        timeoutMs: 1_000,
+        backgroundOnMessageQueued: true,
+      })
+      .catch((error: unknown) => error);
+
+    expect(waitError).toBeInstanceOf(ForegroundWaitBackgroundedError);
+    expect(hasQueuedMessages).toHaveBeenCalledWith(parentId, "tool-end");
     expect(taskService.backgroundForegroundWaitsForWorkspace(parentId)).toBe(0);
   });
 
@@ -7472,7 +7493,7 @@ describe("TaskService", () => {
             name: "agent_explore_child",
             parentWorkspaceId: parentId,
             agentType: "explore",
-            taskStatus: "running",
+            taskStatus: "queued",
           },
         ],
         testTaskSettings(2, 3)
@@ -7481,6 +7502,11 @@ describe("TaskService", () => {
       const hasQueuedMessages = mock(() => true);
       const { workspaceService } = createWorkspaceServiceMocks({ hasQueuedMessages });
       const { taskService } = createTaskServiceHarness(config, { workspaceService });
+      const internal = taskService as unknown as {
+        backgroundableForegroundWaitersByWorkspaceId: Map<string, Set<unknown>>;
+        pendingStartWaitersByTaskId: Map<string, unknown[]>;
+        pendingWaitersByTaskId: Map<string, unknown[]>;
+      };
 
       const waitError = await taskService
         .waitForAgentReport(childId, {
@@ -7492,6 +7518,9 @@ describe("TaskService", () => {
       expect(waitError).toBeInstanceOf(ForegroundWaitBackgroundedError);
       expect(hasQueuedMessages).toHaveBeenCalledWith(parentId, "tool-end");
       expect(taskService.backgroundForegroundWaitsForWorkspace(parentId)).toBe(0);
+      expect(internal.backgroundableForegroundWaitersByWorkspaceId.has(parentId)).toBe(false);
+      expect(internal.pendingStartWaitersByTaskId.has(childId)).toBe(false);
+      expect(internal.pendingWaitersByTaskId.has(childId)).toBe(false);
     });
 
     test("defaults to queue-backgroundable when requestingWorkspaceId is present", async () => {

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -363,6 +363,7 @@ function createWorkspaceServiceMocks(
     sendMessage: ReturnType<typeof mock>;
     resumeStream: ReturnType<typeof mock>;
     clearQueue: ReturnType<typeof mock>;
+    hasQueuedMessages: ReturnType<typeof mock>;
     hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
     waitForPendingStreamErrorRecoveryDecision: ReturnType<typeof mock>;
     remove: ReturnType<typeof mock>;
@@ -380,6 +381,7 @@ function createWorkspaceServiceMocks(
   sendMessage: ReturnType<typeof mock>;
   resumeStream: ReturnType<typeof mock>;
   clearQueue: ReturnType<typeof mock>;
+  hasQueuedMessages: ReturnType<typeof mock>;
   hasPendingQueuedOrPreparingTurn: ReturnType<typeof mock>;
   waitForPendingStreamErrorRecoveryDecision: ReturnType<typeof mock>;
   remove: ReturnType<typeof mock>;
@@ -398,6 +400,7 @@ function createWorkspaceServiceMocks(
     overrides?.resumeStream ??
     mock((): Promise<Result<{ started: boolean }>> => Promise.resolve(Ok({ started: true })));
   const clearQueue = overrides?.clearQueue ?? mock((): Result<void> => Ok(undefined));
+  const hasQueuedMessages = overrides?.hasQueuedMessages ?? mock(() => false);
   const hasPendingQueuedOrPreparingTurn =
     overrides?.hasPendingQueuedOrPreparingTurn ?? mock(() => false);
   const waitForPendingStreamErrorRecoveryDecision =
@@ -429,6 +432,7 @@ function createWorkspaceServiceMocks(
       sendMessage,
       resumeStream,
       clearQueue,
+      hasQueuedMessages,
       hasPendingQueuedOrPreparingTurn,
       waitForPendingStreamErrorRecoveryDecision,
       remove,
@@ -444,6 +448,7 @@ function createWorkspaceServiceMocks(
     sendMessage,
     resumeStream,
     clearQueue,
+    hasQueuedMessages,
     hasPendingQueuedOrPreparingTurn,
     waitForPendingStreamErrorRecoveryDecision,
     remove,
@@ -7447,6 +7452,46 @@ describe("TaskService", () => {
 
       const count2 = taskService.backgroundForegroundWaitsForWorkspace(parentId);
       expect(count2).toBe(0);
+    });
+
+    test("backgrounds waiters when tool-end message was already queued", async () => {
+      const config = await createTestConfig(rootDir);
+
+      const parentId = "parent-ws";
+      const childId = "child-task-ws";
+      const projectPath = "/test/project";
+
+      await saveWorkspaces(
+        config,
+        projectPath,
+        [
+          { path: `${projectPath}/parent`, id: parentId, name: "parent" },
+          {
+            path: `${projectPath}/child`,
+            id: childId,
+            name: "agent_explore_child",
+            parentWorkspaceId: parentId,
+            agentType: "explore",
+            taskStatus: "running",
+          },
+        ],
+        testTaskSettings(2, 3)
+      );
+
+      const hasQueuedMessages = mock(() => true);
+      const { workspaceService } = createWorkspaceServiceMocks({ hasQueuedMessages });
+      const { taskService } = createTaskServiceHarness(config, { workspaceService });
+
+      const waitError = await taskService
+        .waitForAgentReport(childId, {
+          requestingWorkspaceId: parentId,
+          backgroundOnMessageQueued: true,
+        })
+        .catch((error: unknown) => error);
+
+      expect(waitError).toBeInstanceOf(ForegroundWaitBackgroundedError);
+      expect(hasQueuedMessages).toHaveBeenCalledWith(parentId, "tool-end");
+      expect(taskService.backgroundForegroundWaitsForWorkspace(parentId)).toBe(0);
     });
 
     test("defaults to queue-backgroundable when requestingWorkspaceId is present", async () => {

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -3769,6 +3769,11 @@ export class TaskService {
       this.backgroundableForegroundWaitersByWorkspaceId.set(workspaceId, set);
     }
     set.add(waiter);
+    // ponytail: level-trigger the edge-trigger from sendMessage, so a message
+    // queued before this waiter existed still backgrounds the foreground wait.
+    if (this.workspaceService.hasQueuedMessages(workspaceId, "tool-end")) {
+      this.backgroundForegroundWaitsForWorkspace(workspaceId);
+    }
   }
 
   private unregisterBackgroundableForegroundWaiter(

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -3769,11 +3769,6 @@ export class TaskService {
       this.backgroundableForegroundWaitersByWorkspaceId.set(workspaceId, set);
     }
     set.add(waiter);
-    // ponytail: level-trigger the edge-trigger from sendMessage, so a message
-    // queued before this waiter existed still backgrounds the foreground wait.
-    if (this.workspaceService.hasQueuedMessages(workspaceId, "tool-end")) {
-      this.backgroundForegroundWaitsForWorkspace(workspaceId);
-    }
   }
 
   private unregisterBackgroundableForegroundWaiter(
@@ -4034,6 +4029,13 @@ export class TaskService {
         () => waiterEntry.reject(new Error("Timed out waiting for workspace turn")),
         timeoutMs
       );
+
+      if (
+        shouldBackgroundOnQueuedMessage &&
+        this.workspaceService.hasQueuedMessages(options.requestingWorkspaceId, "tool-end")
+      ) {
+        this.backgroundForegroundWaitsForWorkspace(options.requestingWorkspaceId);
+      }
 
       void (async () => {
         const record = await this.taskHandleStore.getWorkspaceTurn(
@@ -4379,6 +4381,14 @@ export class TaskService {
             reject(new Error("Interrupted"));
           };
           options.abortSignal.addEventListener("abort", abortListener, { once: true });
+        }
+
+        if (
+          shouldBackgroundOnQueuedMessage &&
+          requestingWorkspaceId &&
+          this.workspaceService.hasQueuedMessages(requestingWorkspaceId, "tool-end")
+        ) {
+          this.backgroundForegroundWaitsForWorkspace(requestingWorkspaceId);
         }
       })().catch((error: unknown) => {
         reject(error instanceof Error ? error : new Error(String(error)));

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -7578,6 +7578,10 @@ export class WorkspaceService extends EventEmitter {
     }
   }
 
+  hasQueuedMessages(workspaceId: string, dispatchMode?: "tool-end" | "turn-end"): boolean {
+    return this.sessions.get(workspaceId.trim())?.hasQueuedMessages(dispatchMode) ?? false;
+  }
+
   async waitForPendingStreamErrorRecoveryDecision(workspaceId: string): Promise<void> {
     const session = this.sessions.get(workspaceId.trim());
     await session?.waitForPendingStreamErrorRecoveryDecision();


### PR DESCRIPTION
## Summary

Fix foreground sub-agent waits so they are sent to the background when a tool-end user message was already queued before the foreground wait registered.

## Background

The existing auto-backgrounding path was edge-triggered from message enqueue. If the user queued a message while a foreground task wait was already registered, the wait was rejected and the task continued in the background. If the user queued the message first and the agent later spawned a foreground task in the same step, the enqueue-time signal hit an empty waiter set and the foreground wait blocked until the child completed.

## Implementation

`AgentSession.hasQueuedMessages` now accepts an optional dispatch mode, and both the stream step-end callback and task wait registration use the same tool-end queue predicate. When a backgroundable foreground waiter registers, `TaskService` re-checks the requesting workspace's current tool-end queue state and reuses the existing `backgroundForegroundWaitsForWorkspace` path to mark and reject the wait.

## Risks

Low. The behavior is scoped to foreground waits that already opt into queue-triggered backgrounding, and the new check only fires for existing tool-end queued messages.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$9.72`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=9.72 -->
