### PR TITLE
🤖 fix: mark built-in workflow skills

### DIFF
--- a/src/node/builtinSkills/deep-research.md
+++ b/src/node/builtinSkills/deep-research.md
@@ -1,6 +1,6 @@
 ---
 name: deep-research
-description: Run a multi-source, adversarially verified research workflow.
+description: "[Workflow] Run a multi-source, adversarially verified research workflow."
 ---
 
 # Deep Research

--- a/src/node/builtinSkills/workflow-smoke.md
+++ b/src/node/builtinSkills/workflow-smoke.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-smoke
-description: Minimal built-in workflow fixture for validating skill-packaged workflow execution.
+description: "[Workflow] Minimal built-in workflow fixture for validating skill-packaged workflow execution."
 advertise: false
 ---
 

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -7,7 +7,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
     "SKILL.md": [
       "---",
       "name: deep-research",
-      "description: Run a multi-source, adversarially verified research workflow.",
+      'description: "[Workflow] Run a multi-source, adversarially verified research workflow."',
       "---",
       "",
       "# Deep Research",
@@ -7858,7 +7858,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
     "SKILL.md": [
       "---",
       "name: workflow-smoke",
-      "description: Minimal built-in workflow fixture for validating skill-packaged workflow execution.",
+      'description: "[Workflow] Minimal built-in workflow fixture for validating skill-packaged workflow execution."',
       "advertise: false",
       "---",
       "",

--- a/src/node/services/agentSkills/builtInWorkflowSkillDescriptions.test.ts
+++ b/src/node/services/agentSkills/builtInWorkflowSkillDescriptions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+
+import { getBuiltInSkillDefinitions, readBuiltInSkillFile } from "./builtInSkillDefinitions";
+
+function hasPackagedWorkflow(name: string): boolean {
+  try {
+    readBuiltInSkillFile(name, "workflow.js");
+    return true;
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("Built-in skill file not found:")) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+describe("built-in workflow skill descriptions", () => {
+  test("prefixes skills that ship a workflow script", () => {
+    const workflowSkills = getBuiltInSkillDefinitions().filter((pkg) =>
+      hasPackagedWorkflow(pkg.frontmatter.name)
+    );
+
+    expect(workflowSkills.length).toBeGreaterThan(0);
+    expect(
+      workflowSkills
+        .filter((pkg) => !pkg.frontmatter.description.startsWith("[Workflow]"))
+        .map((pkg) => pkg.frontmatter.name)
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Prefix built-in skills that package a workflow script with `[Workflow]` in their descriptions, then regenerate the built-in skill content snapshot.

## Implementation

- Updated `deep-research` and hidden `workflow-smoke` skill descriptions.
- Added a regression test that discovers built-in skills with packaged `workflow.js` files and asserts their descriptions start with `[Workflow]`.

## Validation

- `bun scripts/gen_builtin_skills.ts check`
- `bun test src/node/services/agentSkills/builtInWorkflowSkillDescriptions.test.ts`
- `bunx prettier --check src/node/services/agentSkills/builtInWorkflowSkillDescriptions.test.ts src/node/builtinSkills/deep-research.md src/node/builtinSkills/workflow-smoke.md src/node/services/agentSkills/builtInSkillContent.generated.ts`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`

## Risks

Low. This only changes built-in skill catalog metadata and adds a guard test; workflow script behavior is unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$2.35`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=2.35 -->
