### PR TITLE
🤖 fix: hide placeholder workflow report buttons

### DIFF
--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -6,6 +6,7 @@ import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import { APIContext } from "@/browser/contexts/API";
 import { WorkflowRunToolCall } from "@/browser/features/Tools/WorkflowRunToolCall";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
 import { lightweightMeta } from "@/browser/stories/meta.js";
 
 const meta = {
@@ -345,6 +346,63 @@ const taskActionsProps = {
 export const TaskActions: Story = {
   render: (args) => <WorkflowTaskActionsStory {...taskActionsProps} {...args} />,
   args: taskActionsProps,
+};
+
+const structuredOnlyTaskReportProps = {
+  args: {
+    script_path: TASK_ACTIONS_SCRIPT_PATH,
+    args: { topic: "structured-only workflow task" },
+    run_in_background: true,
+  },
+  status: "completed" as const,
+  result: {
+    status: "running" as const,
+    runId: "wfr_story_structured_only_task",
+    result: null,
+    run: {
+      ...taskActionsRun,
+      id: "wfr_story_structured_only_task",
+      events: [
+        { sequence: 1, type: "phase" as const, at: "2026-05-29T00:00:00.000Z", name: "scope" },
+        {
+          sequence: 2,
+          type: "task" as const,
+          at: "2026-05-29T00:00:01.000Z",
+          stepId: "scope-research-angles",
+          taskId: "cb803680e1",
+          status: "completed",
+          title: "Scope research angles",
+        },
+        {
+          sequence: 3,
+          type: "log" as const,
+          at: "2026-05-29T00:00:01.500Z",
+          message: "Scoped research angles",
+        },
+      ],
+      steps: [
+        {
+          stepId: "scope-research-angles",
+          inputHash: "sha256:scope-research-angles",
+          status: "completed" as const,
+          taskId: "cb803680e1",
+          startedAt: "2026-05-29T00:00:00.000Z",
+          completedAt: "2026-05-29T00:00:01.000Z",
+          result: {
+            reportMarkdown: STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN,
+            structuredOutput: {
+              summary: "Research angles scoped for downstream agents.",
+              followUpCount: 3,
+            },
+          },
+        },
+      ],
+    },
+  },
+} satisfies Parameters<typeof WorkflowRunToolCall>[0];
+
+export const StructuredOnlyTaskReport: Story = {
+  args: structuredOnlyTaskReportProps,
 };
 
 export const RunningForegroundDiscovered: Story = {

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -25,6 +25,7 @@ import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
 import { ThemeProvider } from "@/browser/contexts/ThemeContext";
 import { MessageListProvider } from "@/browser/features/Messages/MessageListContext";
 import { ToolNameProvider } from "@/browser/features/Messages/ToolNameContext";
+import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
 import { getAutoExpandPrefsKey } from "@/common/constants/storage";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 function createWorkflowTaskWorkspaceMetadata(workspaceId: string): FrontendWorkspaceMetadata {
@@ -655,6 +656,110 @@ describe("WorkflowRunToolCall", () => {
     await waitFor(() => {
       expect(document.querySelector('[role="dialog"]')).toBeNull();
     });
+  });
+
+  test("hides task report button for structured-only workflow reports", async () => {
+    const view = render(
+      <ThemeProvider forcedTheme="dark">
+        <TooltipProvider>
+          <WorkflowRunToolCall
+            args={{ name: "implementation", args: {}, run_in_background: true }}
+            status="executing"
+            result={{
+              status: "running",
+              runId: "wfr_structured_only_report",
+              result: null,
+              run: {
+                id: "wfr_structured_only_report",
+                workspaceId: "workspace-1",
+                workflow: {
+                  name: "implementation",
+                  description: "Implementation",
+                  scope: "built-in",
+                  executable: true,
+                },
+                source: "export default function workflow() { return null; }",
+                sourceHash: "sha256:test",
+                args: {},
+                status: "running",
+                createdAt: "2026-05-29T00:00:00.000Z",
+                updatedAt: "2026-05-29T00:00:01.000Z",
+                events: [
+                  {
+                    sequence: 1,
+                    type: "task",
+                    at: "2026-05-29T00:00:00.000Z",
+                    stepId: "scope",
+                    taskId: "task_structured_only",
+                    status: "completed",
+                  },
+                  {
+                    sequence: 2,
+                    type: "task",
+                    at: "2026-05-29T00:00:01.000Z",
+                    stepId: "manual-report",
+                    taskId: "task_placeholder_markdown",
+                    status: "completed",
+                  },
+                ],
+                steps: [
+                  {
+                    stepId: "scope",
+                    inputHash: "sha256:scope",
+                    status: "completed",
+                    taskId: "task_structured_only",
+                    startedAt: "2026-05-29T00:00:00.000Z",
+                    completedAt: "2026-05-29T00:00:01.000Z",
+                    result: {
+                      reportMarkdown: STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN,
+                      structuredOutput: { summary: "Scoped research angles" },
+                    },
+                  },
+                  {
+                    stepId: "manual-report",
+                    inputHash: "sha256:manual-report",
+                    status: "completed",
+                    taskId: "task_placeholder_markdown",
+                    startedAt: "2026-05-29T00:00:00.000Z",
+                    completedAt: "2026-05-29T00:00:01.000Z",
+                    result: {
+                      reportMarkdown: STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN,
+                    },
+                  },
+                ],
+              },
+            }}
+          />
+        </TooltipProvider>
+      </ThemeProvider>
+    );
+
+    expect(view.queryByLabelText("Open report for task_structured_only")).toBeNull();
+    expect(view.container.textContent).not.toContain(
+      STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN
+    );
+
+    const placeholderReportToggle = view.getByLabelText(
+      "Open report for task_placeholder_markdown"
+    );
+    expect(placeholderReportToggle.textContent).toBe("Report");
+    fireEvent.click(placeholderReportToggle);
+    await waitFor(() => {
+      const reportDialog = document.querySelector('[role="dialog"]');
+      expect(reportDialog?.textContent).toContain(STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN);
+    });
+    fireEvent.click(view.getByLabelText("Close"));
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+
+    const completedTaskControl = view.getByRole("button", {
+      name: "Expand structured output for workflow task task_structured_only",
+    });
+    fireEvent.click(completedTaskControl);
+
+    expect(view.container.textContent).toContain("summary");
+    expect(view.container.textContent).toContain("Scoped research angles");
   });
 
   test("labels task rows with the sub-agent title and falls back to stepId without one", () => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -13,6 +13,7 @@ import {
   useOptionalCommandRegistry,
   type CommandAction,
 } from "@/browser/contexts/CommandRegistryContext";
+import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
 import type {
   WorkflowRunEvent,
   WorkflowRunRecord,
@@ -191,10 +192,30 @@ function isWorkflowRunSuccessResult(
   return value != null && !isToolErrorResult(value);
 }
 
+// Schema-shaped workflow agent reports carry structuredOutput only; their placeholder
+// markdown exists for backend compatibility and should not create noisy Report buttons.
+function hasDisplayableReportMarkdown(
+  reportMarkdown: string,
+  result: { structuredOutput?: unknown } | null | undefined
+): boolean {
+  const trimmedReportMarkdown = reportMarkdown.trim();
+  if (trimmedReportMarkdown.length === 0) {
+    return false;
+  }
+  return !(
+    trimmedReportMarkdown === STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN &&
+    result?.structuredOutput !== undefined
+  );
+}
+
 function getReportMarkdown(value: unknown): string | null {
   if (value != null && typeof value === "object") {
-    const reportMarkdown = (value as Record<string, unknown>).reportMarkdown;
-    if (typeof reportMarkdown === "string" && reportMarkdown.trim().length > 0) {
+    const result = value as Record<string, unknown>;
+    const reportMarkdown = result.reportMarkdown;
+    if (
+      typeof reportMarkdown === "string" &&
+      hasDisplayableReportMarkdown(reportMarkdown, result)
+    ) {
       return reportMarkdown;
     }
   }
@@ -468,8 +489,9 @@ function getTaskReportMarkdown(
   steps: readonly WorkflowStepRecord[]
 ): string | null {
   const step = findTaskStepForEvent(event, steps);
-  const reportMarkdown = step?.result?.reportMarkdown;
-  return typeof reportMarkdown === "string" && reportMarkdown.trim().length > 0
+  const result = step?.result;
+  const reportMarkdown = result?.reportMarkdown;
+  return typeof reportMarkdown === "string" && hasDisplayableReportMarkdown(reportMarkdown, result)
     ? reportMarkdown
     : null;
 }

--- a/src/common/constants/workflowReports.ts
+++ b/src/common/constants/workflowReports.ts
@@ -1,0 +1,2 @@
+export const STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN =
+  "Structured workflow report submitted.";

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -41,6 +41,7 @@ import { createRuntime } from "@/node/runtime/runtimeFactory";
 import * as runtimeFactory from "@/node/runtime/runtimeFactory";
 import * as forkOrchestrator from "@/node/services/utils/forkOrchestrator";
 import { Ok, Err, type Result } from "@/common/types/result";
+import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
 import { defaultModel } from "@/common/utils/ai/models";
 import { enforceThinkingPolicy } from "@/common/utils/thinking/policy";
 import { DEFAULT_TASK_SETTINGS } from "@/common/types/tasks";
@@ -4356,7 +4357,7 @@ describe("TaskService", () => {
     );
 
     expect(report).toEqual({
-      reportMarkdown: "Structured workflow report submitted.",
+      reportMarkdown: STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN,
       structuredOutput: schemaOutput,
     });
   });
@@ -11113,7 +11114,7 @@ describe("TaskService", () => {
     expect(sendMessage).not.toHaveBeenCalled();
     expect(findWorkspaceInConfig(config, childId)?.taskStatus).toBe("reported");
     const report = await readSubagentReportArtifact(config.getSessionDir(parentId), childId);
-    expect(report?.reportMarkdown).toBe("Structured workflow report submitted.");
+    expect(report?.reportMarkdown).toBe(STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN);
     expect(report?.structuredOutput).toEqual({ reportMarkdown: "Done", title: null });
   });
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -10,6 +10,7 @@ import type { AIService } from "@/node/services/aiService";
 import type { WorkspaceService } from "@/node/services/workspaceService";
 import type { HistoryService } from "@/node/services/historyService";
 import type { InitStateManager } from "@/node/services/initStateManager";
+import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
 import { log } from "@/node/services/log";
 import {
   discoverAgentDefinitions,
@@ -7803,7 +7804,7 @@ export class TaskService {
         !Array.isArray(part.input)
       ) {
         return {
-          reportMarkdown: "Structured workflow report submitted.",
+          reportMarkdown: STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN,
           structuredOutput: part.input,
         };
       }


### PR DESCRIPTION
## Summary

Hide workflow task Report buttons when the only markdown is the structured-output compatibility placeholder. Real markdown reports still render the button/dialog, while structured-only workflow task results remain available via the structured output row expansion.

## Background

Schema-shaped workflow agent reports use a hardcoded markdown string only to satisfy existing backend report shape requirements. Showing that as a Report action adds noise without giving users useful content.

## Implementation

- Centralized the structured-only placeholder markdown constant.
- Treat that placeholder as non-displayable markdown in workflow run cards.
- Added UI coverage for structured-only task reports and a Storybook scenario for dogfooding the exact row layout.

## Validation

- `make static-check`
- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- Targeted TaskService schema-shaped workflow report tests
- Storybook dogfood at 900px desktop and 375px mobile widths; verified no Report text/button, no placeholder text, and no mobile overflow.

## Risks

Low. The change only suppresses a known placeholder markdown string in workflow-card display logic; real non-empty markdown reports still produce Report buttons.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `211065{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=13.76 -->
