### PR TITLE
🤖 fix: remove skill pill from slash suggestions

### DIFF
--- a/src/browser/features/ChatInput/CommandSuggestions.tsx
+++ b/src/browser/features/ChatInput/CommandSuggestions.tsx
@@ -67,29 +67,6 @@ function HighlightedText({
   return <span className={className}>{parts}</span>;
 }
 
-const SUGGESTION_KIND_BADGES = {
-  skill: { label: "Skill", className: "text-medium" },
-} satisfies Partial<
-  Record<NonNullable<SlashSuggestion["kind"]>, { label: string; className: string }>
->;
-
-function SuggestionKindBadge(props: { kind: SlashSuggestion["kind"] }) {
-  if (props.kind !== "skill") {
-    return null;
-  }
-  const badge = SUGGESTION_KIND_BADGES[props.kind];
-  return (
-    <span
-      className={cn(
-        "border-border-light shrink-0 rounded border px-1 py-0.5 text-[9px] tracking-wide uppercase",
-        badge.className
-      )}
-    >
-      {badge.label}
-    </span>
-  );
-}
-
 // Props interface
 interface CommandSuggestionsProps {
   suggestions: SlashSuggestion[];
@@ -308,7 +285,6 @@ export const CommandSuggestions: React.FC<CommandSuggestionsProps> = ({
           >
             <HighlightedText text={suggestion.display} query={highlightQuery} />
           </div>
-          <SuggestionKindBadge kind={suggestion.kind} />
           <div
             className={cn(
               "text-secondary min-w-0 truncate text-[11px]",


### PR DESCRIPTION
## Summary

Removes the `SKILL` text pill from chat slash command suggestions so skill entries and model one-shot aliases use the same row layout.

## Background

The skill rows already include scope context in their descriptions, and the extra pill made skill suggestions feel visually different from nearby model aliases without adding much value.

## Implementation

Deleted the slash suggestion badge component and its row render call. The underlying suggestion `kind` metadata is unchanged for future UI use.

## Validation

- `bun test src/browser/features/ChatInput/CommandSuggestions.test.tsx`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- `git diff --check`
- Storybook dogfood at desktop and mobile widths confirmed the `SKILL` text no longer appears in the slash suggestion list.

## Risks

Low. This is a presentational removal in the shared command suggestion row; selection behavior and suggestion data are unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `244294{MUX_COSTS_USD:-0}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=5.42 -->
