### PR TITLE
🤖 fix: improve heartbeat modal layout

### DIFF
--- a/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.stories.tsx
+++ b/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.stories.tsx
@@ -1,0 +1,150 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { waitFor, within } from "@storybook/test";
+
+import { APIProvider, type APIClient } from "@/browser/contexts/API";
+import {
+  WorkspaceContext,
+  type WorkspaceContext as WorkspaceContextValue,
+} from "@/browser/contexts/WorkspaceContext";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
+import { HEARTBEAT_DEFAULT_INTERVAL_MS } from "@/constants/heartbeat";
+
+import { WorkspaceHeartbeatModal } from "./WorkspaceHeartbeatModal";
+
+const WORKSPACE_ID = "ws-heartbeat-layout";
+
+const LONG_HEARTBEAT_MESSAGE = [
+  "Recurring needs-triage reconcile for coder/agent-tty.",
+  "Desired state: every open GitHub issue with `needs-triage` and without `triage:ongoing` / `triage:done` has exactly one triage workspace.",
+  "Actual-state reads before side effects; archive stale duplicate workspaces; launch missing ones; report the workspace IDs and next blocking decision.",
+].join(" ");
+
+type HeartbeatSettings = NonNullable<FrontendWorkspaceMetadata["heartbeat"]>;
+
+function createHeartbeatStoryApi(settings: HeartbeatSettings): APIClient {
+  return {
+    workspace: {
+      heartbeat: {
+        get: () => Promise.resolve(settings),
+        set: () => Promise.resolve({ success: true, data: undefined }),
+      },
+    },
+    config: {
+      getConfig: () =>
+        Promise.resolve({
+          heartbeatDefaultIntervalMs: HEARTBEAT_DEFAULT_INTERVAL_MS,
+          heartbeatDefaultPrompt: "Review current progress and decide whether to continue.",
+        }),
+    },
+  } as unknown as APIClient;
+}
+
+function createWorkspaceContextValue(): WorkspaceContextValue {
+  return {
+    workspaceMetadata: new Map<string, FrontendWorkspaceMetadata>(),
+    loading: false,
+    loaded: true,
+    loadError: null,
+    setWorkspaceMetadata: () => undefined,
+  } as unknown as WorkspaceContextValue;
+}
+
+function WorkspaceHeartbeatModalStoryShell(props: { children: ReactNode }) {
+  const settings: HeartbeatSettings = {
+    enabled: true,
+    intervalMs: 7 * 60_000,
+    contextMode: "compact",
+    message: LONG_HEARTBEAT_MESSAGE,
+  };
+
+  return (
+    <APIProvider client={createHeartbeatStoryApi(settings)}>
+      <WorkspaceContext.Provider value={createWorkspaceContextValue()}>
+        <div className="bg-background min-h-screen">{props.children}</div>
+      </WorkspaceContext.Provider>
+    </APIProvider>
+  );
+}
+
+function renderOpenModal() {
+  return (
+    <WorkspaceHeartbeatModalStoryShell>
+      <WorkspaceHeartbeatModal
+        workspaceId={WORKSPACE_ID}
+        open={true}
+        onOpenChange={() => {
+          // Keep the modal open for viewport snapshots.
+        }}
+      />
+    </WorkspaceHeartbeatModalStoryShell>
+  );
+}
+
+async function assertHeartbeatModalLoaded(canvasElement: HTMLElement): Promise<void> {
+  const body = within(canvasElement.ownerDocument.body);
+  const dialog = await body.findByRole("dialog", { name: "Configure heartbeat" });
+  const modal = within(dialog);
+
+  await waitFor(() => {
+    const messageField = modal.getByLabelText("Heartbeat message");
+    if (!(messageField instanceof HTMLTextAreaElement)) {
+      throw new Error("Expected heartbeat message field to be a textarea");
+    }
+    if (messageField.value !== LONG_HEARTBEAT_MESSAGE) {
+      throw new Error("Expected long heartbeat message to load before snapshotting");
+    }
+  });
+}
+
+const meta = {
+  title: "Components/WorkspaceHeartbeatModal",
+  component: WorkspaceHeartbeatModal,
+  args: {
+    workspaceId: WORKSPACE_ID,
+    open: true,
+    onOpenChange: () => undefined,
+  },
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { delay: 500 },
+  },
+} satisfies Meta<typeof WorkspaceHeartbeatModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const LongMessageDesktop: Story = {
+  globals: {
+    viewport: { value: "desktop", isRotated: false },
+  },
+  parameters: {
+    chromatic: {
+      modes: {
+        "dark-desktop": { theme: "dark", viewport: { width: 1280, height: 800 } },
+      },
+    },
+  },
+  render: renderOpenModal,
+  play: async ({ canvasElement }) => {
+    await assertHeartbeatModalLoaded(canvasElement);
+  },
+};
+
+export const LongMessageMobile: Story = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    chromatic: {
+      modes: {
+        "dark-mobile": { theme: "dark", viewport: { width: 375, height: 667 } },
+      },
+    },
+  },
+  render: renderOpenModal,
+  play: async ({ canvasElement }) => {
+    await assertHeartbeatModalLoaded(canvasElement);
+  },
+};

--- a/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.tsx
+++ b/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.tsx
@@ -196,8 +196,8 @@ export function WorkspaceHeartbeatModal(props: WorkspaceHeartbeatModalProps) {
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
+      <DialogContent className="max-h-[90vh] max-w-[calc(100vw-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0 sm:max-w-2xl lg:max-w-5xl">
+        <DialogHeader className="border-border border-b px-6 py-5 pr-12">
           <DialogTitle className="flex items-center gap-2">
             <HeartPulse className="h-5 w-5" />
             Configure heartbeat
@@ -209,128 +209,139 @@ export function WorkspaceHeartbeatModal(props: WorkspaceHeartbeatModalProps) {
             <Loader2 className="text-muted h-6 w-6 animate-spin" />
           </div>
         ) : (
-          <div className="space-y-4">
-            <p className="text-muted text-sm">
-              Schedule future background follow-ups for this workspace. Valid range:{" "}
-              {HEARTBEAT_MIN_INTERVAL_MINUTES}–{HEARTBEAT_MAX_INTERVAL_MINUTES} minutes. New
-              workspaces default to {HEARTBEAT_DEFAULT_INTERVAL_MINUTES} minutes unless you change
-              them.
-            </p>
+          <>
+            <div className="min-h-0 space-y-4 overflow-y-auto px-6 py-5">
+              <p className="text-muted max-w-3xl text-sm">
+                Schedule future background follow-ups for this workspace. Valid range:{" "}
+                {HEARTBEAT_MIN_INTERVAL_MINUTES}–{HEARTBEAT_MAX_INTERVAL_MINUTES} minutes. New
+                workspaces default to {HEARTBEAT_DEFAULT_INTERVAL_MINUTES} minutes unless you change
+                them.
+              </p>
 
-            <div className="border-border rounded-lg border p-4">
-              <div className="flex items-center justify-between gap-4">
-                <div className="min-w-0 flex-1">
-                  <div className="text-foreground text-sm font-medium">Enable heartbeats</div>
-                  <div className="text-muted mt-1 text-xs">
-                    Keep this workspace eligible for future background heartbeat follow-ups.
-                  </div>
-                </div>
-                <Switch
-                  checked={draftEnabled}
-                  onCheckedChange={(checked) => {
-                    setDraftEnabled(checked);
-                    setDraftDirty(true);
-                  }}
-                  disabled={isSaving}
-                  aria-label="Enable workspace heartbeats"
-                />
-              </div>
-
-              <div className="mt-4 flex items-center justify-between gap-4">
-                <label htmlFor="workspace-heartbeat-interval" className="min-w-0 flex-1">
-                  <div className="text-foreground text-sm font-medium">Interval</div>
-                  <div className="text-muted mt-1 text-xs">Heartbeat cadence in minutes.</div>
-                </label>
-                <div className="flex items-center gap-2">
-                  <Input
-                    id="workspace-heartbeat-interval"
-                    type="number"
-                    inputMode="numeric"
-                    min={HEARTBEAT_MIN_INTERVAL_MINUTES}
-                    max={HEARTBEAT_MAX_INTERVAL_MINUTES}
-                    step={1}
-                    value={draftIntervalMinutes}
-                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-                      setDraftIntervalMinutes(event.target.value);
-                      setDraftDirty(true);
-                    }}
-                    onBlur={handleIntervalBlur}
-                    disabled={isSaving}
-                    className="border-border-medium bg-background-secondary h-9 w-24 text-right"
-                    aria-label="Heartbeat interval in minutes"
-                  />
-                  <span className="text-muted text-sm">min</span>
-                </div>
-              </div>
-
-              <div className="mt-4 space-y-2">
-                <label htmlFor="workspace-heartbeat-context-mode" className="block">
-                  <div className="text-foreground text-sm font-medium">Context</div>
-                  <div className="text-muted mt-1 text-xs">
-                    Choose whether heartbeats reuse, compact, or reset request context.
-                  </div>
-                </label>
-                <select
-                  id="workspace-heartbeat-context-mode"
-                  value={draftContextMode}
-                  onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
-                    const nextContextMode =
-                      HEARTBEAT_CONTEXT_MODE_OPTIONS.find(
-                        (option) => option.value === event.target.value
-                      )?.value ?? HEARTBEAT_DEFAULT_CONTEXT_MODE;
-                    setDraftContextMode(nextContextMode);
-                    setDraftDirty(true);
-                  }}
-                  disabled={isSaving}
-                  className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent h-9 w-full rounded-md border px-3 text-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                  aria-label="Heartbeat context mode"
-                >
-                  {HEARTBEAT_CONTEXT_MODE_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-                <p className="text-muted text-xs">
-                  {getHeartbeatContextModeHelperText(draftContextMode)}
-                </p>
-              </div>
-
-              {draftEnabled && (
-                <div className="mt-4 space-y-2">
-                  <label htmlFor="workspace-heartbeat-message" className="block">
-                    <div className="text-foreground text-sm font-medium">Message</div>
-                    <div className="text-muted mt-1 text-xs">
-                      Leave empty to use the default heartbeat message.
+              {/* Keep custom heartbeat instructions in a roomy column so long prompts stay readable. */}
+              <div
+                className={
+                  draftEnabled
+                    ? "grid gap-4 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)]"
+                    : "grid gap-4"
+                }
+              >
+                <div className="border-border rounded-lg border p-4">
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="min-w-0 flex-1">
+                      <div className="text-foreground text-sm font-medium">Enable heartbeats</div>
+                      <div className="text-muted mt-1 text-xs">
+                        Keep this workspace eligible for future background heartbeat follow-ups.
+                      </div>
                     </div>
-                  </label>
-                  <textarea
-                    ref={messageTextareaRef}
-                    id="workspace-heartbeat-message"
-                    rows={4}
-                    value={draftMessage}
-                    onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-                      setDraftMessage(event.target.value);
-                      setDraftDirty(true);
-                    }}
-                    disabled={isSaving}
-                    className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent min-h-[120px] w-full resize-y rounded-md border p-3 text-sm leading-relaxed focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-                    placeholder={globalDefaultPrompt ?? HEARTBEAT_DEFAULT_MESSAGE_BODY}
-                    aria-label="Heartbeat message"
-                  />
+                    <Switch
+                      checked={draftEnabled}
+                      onCheckedChange={(checked) => {
+                        setDraftEnabled(checked);
+                        setDraftDirty(true);
+                      }}
+                      disabled={isSaving}
+                      aria-label="Enable workspace heartbeats"
+                    />
+                  </div>
+
+                  <div className="mt-4 flex items-center justify-between gap-4">
+                    <label htmlFor="workspace-heartbeat-interval" className="min-w-0 flex-1">
+                      <div className="text-foreground text-sm font-medium">Interval</div>
+                      <div className="text-muted mt-1 text-xs">Heartbeat cadence in minutes.</div>
+                    </label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        id="workspace-heartbeat-interval"
+                        type="number"
+                        inputMode="numeric"
+                        min={HEARTBEAT_MIN_INTERVAL_MINUTES}
+                        max={HEARTBEAT_MAX_INTERVAL_MINUTES}
+                        step={1}
+                        value={draftIntervalMinutes}
+                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                          setDraftIntervalMinutes(event.target.value);
+                          setDraftDirty(true);
+                        }}
+                        onBlur={handleIntervalBlur}
+                        disabled={isSaving}
+                        className="border-border-medium bg-background-secondary h-9 w-24 text-right"
+                        aria-label="Heartbeat interval in minutes"
+                      />
+                      <span className="text-muted text-sm">min</span>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 space-y-2">
+                    <label htmlFor="workspace-heartbeat-context-mode" className="block">
+                      <div className="text-foreground text-sm font-medium">Context</div>
+                      <div className="text-muted mt-1 text-xs">
+                        Choose whether heartbeats reuse, compact, or reset request context.
+                      </div>
+                    </label>
+                    <select
+                      id="workspace-heartbeat-context-mode"
+                      value={draftContextMode}
+                      onChange={(event: React.ChangeEvent<HTMLSelectElement>) => {
+                        const nextContextMode =
+                          HEARTBEAT_CONTEXT_MODE_OPTIONS.find(
+                            (option) => option.value === event.target.value
+                          )?.value ?? HEARTBEAT_DEFAULT_CONTEXT_MODE;
+                        setDraftContextMode(nextContextMode);
+                        setDraftDirty(true);
+                      }}
+                      disabled={isSaving}
+                      className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent h-9 w-full rounded-md border px-3 text-sm focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                      aria-label="Heartbeat context mode"
+                    >
+                      {HEARTBEAT_CONTEXT_MODE_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="text-muted text-xs">
+                      {getHeartbeatContextModeHelperText(draftContextMode)}
+                    </p>
+                  </div>
+                </div>
+
+                {draftEnabled && (
+                  <div className="border-border rounded-lg border p-4">
+                    <label htmlFor="workspace-heartbeat-message" className="block">
+                      <div className="text-foreground text-sm font-medium">Message</div>
+                      <div className="text-muted mt-1 text-xs">
+                        Leave empty to use the default heartbeat message.
+                      </div>
+                    </label>
+                    <textarea
+                      ref={messageTextareaRef}
+                      id="workspace-heartbeat-message"
+                      rows={10}
+                      value={draftMessage}
+                      onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                        setDraftMessage(event.target.value);
+                        setDraftDirty(true);
+                      }}
+                      disabled={isSaving}
+                      className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent mt-3 min-h-[240px] w-full resize-y rounded-md border p-3 text-sm leading-relaxed focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 lg:min-h-[320px]"
+                      placeholder={globalDefaultPrompt ?? HEARTBEAT_DEFAULT_MESSAGE_BODY}
+                      aria-label="Heartbeat message"
+                    />
+                  </div>
+                )}
+              </div>
+
+              {errorMessages.length > 0 && (
+                <div className="bg-danger-soft/10 text-danger-soft space-y-1 rounded-md p-3 text-sm">
+                  {errorMessages.map((message) => (
+                    <p key={message}>{message}</p>
+                  ))}
                 </div>
               )}
             </div>
 
-            {errorMessages.length > 0 && (
-              <div className="bg-danger-soft/10 text-danger-soft space-y-1 rounded-md p-3 text-sm">
-                {errorMessages.map((message) => (
-                  <p key={message}>{message}</p>
-                ))}
-              </div>
-            )}
-
-            <div className="flex justify-end gap-2">
+            <div className="border-border flex justify-end gap-2 border-t px-6 py-4">
               <Button variant="ghost" onClick={() => props.onOpenChange(false)} disabled={isSaving}>
                 Cancel
               </Button>
@@ -339,7 +350,7 @@ export function WorkspaceHeartbeatModal(props: WorkspaceHeartbeatModalProps) {
                 Save
               </Button>
             </div>
-          </div>
+          </>
         )}
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
## Summary

Improves the workspace heartbeat configuration modal so long custom messages are easier to read and edit. The dialog now expands wider on desktop, uses a two-column layout when heartbeats are enabled, keeps actions pinned in a footer, and adds desktop/mobile Storybook scenarios for the long-message layout.

## Background

The previous modal constrained the heartbeat message to a narrow field, making recurring background prompts hard to review before saving.

## Implementation

- Widened the heartbeat modal at larger breakpoints while preserving a constrained mobile width.
- Split heartbeat controls and the message editor into separate cards on desktop.
- Added a scrollable content region with a pinned footer for Save/Cancel actions.
- Added Storybook coverage for long-message desktop and mobile layouts.

## Validation

- `make static-check`
- `bun test src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `make fmt-check`
- Dogfooded in Storybook with `agent-browser` at 1280×800 and 375×667, capturing screenshots and a WebM recording.

## Risks

Low. This is scoped to the heartbeat settings modal presentation and Storybook coverage; existing save/load behavior is covered by the focused modal tests.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$12.69`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=12.69 -->
