### PR TITLE
🤖 ci: cache Playwright browsers on macOS

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -21,10 +21,15 @@ runs:
       id: cache-playwright
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ inputs.browsers }}
+        # Playwright uses OS-specific browser cache roots; include each default so
+        # macOS saves the cache instead of redownloading browsers on every run.
+        path: |
+          ~/.cache/ms-playwright
+          ~/Library/Caches/ms-playwright
+          ~/AppData/Local/ms-playwright
+        key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ inputs.browsers }}
         restore-keys: |
-          ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+          ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.playwright-version.outputs.version }}-
 
     - name: Install Playwright browsers
       if: steps.cache-playwright.outputs.cache-hit != 'true'

--- a/.github/workflows/perf-profiles.yml
+++ b/.github/workflows/perf-profiles.yml
@@ -28,6 +28,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xvfb
       - uses: ./.github/actions/setup-playwright
+        timeout-minutes: 10
       - name: Run perf profiling scenarios
         run: xvfb-run -a make test-e2e-perf
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -283,6 +283,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-mux
       - uses: ./.github/actions/setup-playwright
+        timeout-minutes: 10
       - run: make storybook-build
       - run: |
           bun x http-server storybook-static -p 6006 &
@@ -321,7 +322,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb
+      # Bound browser setup; Playwright downloads can stall after progress reaches 100%.
       - uses: ./.github/actions/setup-playwright
+        timeout-minutes: 10
       - name: Run tests
         if: matrix.os == 'linux'
         run: xvfb-run -a make test-e2e


### PR DESCRIPTION
## Summary

Cache Playwright browser installs on the correct OS-specific paths and bound the shared setup step so CI fails fast if a browser download stalls.

## Background

The macOS E2E job on PR #3610 got stuck inside `setup-playwright` after Chromium reached 100%. The existing cache path only covered Linux (`~/.cache/ms-playwright`), so macOS runners redownloaded browsers into `~/Library/Caches/ms-playwright` on every cache miss instead of saving/restoring that directory.

## Implementation

- Cache the Linux, macOS, and Windows Playwright browser cache roots in `.github/actions/setup-playwright`.
- Add `runner.arch` to the Playwright cache key so arm64/x64 browser caches stay separate.
- Add a 10-minute timeout to each workflow callsite of the shared setup action.

## Validation

- `make lint-actions`
- `make static-check`
- `git diff --check`

## Risks

Low. This only changes CI cache paths/keys and setup-step timeouts. The main behavior change is that a future stalled browser install fails in 10 minutes rather than blocking the workflow for hours.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `3451720{MUX_COSTS_USD:-unknown}`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=4.67 -->
