### PR TITLE
🤖 refactor: remove workflow agentType option

### DIFF
--- a/src/common/orpc/schemas/workflow.ts
+++ b/src/common/orpc/schemas/workflow.ts
@@ -244,6 +244,7 @@ export const WorkflowRunRecordSchema = z.object({
   sourceHash: z.string().min(1),
   args: JsonValueSchema,
   agentOutputSchemaRequired: z.boolean().optional(),
+  agentTypeAliasAllowed: z.boolean().optional(),
   parentWorkflow: WorkflowRunParentSchema.optional(),
   status: WorkflowRunStatusSchema,
   createdAt: IsoDateTimeSchema,

--- a/src/node/builtinSkills/workflow-authoring.md
+++ b/src/node/builtinSkills/workflow-authoring.md
@@ -163,7 +163,7 @@ Required options:
 - `id`: stable step ID used for replay; never derive from unstable ordering unless the input ordering is stable.
 - `schema`: optional JSON object schema. When present, the child reports schema-shaped data through `agent_report` and `agent()` returns that structured object directly. When omitted, `agent()` returns the child report markdown string.
 
-Workflow agents default to `exec`. Optional fields include `title`, `agentId` (preferred), legacy `agentType`, `model`, `thinking`, `isolation`, and `onRefusal`. Use `agentId: "explore"` for read-only research/discovery stages. `model` accepts the same aliases/full model strings as the UI, `thinking` accepts `off|low|medium|high|xhigh|max` or a numeric index, and `effort` is rejected to avoid ambiguous provider-specific behavior.
+Workflow agents default to `exec`. Optional fields include `title`, `agentId`, `model`, `thinking`, `isolation`, and `onRefusal`. Use `agentId: "explore"` for read-only research/discovery stages. `model` accepts the same aliases/full model strings as the UI, `thinking` accepts `off|low|medium|high|xhigh|max` or a numeric index, and `effort` is rejected to avoid ambiguous provider-specific behavior.
 
 ```js
 const scope = agent("Scope this topic", {

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -7676,7 +7676,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "- `id`: stable step ID used for replay; never derive from unstable ordering unless the input ordering is stable.",
       "- `schema`: optional JSON object schema. When present, the child reports schema-shaped data through `agent_report` and `agent()` returns that structured object directly. When omitted, `agent()` returns the child report markdown string.",
       "",
-      'Workflow agents default to `exec`. Optional fields include `title`, `agentId` (preferred), legacy `agentType`, `model`, `thinking`, `isolation`, and `onRefusal`. Use `agentId: "explore"` for read-only research/discovery stages. `model` accepts the same aliases/full model strings as the UI, `thinking` accepts `off|low|medium|high|xhigh|max` or a numeric index, and `effort` is rejected to avoid ambiguous provider-specific behavior.',
+      'Workflow agents default to `exec`. Optional fields include `title`, `agentId`, `model`, `thinking`, `isolation`, and `onRefusal`. Use `agentId: "explore"` for read-only research/discovery stages. `model` accepts the same aliases/full model strings as the UI, `thinking` accepts `off|low|medium|high|xhigh|max` or a numeric index, and `effort` is rejected to avoid ambiguous provider-specific behavior.',
       "",
       "```js",
       'const scope = agent("Scope this topic", {',

--- a/src/node/services/workflows/WorkflowRunStore.ts
+++ b/src/node/services/workflows/WorkflowRunStore.ts
@@ -50,6 +50,8 @@ export interface CreateWorkflowRunInput {
   source: string;
   args: unknown;
   agentOutputSchemaRequired?: boolean;
+  /** Existing persisted source snapshots may still contain agentType; new runs default to false. */
+  agentTypeAliasAllowed?: boolean;
   parentWorkflow?: WorkflowRunParent;
   now: string;
 }
@@ -114,6 +116,7 @@ export class WorkflowRunStore {
       sourceHash: hashSource(input.source),
       args: input.args,
       agentOutputSchemaRequired: input.agentOutputSchemaRequired ?? true,
+      agentTypeAliasAllowed: input.agentTypeAliasAllowed ?? false,
       ...(input.parentWorkflow != null ? { parentWorkflow: input.parentWorkflow } : {}),
       status: "pending",
       createdAt: input.now,
@@ -166,6 +169,7 @@ export class WorkflowRunStore {
           sourceHash: hashSource(input.source),
           args: input.args,
           agentOutputSchemaRequired: input.agentOutputSchemaRequired ?? true,
+          agentTypeAliasAllowed: input.agentTypeAliasAllowed ?? false,
           ...(input.parentWorkflow != null ? { parentWorkflow: input.parentWorkflow } : {}),
           status: "pending",
           createdAt: input.now,

--- a/src/node/services/workflows/WorkflowRunner.test.ts
+++ b/src/node/services/workflows/WorkflowRunner.test.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/await-thenable, @typescript-eslint/no-unsafe-argument, @typescript-eslint/require-await */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { describe, expect, mock, test } from "bun:test";
 import { QuickJSRuntimeFactory } from "@/node/services/ptc/quickjsRuntime";
 import { ForegroundWaitBackgroundedError } from "@/node/services/taskService";
@@ -138,7 +140,7 @@ describe("WorkflowRunner", () => {
     expect(seenSpecs[1]).toMatchObject({ id: "markdown" });
   });
 
-  test("new agent API maps agent, model, and thinking options", async () => {
+  test("new agent API maps agentId, model, and thinking options", async () => {
     using tmp = new DisposableTempDir("workflow-runner-agent-options");
     const store = new WorkflowRunStore({
       sessionDir: tmp.path,
@@ -151,7 +153,7 @@ describe("WorkflowRunner", () => {
       source: `export default function workflow({ agent }) {
   const result = agent("Verify claim", {
     id: "verify",
-    agentType: "exec",
+    agentId: "exec",
     model: "fable",
     thinking: "high",
   });
@@ -180,6 +182,84 @@ describe("WorkflowRunner", () => {
         thinkingLevel: "high",
       }),
     ]);
+  });
+
+  test("new agent API rejects legacy agentType option", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-agent-type-rejected");
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
+    await store.createRun({
+      id: "wfr_agent_type_rejected",
+      workspaceId: "workspace-1",
+      workflow: definition,
+      source: `export default function workflow({ agent }) {
+  agent("Verify claim", { id: "verify", agentType: "explore" });
+  return { reportMarkdown: "unreachable" };
+}
+`,
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    const runAgent = mock(async () => ({
+      taskId: "task_verify",
+      reportMarkdown: "verified",
+      structuredOutput: {},
+    }));
+    const runner = createRunner(store, { runAgent });
+
+    await expect(runner.run("wfr_agent_type_rejected")).rejects.toThrow(
+      "agent options.agentType is not supported; use options.agentId"
+    );
+    expect(runAgent).not.toHaveBeenCalled();
+  });
+
+  test("legacy runs still replay agentType source snapshots", async () => {
+    using tmp = new DisposableTempDir("workflow-runner-legacy-agent-type-replay");
+    const store = new WorkflowRunStore({
+      sessionDir: tmp.path,
+      staleLeaseMs: WORKFLOW_RUNNER_TEST_STALE_LEASE_MS,
+    });
+    await store.createRun({
+      id: "wfr_legacy_agent_type_replay",
+      workspaceId: "workspace-1",
+      workflow: definition,
+      source: `export default function workflow({ agent }) {
+  const result = agent("Verify claim", { id: "verify", agentType: "explore" });
+  return { reportMarkdown: result };
+}
+`,
+      args: {},
+      now: "2026-05-29T00:00:00.000Z",
+    });
+    const runFile = path.join(tmp.path, "workflows", "wfr_legacy_agent_type_replay", "run.json");
+    const persistedRun = JSON.parse(await fs.readFile(runFile, "utf-8")) as Record<string, unknown>;
+    delete persistedRun.agentTypeAliasAllowed;
+    await fs.writeFile(runFile, `${JSON.stringify(persistedRun, null, 2)}\n`, "utf-8");
+    const legacySpec = {
+      id: "verify",
+      prompt: "Verify claim",
+      agentId: "explore",
+      markdownOnly: true,
+    };
+    await store.recordStepCompleted("wfr_legacy_agent_type_replay", {
+      stepId: legacySpec.id,
+      inputHash: hashWorkflowStepInput(legacySpec.id, legacySpec),
+      taskId: "task_legacy_verify",
+      result: { taskId: "task_legacy_verify", reportMarkdown: "verified", structuredOutput: {} },
+      startedAt: "2026-05-29T00:00:00.500Z",
+      completedAt: "2026-05-29T00:00:00.750Z",
+    });
+    const runAgent = mock(async () => {
+      throw new Error("agent should replay");
+    });
+    const runner = createRunner(store, { runAgent });
+
+    await expect(runner.run("wfr_legacy_agent_type_replay")).resolves.toEqual({
+      reportMarkdown: "verified",
+    });
+    expect(runAgent).not.toHaveBeenCalled();
   });
 
   test("parallel runs agent thunks concurrently and returns ordered schema outputs", async () => {
@@ -1018,7 +1098,7 @@ describe("WorkflowRunner", () => {
       workspaceId: "workspace-1",
       workflow: definition,
       source: `export default function workflow({ agent, applyPatch }) {
-  agent("Implement the change", { id: "implement", agentType: "exec" });
+  agent("Implement the change", { id: "implement" });
   const patch = applyPatch({ id: "apply-implement", agentId: "implement" });
   return { reportMarkdown: patch.status + ":" + patch.taskId };
 }

--- a/src/node/services/workflows/WorkflowRunner.ts
+++ b/src/node/services/workflows/WorkflowRunner.ts
@@ -430,6 +430,9 @@ export class WorkflowRunner {
       }
       const ignoreStartedTaskIds = resumingInterruptedRun;
       const allowLegacyMissingOutputSchema = run.agentOutputSchemaRequired !== true;
+      // Runs persisted before agentType was removed lack this marker but may still resume their
+      // original source snapshot. New runs set it to false at creation and fail fast.
+      const allowLegacyAgentType = run.agentTypeAliasAllowed !== false;
       let backgrounded: Promise<void> | null = null;
       const markBackgrounded = async () => {
         leaseGuard.throwIfLost();
@@ -607,7 +610,7 @@ export class WorkflowRunner {
 
       let compiledSource: string;
       try {
-        compiledSource = compileWorkflowSource(run.source);
+        compiledSource = compileWorkflowSource(run.source, { allowLegacyAgentType });
       } catch (error) {
         leaseGuard.throwIfLost();
         await this.appendEvent(runId, {
@@ -2424,7 +2427,7 @@ function normalizeWorkflowResultForEvent(result: unknown): WorkflowResult {
   return WorkflowResultSchema.parse({ reportMarkdown });
 }
 
-function compileWorkflowSource(source: string): string {
+function compileWorkflowSource(source: string, options: { allowLegacyAgentType: boolean }): string {
   // Workflow scripts are evaluated as a script (not a module), so export
   // syntax must be rewritten away. Top-level named export declarations are
   // allowed so built-in workflows can expose pure helpers for direct unit
@@ -2450,6 +2453,7 @@ ${WORKFLOW_RUNTIME_STDLIB_SOURCE}
 let __muxParallelCollectingAgents = null;
 let __muxPipelineCollectingAgents = null;
 const __MUX_PARALLEL_AGENT_MARKER = "__muxParallelAgentMarker";
+const __MUX_ALLOW_LEGACY_AGENT_TYPE = ${options.allowLegacyAgentType ? "true" : "false"};
 function __muxParallel(thunks, options) {
   if (!Array.isArray(thunks)) {
     throw new Error("parallel requires an array of thunks");
@@ -2602,6 +2606,9 @@ function __muxAgent(prompt, options) {
     delete spec.schema;
   }
   if (Object.prototype.hasOwnProperty.call(spec, "agentType")) {
+    if (!__MUX_ALLOW_LEGACY_AGENT_TYPE) {
+      throw new Error("agent options.agentType is not supported; use options.agentId");
+    }
     spec.agentId = spec.agentType;
     delete spec.agentType;
   }


### PR DESCRIPTION
## Summary
Remove the legacy `agentType` workflow-agent option so workflow authors must use `agentId` consistently.

## Background
The workflow authoring skill still advertised `legacy agentType` as an optional alias. This removes the alias from new workflow runs to avoid two names for the same workflow-agent selector.

## Implementation
- Reject new `agent(..., { agentType: ... })` calls with a clear error directing authors to `agentId`.
- Preserve replay/resume compatibility for persisted workflow run source snapshots that already contain `agentType`, including current-schema runs created before this change.
- Store a new-run marker so runs created after this change reject the alias, while older run records that lack the marker can still replay.
- Keep `agentId`, `model`, and `thinking` normalization unchanged.
- Update workflow-authoring skill content and tests to use `agentId` only.

## Validation
- `bun test src/node/services/workflows/WorkflowRunner.test.ts`
- `bun test src/node/services/workflows/WorkflowRunStore.test.ts`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `make fmt-check`
- `make static-check`
- `git diff --check`

## Risks
Low. New workflow runs intentionally fail on the legacy `agentType` alias, while existing persisted runs keep enough compatibility to replay or resume their original source snapshots.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$2.84`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=2.84 -->
