### PR TITLE
🤖 fix: surface workflow progress to awaiting agents

### DIFF
--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -756,6 +756,31 @@ export const TaskAwaitToolCompletedResultSchema = z
   })
   .strict();
 
+export const WorkflowProgressPhaseSummarySchema = z
+  .object({
+    name: z.string().min(1),
+    at: z.string(),
+  })
+  .strict();
+
+export const WorkflowProgressStepCountsSchema = z
+  .object({
+    started: z.number().int().nonnegative(),
+    completed: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    interrupted: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export const WorkflowProgressSummarySchema = z
+  .object({
+    name: z.string().min(1),
+    latestPhase: WorkflowProgressPhaseSummarySchema.optional(),
+    lastProgressAt: z.string().optional(),
+    stepCounts: WorkflowProgressStepCountsSchema,
+  })
+  .strict();
+
 export const TaskAwaitToolActiveResultSchema = z
   .object({
     status: z.enum([
@@ -772,6 +797,7 @@ export const TaskAwaitToolActiveResultSchema = z
     output: z.string().optional(),
     elapsed_ms: z.number().optional(),
     note: z.string().optional(),
+    workflowProgress: WorkflowProgressSummarySchema.optional(),
   })
   .strict();
 
@@ -1046,6 +1072,7 @@ export const TaskListToolTaskSchema = z
     workspaceId: z.string().optional(),
     modelString: z.string().optional(),
     thinkingLevel: TaskListThinkingLevelSchema.optional(),
+    workflowProgress: WorkflowProgressSummarySchema.optional(),
     depth: z.number().int().min(0),
   })
   .strict();
@@ -1877,6 +1904,7 @@ export const TOOL_DEFINITIONS = {
       "This is ideal for independent lanes (variants) or any case where per-result work exists. " +
       "Set min_completed higher (up to the number of awaited tasks) when you genuinely need more before proceeding — e.g. best-of-N synthesis that must compare every candidate should pass min_completed equal to the batch size. " +
       "The result always includes every task complete at the moment it returns, plus current status for the rest; not-yet-completed tasks keep running and stay re-awaitable on a later call. " +
+      "Active workflow-run results may include compact `workflowProgress` (latest phase, last progress timestamp, and step counts); use that to see that phased progress is still happening instead of treating elapsed time alone as a hang. " +
       "You always get per-task results (like Promise.allSettled), just possibly before every task has finished. " +
       "Possible statuses: completed, queued, starting, running, backgrounded, awaiting_report, interrupted, not_found, invalid_scope, error. " +
       "Bash task outputs may be automatically filtered; when this happens, check each result's note for details and (if available) where the full output was saved.",
@@ -1895,6 +1923,7 @@ export const TOOL_DEFINITIONS = {
       "List descendant tasks for the current workspace, including status + metadata. " +
       "This includes sub-agent tasks, background bash tasks, and top-level workflow runs, but omits workflow-owned sub-agents/background bash tasks whose reports are consumed through parent workflow runs. " +
       "Use this after compaction, interruptions, or an app restart to rediscover active tasks and resumable workflow runs (statuses interrupted/failed; resume with workflow_resume). " +
+      "Workflow rows may include compact `workflowProgress` so callers can see the latest phase before deciding whether to await, resume, or leave the run alone. " +
       "Archived non-actionable child workspace tasks are hidden by default; pass includeArchived: true to inspect them. " +
       "This is a discovery tool, NOT a waiting mechanism. If the current request actually depends on a task's output, call task_await with the specific task IDs you need; do not await all active tasks just because they appear here.",
     schema: TaskListToolArgsSchema,

--- a/src/node/services/tools/task_await.test.ts
+++ b/src/node/services/tools/task_await.test.ts
@@ -1080,6 +1080,101 @@ describe("task_await tool", () => {
     });
   });
 
+  it("surfaces compact workflow progress for active workflow awaits", async () => {
+    using tempDir = new TestTempDir("test-task-await-tool-workflow-progress");
+    const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });
+    const runningRun = {
+      ...createWorkflowRun("running", [
+        {
+          sequence: 1,
+          type: "status" as const,
+          at: "2026-01-01T00:00:01.000Z",
+          status: "running" as const,
+        },
+        {
+          sequence: 2,
+          type: "phase" as const,
+          at: "2026-01-01T00:00:02.000Z",
+          name: "verify",
+          details: { claimCount: 2 },
+        },
+        {
+          sequence: 3,
+          type: "task" as const,
+          at: "2026-01-01T00:00:03.000Z",
+          stepId: "verify-1",
+          taskId: "child-task-id",
+          title: "Verify claim 1",
+          status: "started",
+        },
+        {
+          sequence: 4,
+          type: "log" as const,
+          at: "2026-01-01T00:00:04.000Z",
+          message: "Verification half done",
+          data: { verified: 1 },
+        },
+      ]),
+      steps: [
+        {
+          stepId: "scope",
+          inputHash: "sha256:scope",
+          status: "completed" as const,
+          taskId: "scope-task",
+          startedAt: "2026-01-01T00:00:01.000Z",
+          completedAt: "2026-01-01T00:00:02.000Z",
+        },
+        {
+          stepId: "verify-1",
+          inputHash: "sha256:verify-1",
+          status: "started" as const,
+          taskId: "child-task-id",
+          startedAt: "2026-01-01T00:00:03.000Z",
+        },
+      ],
+    };
+
+    const taskService = {
+      listActiveDescendantAgentTaskIds: mock(() => []),
+      isDescendantAgentTask: mock(() => Promise.resolve(false)),
+      waitForAgentReport: mock(() => {
+        throw new Error("workflow run IDs should not be treated as agent tasks");
+      }),
+    } as unknown as TaskService;
+    const workflowService = {
+      getRun: mock(() => Promise.resolve(runningRun)),
+    };
+    const tool = createTaskAwaitTool({
+      ...baseConfig,
+      taskService,
+      workflowService: workflowService as unknown as TestWorkflowService,
+    });
+
+    const result: unknown = await Promise.resolve(
+      tool.execute!({ task_ids: ["wfr_demo"], timeout_secs: 0 }, mockToolCallOptions)
+    );
+
+    const workflowResult = result as { results: Array<Record<string, unknown>> };
+    expect(workflowResult.results).toHaveLength(1);
+    expect(workflowResult.results[0]).toMatchObject({
+      status: "running",
+      taskId: "wfr_demo",
+      workflowProgress: {
+        name: "demo",
+        latestPhase: {
+          name: "verify",
+          at: "2026-01-01T00:00:02.000Z",
+        },
+        lastProgressAt: "2026-01-01T00:00:04.000Z",
+        stepCounts: { started: 1, completed: 1, failed: 0, interrupted: 0 },
+      },
+    });
+    expect(String(workflowResult.results[0]?.note)).toContain("Latest phase: verify");
+    expect(JSON.stringify(workflowResult.results[0])).not.toContain("claimCount");
+    expect(JSON.stringify(workflowResult.results[0])).not.toContain("recentEvents");
+    expect(JSON.stringify(workflowResult.results[0])).not.toContain("child-task-id");
+  });
+
   it("discovers active workflow runs when task_ids is omitted", async () => {
     using tempDir = new TestTempDir("test-task-await-tool-workflow-discovery");
     const baseConfig = createTestToolConfig(tempDir.path, { workspaceId: "parent-workspace" });

--- a/src/node/services/tools/task_await.ts
+++ b/src/node/services/tools/task_await.ts
@@ -29,6 +29,7 @@ import {
   isWorkspaceTurnTaskId,
   type WorkspaceTurnTaskStatus,
 } from "@/node/services/taskHandleStore";
+import { buildWorkflowProgressSummary, formatWorkflowProgressNote } from "./workflowProgress";
 import {
   ForegroundWaitBackgroundedError,
   type AgentTaskStatus,
@@ -165,6 +166,8 @@ function buildWorkflowAwaitResult(run: WorkflowRunRecord) {
     taskId: run.id,
     ...withElapsedMs(getWorkflowRunElapsedMs(run)),
   };
+  const workflowProgress = buildWorkflowProgressSummary(run);
+  const workflowProgressField = workflowProgress == null ? {} : { workflowProgress };
 
   switch (run.status) {
     case "completed": {
@@ -197,19 +200,25 @@ function buildWorkflowAwaitResult(run: WorkflowRunRecord) {
       return {
         status: "queued" as const,
         ...base,
-        note: `Workflow ${run.workflow.name} is queued.`,
+        ...workflowProgressField,
+        note: formatWorkflowProgressNote(`Workflow ${run.workflow.name} is queued.`, run),
       };
     case "backgrounded":
       return {
         status: "backgrounded" as const,
         ...base,
-        note: `Workflow ${run.workflow.name} is backgrounded. Use task_await to monitor progress.`,
+        ...workflowProgressField,
+        note: formatWorkflowProgressNote(
+          `Workflow ${run.workflow.name} is backgrounded. Use task_await to monitor progress.`,
+          run
+        ),
       };
     case "running":
       return {
         status: "running" as const,
         ...base,
-        note: `Workflow ${run.workflow.name} is still running.`,
+        ...workflowProgressField,
+        note: formatWorkflowProgressNote(`Workflow ${run.workflow.name} is still running.`, run),
       };
   }
 }

--- a/src/node/services/tools/task_list.test.ts
+++ b/src/node/services/tools/task_list.test.ts
@@ -531,9 +531,39 @@ describe("task_list tool", () => {
 
     const listDescendantAgentTasks = mock(() => []);
     const taskService = { listDescendantAgentTasks } as unknown as TaskService;
+    const activeRun = {
+      ...buildWorkflowRun("wfr_active", "backgrounded"),
+      events: [
+        {
+          sequence: 1,
+          type: "phase" as const,
+          at: "2026-05-29T00:00:01.000Z",
+          name: "verify",
+          details: { claimCount: 2 },
+        },
+        {
+          sequence: 2,
+          type: "task" as const,
+          at: "2026-05-29T00:00:02.000Z",
+          stepId: "verify-1",
+          taskId: "child-task-id",
+          title: "Verify claim 1",
+          status: "started",
+        },
+      ],
+      steps: [
+        {
+          stepId: "verify-1",
+          inputHash: "sha256:verify-1",
+          status: "started" as const,
+          taskId: "child-task-id",
+          startedAt: "2026-05-29T00:00:02.000Z",
+        },
+      ],
+    };
     const listRuns = mock(() =>
       Promise.resolve([
-        buildWorkflowRun("wfr_active", "backgrounded"),
+        activeRun,
         // Terminal/interrupted runs are excluded by the default (active) status filter.
         buildWorkflowRun("wfr_done", "completed"),
         buildWorkflowRun("wfr_stopped", "interrupted"),
@@ -561,10 +591,21 @@ describe("task_list tool", () => {
           parentWorkspaceId: "root-workspace",
           title: "deep-research",
           createdAt: "2026-05-29T00:00:00.000Z",
+          workflowProgress: {
+            name: "deep-research",
+            latestPhase: {
+              name: "verify",
+              at: "2026-05-29T00:00:01.000Z",
+            },
+            lastProgressAt: "2026-05-29T00:00:02.000Z",
+            stepCounts: { started: 1, completed: 0, failed: 0, interrupted: 0 },
+          },
           depth: 1,
         },
       ],
     });
+    expect(JSON.stringify(result)).not.toContain("child-task-id");
+    expect(JSON.stringify(result)).not.toContain("claimCount");
   });
 
   it("discovers resumable workflow runs without querying agent tasks", async () => {

--- a/src/node/services/tools/task_list.ts
+++ b/src/node/services/tools/task_list.ts
@@ -16,6 +16,7 @@ import { Config } from "@/node/config";
 import { log } from "@/node/services/log";
 import type { WorkspaceTurnTaskStatus } from "@/node/services/taskHandleStore";
 
+import { buildWorkflowProgressSummary } from "./workflowProgress";
 import { toBashTaskId } from "./taskId";
 import { parseToolResult, requireTaskService, requireWorkspaceId } from "./toolUtils";
 
@@ -244,12 +245,14 @@ export const createTaskListTool: ToolFactory = (config: ToolConfiguration) => {
           ) {
             continue;
           }
+          const workflowProgress = buildWorkflowProgressSummary(parsed.data);
           tasks.push({
             taskId: parsed.data.id,
             status: parsed.data.status,
             parentWorkspaceId: workspaceId,
             title: parsed.data.workflow.name,
             createdAt: parsed.data.createdAt,
+            ...(workflowProgress != null ? { workflowProgress } : {}),
             depth: 1,
           });
         }

--- a/src/node/services/tools/workflowProgress.ts
+++ b/src/node/services/tools/workflowProgress.ts
@@ -1,0 +1,63 @@
+import type {
+  WorkflowRunEvent,
+  WorkflowRunRecord,
+  WorkflowStepStatus,
+} from "@/common/types/workflow";
+import assert from "@/common/utils/assert";
+
+type WorkflowProgressEvent = Exclude<WorkflowRunEvent, { type: "status" | "result" }>;
+
+function isWorkflowProgressEvent(event: WorkflowRunEvent): event is WorkflowProgressEvent {
+  return event.type !== "status" && event.type !== "result";
+}
+
+function getWorkflowStepCounts(steps: ReadonlyArray<{ status: WorkflowStepStatus }>) {
+  const counts: Record<WorkflowStepStatus, number> = {
+    started: 0,
+    completed: 0,
+    failed: 0,
+    interrupted: 0,
+  };
+
+  for (const step of steps) {
+    counts[step.status] += 1;
+  }
+
+  return counts;
+}
+
+export function buildWorkflowProgressSummary(run: WorkflowRunRecord) {
+  assert(run.workflow.name.length > 0, "buildWorkflowProgressSummary: workflow name is required");
+
+  const progressEvents = run.events.filter(isWorkflowProgressEvent);
+  const latestPhase = run.events.findLast((event) => event.type === "phase");
+  const latestProgressEvent = progressEvents.at(-1);
+
+  if (latestPhase == null && progressEvents.length === 0 && run.steps.length === 0) {
+    return undefined;
+  }
+
+  return {
+    name: run.workflow.name,
+    ...(latestPhase != null
+      ? {
+          latestPhase: {
+            name: latestPhase.name,
+            at: latestPhase.at,
+          },
+        }
+      : {}),
+    ...(latestProgressEvent != null ? { lastProgressAt: latestProgressEvent.at } : {}),
+    stepCounts: getWorkflowStepCounts(run.steps),
+  };
+}
+
+export function formatWorkflowProgressNote(baseNote: string, run: WorkflowRunRecord): string {
+  assert(baseNote.length > 0, "formatWorkflowProgressNote: base note is required");
+
+  const latestPhase = run.events.findLast((event) => event.type === "phase");
+  if (latestPhase == null) {
+    return baseNote;
+  }
+  return `${baseNote} Latest phase: ${latestPhase.name}.`;
+}


### PR DESCRIPTION
Summary

Expose a compact workflow progress summary to agents using task_list or task_await so long-running phased workflows are recognizable as active instead of looking stuck based only on elapsed time.

Background

Workflow runs already persist phase/progress events for the UI, but model-facing task_list/task_await results only reported a coarse running/backgrounded status. That made it too easy for a parent agent to infer a healthy workflow was hung and consider terminating it.

Implementation

- Add a shared workflowProgress summary builder for task tool outputs.
- Include latest phase, last progress timestamp, and step status counts for active workflow rows/results.
- Keep the payload intentionally high-level: no recent events, no phase details, no full run record/source, and no workflow-owned child task IDs.
- Update task tool schemas and descriptions to explain that workflowProgress is a liveness signal for phased workflows.

Validation

- bun test src/node/services/tools/task_await.test.ts src/node/services/tools/task_list.test.ts
- make typecheck
- MUX_ESLINT_CONCURRENCY=1 make lint
- make fmt-check
- MUX_ESLINT_CONCURRENCY=1 make static-check

Risks

Low. The change only adds optional fields to task tool outputs for workflow runs and keeps completed/error payloads unchanged. The main risk is model behavior sensitivity to new metadata, mitigated by keeping the payload compact and intentionally non-detailed.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$18.06`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=18.06 -->
