### PR TITLE
🤖 fix: apply default budget for model goals

### DIFF
--- a/src/common/utils/goals/resolveGoalSetIntent.test.ts
+++ b/src/common/utils/goals/resolveGoalSetIntent.test.ts
@@ -40,10 +40,25 @@ describe("resolveModelGoalSetIntent", () => {
     expect(intent.turnCap).toBe(8);
   });
 
-  test("honors no-budget defaults for model tools without treating null as explicit clear", () => {
+  test("applies the positive budget default even when user-authored goals may omit budgets", () => {
     const intent = resolveModelGoalSetIntent(
       { objective: "ship", budgetCents: null, turnCap: null },
       { ...defaults, alwaysRequireExplicitBudget: false, defaultTurnCap: null }
+    );
+
+    expect(intent.budgetCents).toBe(500);
+    expect(intent.turnCap).toBeNull();
+  });
+
+  test("resolves to unbounded only when effective defaults have no positive budget or turn cap", () => {
+    const intent = resolveModelGoalSetIntent(
+      { objective: "ship", budgetCents: null, turnCap: null },
+      {
+        ...defaults,
+        defaultBudgetCents: 0,
+        defaultTurnCap: null,
+        alwaysRequireExplicitBudget: false,
+      }
     );
 
     expect(intent.budgetCents).toBeNull();

--- a/src/common/utils/goals/resolveGoalSetIntent.ts
+++ b/src/common/utils/goals/resolveGoalSetIntent.ts
@@ -101,6 +101,8 @@ export function resolveGoalSetIntent(
  * providers. For agent-created goals, `null` must therefore mean "use the
  * effective defaults" rather than the UI meaning "the user explicitly cleared
  * this bound"; otherwise a model could accidentally create an unbounded goal.
+ * The budget default applies even when user-authored forms allow omitted
+ * budgets to mean "no budget" — a model omission is not an explicit user clear.
  */
 export function resolveModelGoalSetIntent(
   input: GoalSetIntentInput,
@@ -110,9 +112,7 @@ export function resolveModelGoalSetIntent(
   const budgetCents =
     input.budgetCents != null
       ? normalizeGoalBudgetCents(input.budgetCents)
-      : defaults.alwaysRequireExplicitBudget
-        ? normalizeGoalBudgetCents(defaults.defaultBudgetCents)
-        : null;
+      : normalizeGoalBudgetCents(defaults.defaultBudgetCents);
   const turnCap = input.turnCap ?? defaults.defaultTurnCap;
 
   return {

--- a/src/node/services/tools/goal.test.ts
+++ b/src/node/services/tools/goal.test.ts
@@ -158,6 +158,27 @@ describe("goal tools", () => {
     expect(result).toMatchObject({ goal: { budgetCents: 450, turnCap: 3 } });
   });
 
+  test("set_goal uses positive default budget even when omitted user budgets are allowed", async () => {
+    const tool = createSetGoalTool({
+      cwd: "/tmp",
+      runtimeTempDir: "/tmp",
+      runtime: inertRuntime,
+      workspaceId,
+      goalService,
+      goalDefaults: {
+        defaultBudgetCents: 650,
+        defaultTurnCap: null,
+        alwaysRequireExplicitBudget: false,
+      },
+    });
+
+    const result: unknown = await Promise.resolve(
+      tool.execute!({ objective: "Use global budget default" }, mockToolCallOptions)
+    );
+
+    expect(result).toMatchObject({ goal: { budgetCents: 650, turnCap: null } });
+  });
+
   test("set_goal accepts explicit positive budget and turn cap", async () => {
     const tool = createSetGoalTool({
       cwd: "/tmp",

--- a/src/node/services/tools/set_goal.ts
+++ b/src/node/services/tools/set_goal.ts
@@ -42,7 +42,7 @@ export const createSetGoalTool: ToolFactory = (config) => {
       assertResolvedModelGoalBounds(resolved);
       if (resolved.budgetCents == null && resolved.turnCap == null) {
         throw new Error(
-          "set_goal requires a budget or turn cap for model-created goals. Ask the user to provide a budget/turn cap or configure workspace goal defaults."
+          "set_goal requires a budget or turn cap for model-created goals. Ask the user to provide one, or configure a positive effective default goal budget/turn cap."
         );
       }
 


### PR DESCRIPTION
## Summary

Model-created `set_goal` calls now inherit the effective positive default goal budget even when user-authored goal forms allow omitted budgets to mean “no budget”. This prevents an omitted model budget/turn cap from unexpectedly resolving to an unbounded goal and failing before the workspace/global defaults can apply.

## Background

The `set_goal` tool description says omitted or null budget/turn fields use the effective workspace goal defaults. In practice, the model-specific resolver still respected `alwaysRequireExplicitBudget: false` like user-facing forms do, so a model call with omitted bounds could resolve to no budget and no turn cap and trip the safety guard.

## Implementation

- Updated `resolveModelGoalSetIntent` so omitted/null model budgets always use the positive effective default budget when one exists.
- Kept the safety guard for configurations whose effective defaults truly have no positive budget and no turn cap.
- Clarified the guard error message and added coverage for the model-tool behavior.

## Validation

- `bun test src/common/utils/goals/resolveGoalSetIntent.test.ts src/node/services/tools/goal.test.ts`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`

## Risks

Low. This only changes model-authored goal default resolution; user-authored goal creation still uses the existing tri-state semantics where blank budget fields can mean no budget when that setting is configured.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$3.93`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=3.93 -->
