### PR TITLE
feat: add HeartbeatToolCall transcript card

### DIFF
--- a/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
@@ -63,7 +63,10 @@ export const ScheduledEnabled: Story = {
   },
 };
 
-/** set · long cadence that compacts context before each check-in. */
+/**
+ * set · long cadence that compacts context first, with no custom message — exercises
+ * the default-prompt fallback (the common case, since `message` is only stored when set).
+ */
 export const LongCadenceCompact: Story = {
   args: {
     args: { action: "set", enabled: true, intervalMs: 2 * 3_600_000, contextMode: "compact" },
@@ -73,12 +76,7 @@ export const LongCadenceCompact: Story = {
       success: true,
       action: "set",
       configured: true,
-      settings: {
-        enabled: true,
-        intervalMs: 2 * 3_600_000,
-        contextMode: "compact",
-        message: HEARTBEAT_DEFAULT_MESSAGE_BODY,
-      },
+      settings: { enabled: true, intervalMs: 2 * 3_600_000, contextMode: "compact" },
       summary: "Heartbeat is enabled for this workspace at 2 hours.",
     },
   },

--- a/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
@@ -221,12 +221,38 @@ export const Executing: Story = {
   },
 };
 
-/** Error · interval outside the supported range. */
-export const ErrorOutOfRange: Story = {
+/**
+ * Error · a reachable failure result. Out-of-range intervals are rejected by the tool
+ * schema before this card renders (they route to GenericToolCall), so the card's ErrorBox
+ * is exercised here with valid args and a server-side failure.
+ */
+export const ErrorResult: Story = {
   args: {
-    args: { action: "set", intervalMs: 30_000 },
+    args: { action: "set", enabled: true, intervalMs: 30 * 60_000 },
     status: "failed",
     defaultExpanded: true,
-    result: { success: false, error: "intervalMs must be between 5 minutes and 24 hours." },
+    result: {
+      success: false,
+      error: "Failed to update heartbeat settings: workspace configuration is unavailable.",
+    },
+  },
+};
+
+/**
+ * Interrupted before the result arrived (no settings/error/executing state). The expanded
+ * body falls back to the requested args instead of going blank — the generic renderer used
+ * to surface the args here.
+ */
+export const Interrupted: Story = {
+  args: {
+    args: {
+      action: "set",
+      enabled: true,
+      intervalMs: 2 * 3_600_000,
+      contextMode: "compact",
+      message: "Watch the long-running migration and report when it finishes.",
+    },
+    status: "interrupted",
+    defaultExpanded: true,
   },
 };

--- a/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { HeartbeatToolCall } from "@/browser/features/Tools/HeartbeatToolCall";
+import { CHROMATIC_DISABLED, lightweightMeta, StoryUiShell } from "@/browser/stories/meta.js";
+import { HEARTBEAT_DEFAULT_MESSAGE_BODY } from "@/constants/heartbeat";
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Chat/Tools/Heartbeat",
+  component: HeartbeatToolCall,
+  parameters: {
+    ...lightweightMeta.parameters,
+    // The repo-wide Chromatic snapshot budget (tests/ui/storybook/budget.test.ts) is
+    // already at its ceiling, so these states stay out of paid visual snapshots. They
+    // still render under local Storybook and the CI Storybook test-runner smoke pass.
+    // Flip to CHROMATIC_SINGLE_MODE once the budget is raised to add regression coverage.
+    chromatic: CHROMATIC_DISABLED,
+  },
+  decorators: [
+    (Story) => (
+      <StoryUiShell>
+        <div className="bg-background p-6">
+          <div className="w-full max-w-2xl">
+            <Story />
+          </div>
+        </div>
+      </StoryUiShell>
+    ),
+  ],
+} satisfies Meta<typeof HeartbeatToolCall>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const TASK_PROMPT =
+  "Check the CI run for the auth refactor. If it's green, open the PR; if it's red, " +
+  "summarize the first failure and stop.";
+
+/** set · enabled with a custom task prompt (expanded to show the full schedule). */
+export const ScheduledEnabled: Story = {
+  args: {
+    args: {
+      action: "set",
+      enabled: true,
+      intervalMs: 30 * 60_000,
+      contextMode: "normal",
+      message: TASK_PROMPT,
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      success: true,
+      action: "set",
+      configured: true,
+      settings: {
+        enabled: true,
+        intervalMs: 30 * 60_000,
+        contextMode: "normal",
+        message: TASK_PROMPT,
+      },
+      summary: "Heartbeat is enabled for this workspace at 30 minutes.",
+    },
+  },
+};
+
+/** set · long cadence that compacts context before each check-in. */
+export const LongCadenceCompact: Story = {
+  args: {
+    args: { action: "set", enabled: true, intervalMs: 2 * 3_600_000, contextMode: "compact" },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      success: true,
+      action: "set",
+      configured: true,
+      settings: {
+        enabled: true,
+        intervalMs: 2 * 3_600_000,
+        contextMode: "compact",
+        message: HEARTBEAT_DEFAULT_MESSAGE_BODY,
+      },
+      summary: "Heartbeat is enabled for this workspace at 2 hours.",
+    },
+  },
+};
+
+/** get · reads current settings (reset context mode). */
+export const ReadReset: Story = {
+  args: {
+    args: { action: "get" },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      success: true,
+      action: "get",
+      configured: true,
+      settings: {
+        enabled: true,
+        intervalMs: 3_600_000,
+        contextMode: "reset",
+        message: HEARTBEAT_DEFAULT_MESSAGE_BODY,
+      },
+      summary: "Heartbeat is enabled for this workspace at 1 hour.",
+    },
+  },
+};
+
+/** set · kept but paused (amber). */
+export const Paused: Story = {
+  args: {
+    args: { action: "set", enabled: false },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      success: true,
+      action: "set",
+      configured: true,
+      settings: {
+        enabled: false,
+        intervalMs: 30 * 60_000,
+        contextMode: "normal",
+        message: HEARTBEAT_DEFAULT_MESSAGE_BODY,
+      },
+      summary: "Heartbeat is disabled for this workspace at 30 minutes.",
+    },
+  },
+};
+
+/** get · nothing configured for this workspace. */
+export const ReadNotConfigured: Story = {
+  args: {
+    args: { action: "get" },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      success: true,
+      action: "get",
+      configured: false,
+      settings: null,
+      summary: "No heartbeat settings are configured for this workspace.",
+    },
+  },
+};
+
+/** unset · schedule removed. */
+export const Cleared: Story = {
+  args: {
+    args: { action: "unset" },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      success: true,
+      action: "unset",
+      configured: false,
+      settings: null,
+      summary: "Heartbeat settings removed for this workspace.",
+    },
+  },
+};
+
+/** Mid-flight, before the result arrives. */
+export const Executing: Story = {
+  args: {
+    args: { action: "set", enabled: true, intervalMs: 30 * 60_000 },
+    status: "executing",
+    defaultExpanded: true,
+  },
+};
+
+/** Error · interval outside the supported range. */
+export const ErrorOutOfRange: Story = {
+  args: {
+    args: { action: "set", intervalMs: 30_000 },
+    status: "failed",
+    defaultExpanded: true,
+    result: { success: false, error: "intervalMs must be between 5 minutes and 24 hours." },
+  },
+};

--- a/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
@@ -64,6 +64,34 @@ export const ScheduledEnabled: Story = {
 };
 
 /**
+ * set · multiline custom message with a long unbroken token — verifies the prompt
+ * body preserves newlines and wraps long URLs/paths instead of overflowing the card
+ * (check at the ~375px mobile width).
+ */
+export const CustomMessageWrapping: Story = {
+  args: {
+    args: { action: "set", enabled: true, intervalMs: 1_800_000 },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      success: true,
+      action: "set",
+      configured: true,
+      settings: {
+        enabled: true,
+        intervalMs: 1_800_000,
+        contextMode: "normal",
+        message:
+          "Poll the deploy and report status.\n" +
+          "Logs: https://ci.example.com/runs/0123456789abcdef0123456789abcdef/jobs/deploy-prod-us-east-1/raw?download=true\n" +
+          "If it failed, summarize the first error and stop.",
+      },
+      summary: "Heartbeat is enabled for this workspace at 30 minutes.",
+    },
+  },
+};
+
+/**
  * set · long cadence that compacts context first, with no custom message — exercises
  * the default-prompt fallback (the common case, since `message` is only stored when set).
  */

--- a/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.stories.tsx
@@ -64,9 +64,10 @@ export const ScheduledEnabled: Story = {
 };
 
 /**
- * set · multiline custom message with a long unbroken token — verifies the prompt
- * body preserves newlines and wraps long URLs/paths instead of overflowing the card
- * (check at the ~375px mobile width).
+ * set · multiline custom message with a long unbroken token. Pinned to a fixed ~360px
+ * container (the Storybook test-runner renders at desktop width and ignores viewport /
+ * Chromatic modes, so the narrow case must be forced with a wrapper) and a play that
+ * fails if the prompt body's long URL/path overflows instead of wrapping.
  */
 export const CustomMessageWrapping: Story = {
   args: {
@@ -88,6 +89,33 @@ export const CustomMessageWrapping: Story = {
       },
       summary: "Heartbeat is enabled for this workspace at 30 minutes.",
     },
+  },
+  decorators: [
+    (Story) => (
+      <div data-testid="heartbeat-card-container" className="w-[375px]">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    // defaultExpanded renders the prompt synchronously; confirm the long token is present.
+    if (!canvasElement.textContent?.includes("ci.example.com")) {
+      throw new Error("Heartbeat check-in prompt did not render");
+    }
+    const container = canvasElement.querySelector('[data-testid="heartbeat-card-container"]');
+    if (!(container instanceof HTMLElement)) {
+      throw new Error("Heartbeat story container not found");
+    }
+    // Let layout settle before measuring.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    );
+    if (container.scrollWidth > container.clientWidth + 1) {
+      throw new Error(
+        `Heartbeat tool card overflowed its ${container.clientWidth}px container by ` +
+          `${container.scrollWidth - container.clientWidth}px`
+      );
+    }
   },
 };
 

--- a/src/browser/features/Tools/HeartbeatToolCall.test.ts
+++ b/src/browser/features/Tools/HeartbeatToolCall.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatHeartbeatInterval, formatHeartbeatIntervalShort } from "./HeartbeatToolCall";
+
+describe("formatHeartbeatInterval", () => {
+  test("pluralizes minutes and prefers whole hours", () => {
+    expect(formatHeartbeatInterval(60_000)).toBe("1 minute");
+    expect(formatHeartbeatInterval(30 * 60_000)).toBe("30 minutes");
+    expect(formatHeartbeatInterval(3_600_000)).toBe("1 hour");
+    expect(formatHeartbeatInterval(2 * 3_600_000)).toBe("2 hours");
+  });
+
+  test("falls back to milliseconds for sub-minute values", () => {
+    expect(formatHeartbeatInterval(30_000)).toBe("30000 ms");
+  });
+});
+
+describe("formatHeartbeatIntervalShort", () => {
+  test("uses the largest whole unit", () => {
+    expect(formatHeartbeatIntervalShort(30 * 60_000)).toBe("30m");
+    expect(formatHeartbeatIntervalShort(3_600_000)).toBe("1h");
+    expect(formatHeartbeatIntervalShort(2 * 3_600_000)).toBe("2h");
+  });
+});

--- a/src/browser/features/Tools/HeartbeatToolCall.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.tsx
@@ -250,10 +250,10 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
                     Check-in prompt
                   </div>
                   {/* Custom messages come from a multiline textarea and can contain long
-                      URLs/paths — preserve newlines and break long tokens (with a scroll cap)
-                      so the card never overflows its container on narrow/mobile widths, as the
-                      generic tool-output fallback did. */}
-                  <div className="text-foreground max-h-[200px] overflow-y-auto border-l-2 border-white/10 pl-2.5 break-words whitespace-pre-wrap italic">
+                      URLs/paths — preserve newlines and break long tokens so the card never
+                      overflows its container on narrow/mobile widths, as the generic
+                      tool-output fallback did. */}
+                  <div className="text-foreground border-l-2 border-white/10 pl-2.5 break-words whitespace-pre-wrap italic">
                     {customMessage}
                   </div>
                 </div>

--- a/src/browser/features/Tools/HeartbeatToolCall.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.tsx
@@ -18,7 +18,12 @@ import {
 } from "./Shared/toolUtils";
 import { HeartbeatToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 import type { HeartbeatToolArgs, HeartbeatToolResult } from "@/common/types/tools";
-import { HEARTBEAT_DEFAULT_CONTEXT_MODE, type HeartbeatContextMode } from "@/constants/heartbeat";
+import {
+  HEARTBEAT_DEFAULT_CONTEXT_MODE,
+  formatHeartbeatInterval,
+  formatHeartbeatIntervalShort,
+  type HeartbeatContextMode,
+} from "@/constants/heartbeat";
 
 /**
  * Transcript card for the `heartbeat` tool — the agent's recurring, idle-gated
@@ -41,29 +46,6 @@ const CONTEXT_MODES: Record<HeartbeatContextMode, { label: string; blurb: string
   compact: { label: "Compact", blurb: "Compacts context before each check-in" },
   reset: { label: "Reset", blurb: "Starts each check-in from a fresh boundary" },
 };
-
-const MINUTE_MS = 60 * 1000;
-const HOUR_MS = 60 * MINUTE_MS;
-
-/** Human cadence for the expanded detail, e.g. "30 minutes", "2 hours", "1 hour". */
-export function formatHeartbeatInterval(ms: number): string {
-  if (ms % HOUR_MS === 0) {
-    const hours = ms / HOUR_MS;
-    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
-  }
-  if (ms % MINUTE_MS === 0) {
-    const minutes = ms / MINUTE_MS;
-    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
-  }
-  return `${ms} ms`;
-}
-
-/** Compact cadence for the header pill, e.g. "30m", "2h". */
-export function formatHeartbeatIntervalShort(ms: number): string {
-  if (ms % HOUR_MS === 0) return `${ms / HOUR_MS}h`;
-  if (ms % MINUTE_MS === 0) return `${ms / MINUTE_MS}m`;
-  return `${ms} ms`;
-}
 
 /**
  * Narrow an arbitrary tool result to a successful heartbeat payload. Results
@@ -146,6 +128,56 @@ const HeartbeatStat: React.FC<{ label: string; value: React.ReactNode }> = (prop
   </div>
 );
 
+const REQUEST_ACTION_LABELS: Record<HeartbeatToolArgs["action"], string> = {
+  set: "Schedule",
+  get: "Read",
+  unset: "Clear",
+};
+
+// Fallback for states with no resolved settings, error, or recognized empty result:
+// in-flight/interrupted/redacted calls, or a degraded success (e.g. a corrupted set
+// result with settings:null). Surfaces what the agent requested so the expanded card is
+// never blank — the generic renderer used to show the raw args here.
+const RequestedArgs: React.FC<{ args: HeartbeatToolArgs }> = (props) => {
+  const args = props.args;
+  const requestedMessage = args.message ?? "";
+  return (
+    <div className="bg-code-bg space-y-3 rounded px-3 py-2.5 text-[11px] leading-relaxed">
+      <div className="text-secondary text-[10px] tracking-wide uppercase">Requested</div>
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+        <HeartbeatStat label="Action" value={REQUEST_ACTION_LABELS[args.action]} />
+        {args.enabled != null && (
+          <HeartbeatStat label="State" value={args.enabled ? "Enable" : "Pause"} />
+        )}
+        {args.intervalMs != null && (
+          <HeartbeatStat
+            label="Cadence"
+            value={
+              <span className="counter-nums">every {formatHeartbeatInterval(args.intervalMs)}</span>
+            }
+          />
+        )}
+        {args.contextMode != null && (
+          <HeartbeatStat
+            label="Context"
+            value={CONTEXT_MODES[args.contextMode]?.label ?? args.contextMode}
+          />
+        )}
+      </dl>
+      {requestedMessage.length > 0 && (
+        <div>
+          <div className="text-secondary mb-1 text-[10px] tracking-wide uppercase">
+            Check-in prompt
+          </div>
+          <div className="text-foreground border-l-2 border-white/10 pl-2.5 break-words whitespace-pre-wrap italic">
+            {requestedMessage}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
 interface HeartbeatToolCallProps {
   args: HeartbeatToolArgs;
   result?: unknown;
@@ -194,6 +226,12 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
   } else if (success?.action === "get") {
     badge = { tone: "cleared", label: "Not set" };
   }
+
+  // Which detail block (if any) the resolved result drives. When none applies and the
+  // call isn't executing or errored, fall back to the requested args so the expanded body
+  // is never blank (interrupted/in-flight, or a degraded success with null settings).
+  const hasResolvedDetail =
+    Boolean(settings) || success?.action === "unset" || (success?.action === "get" && !settings);
 
   return (
     <ToolContainer expanded={expanded} className="@container">
@@ -281,6 +319,10 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
             <div className="text-muted px-3 py-2 text-[11px] italic">
               Updating heartbeat settings…
             </div>
+          )}
+
+          {!errorResult && !hasResolvedDetail && status !== "executing" && (
+            <RequestedArgs args={props.args} />
           )}
         </ToolDetails>
       )}

--- a/src/browser/features/Tools/HeartbeatToolCall.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.tsx
@@ -1,0 +1,276 @@
+import React from "react";
+import { Activity } from "lucide-react";
+import { cn } from "@/common/lib/utils";
+import {
+  ToolContainer,
+  ToolHeader,
+  ExpandIcon,
+  StatusIndicator,
+  ToolDetails,
+  ToolIcon,
+  ErrorBox,
+} from "./Shared/ToolPrimitives";
+import {
+  useToolExpansion,
+  getStatusDisplay,
+  isToolErrorResult,
+  type ToolStatus,
+} from "./Shared/toolUtils";
+import { HeartbeatToolResultSchema } from "@/common/utils/tools/toolDefinitions";
+import type { HeartbeatToolArgs, HeartbeatToolResult } from "@/common/types/tools";
+import { HEARTBEAT_DEFAULT_CONTEXT_MODE, type HeartbeatContextMode } from "@/constants/heartbeat";
+
+/**
+ * Transcript card for the `heartbeat` tool — the agent's recurring, idle-gated
+ * self check-in. Reads as a glanceable status pill (cadence + state) in the
+ * header and expands to the full schedule and check-in prompt.
+ *
+ * Mirrors the heartbeat backend (HeartbeatToolResultSchema / src/constants/heartbeat.ts):
+ * `action` is get | set | unset, and a successful result carries the resolved
+ * `settings` (null when nothing is configured) plus a human `summary`.
+ */
+
+type HeartbeatSuccess = Extract<HeartbeatToolResult, { success: true }>;
+type HeartbeatSettings = NonNullable<HeartbeatSuccess["settings"]>;
+
+// Terse, card-friendly context-mode copy. The config modal
+// (WorkspaceHeartbeatModal) uses more verbose, instruction-flavored labels;
+// a transcript card wants short descriptive blurbs instead.
+const CONTEXT_MODES: Record<HeartbeatContextMode, { label: string; blurb: string }> = {
+  normal: { label: "Normal", blurb: "Continues with full context" },
+  compact: { label: "Compact", blurb: "Compacts context before each check-in" },
+  reset: { label: "Reset", blurb: "Starts each check-in from a fresh boundary" },
+};
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+/** Human cadence for the expanded detail, e.g. "30 minutes", "2 hours", "1 hour". */
+export function formatHeartbeatInterval(ms: number): string {
+  if (ms % HOUR_MS === 0) {
+    const hours = ms / HOUR_MS;
+    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+  if (ms % MINUTE_MS === 0) {
+    const minutes = ms / MINUTE_MS;
+    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  }
+  return `${ms} ms`;
+}
+
+/** Compact cadence for the header pill, e.g. "30m", "2h". */
+export function formatHeartbeatIntervalShort(ms: number): string {
+  if (ms % HOUR_MS === 0) return `${ms / HOUR_MS}h`;
+  if (ms % MINUTE_MS === 0) return `${ms / MINUTE_MS}m`;
+  return `${ms} ms`;
+}
+
+/**
+ * Narrow an arbitrary tool result to a successful heartbeat payload. Results
+ * flow verbatim from persisted transcripts, so we validate against the schema
+ * rather than trusting the shape (self-healing: a malformed result simply
+ * renders no settings instead of throwing).
+ */
+function extractHeartbeatSuccess(result: unknown): HeartbeatSuccess | null {
+  const parsed = HeartbeatToolResultSchema.safeParse(result);
+  return parsed.success && parsed.data.success ? parsed.data : null;
+}
+
+type BadgeTone = "enabled" | "disabled" | "cleared";
+
+// Green (live) shares the GoalStatusBadge palette so "active/healthy" reads the
+// same across tool cards; amber means "kept but won't progress" (paused);
+// muted means "not scheduled" (cleared / not set).
+const BADGE_CLASSES: Record<BadgeTone, string> = {
+  enabled: "bg-success/10 text-success border-success/40",
+  disabled: "bg-warning-overlay text-warning border-warning/40",
+  cleared: "bg-white/5 text-secondary border-white/10",
+};
+
+const HeartbeatBadge: React.FC<{ tone: BadgeTone; label: string }> = ({ tone, label }) => (
+  <span
+    className={cn(
+      "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-1.5 py-0.5",
+      "text-[10px] font-medium leading-none tracking-wide uppercase",
+      BADGE_CLASSES[tone]
+    )}
+  >
+    {tone === "enabled" ? (
+      // Pulsing dot signals a live, ticking schedule; CSS gates it on reduced-motion.
+      <span className="heartbeat-dot bg-success inline-block h-1.5 w-1.5 rounded-full" />
+    ) : (
+      <Activity aria-hidden="true" className="h-2.5 w-2.5" />
+    )}
+    {label}
+  </span>
+);
+
+// The signature visual: a slim ECG strip that scans while the heartbeat is live.
+const PULSE_TRACE_POINTS =
+  "0,14 40,14 50,14 54,5 58,23 62,14 96,14 160,14 166,14 170,5 174,23 178,14 212,14 240,14";
+
+const PulseTrace: React.FC<{ live: boolean }> = ({ live }) => (
+  <svg
+    viewBox="0 0 240 28"
+    preserveAspectRatio="none"
+    className="block h-[26px] w-full"
+    aria-hidden="true"
+  >
+    <line
+      x1="0"
+      y1="14"
+      x2="240"
+      y2="14"
+      stroke="currentColor"
+      strokeWidth="1"
+      className="text-secondary"
+      opacity="0.18"
+    />
+    <polyline
+      points={PULSE_TRACE_POINTS}
+      fill="none"
+      stroke={live ? "var(--color-success)" : "var(--color-warning)"}
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={live ? "heartbeat-trace" : undefined}
+      opacity={live ? 1 : 0.55}
+    />
+  </svg>
+);
+
+const HeartbeatStat: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+  <div className="flex flex-col gap-0.5">
+    <dt className="text-secondary text-[10px] tracking-wide uppercase">{label}</dt>
+    <dd className="text-foreground leading-tight">{value}</dd>
+  </div>
+);
+
+interface HeartbeatToolCallProps {
+  args: HeartbeatToolArgs;
+  result?: unknown;
+  status?: ToolStatus;
+  /** Initial expansion fallback (until the user toggles this tool in the workspace). */
+  defaultExpanded?: boolean;
+}
+
+export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = ({
+  args,
+  result,
+  status = "pending",
+  defaultExpanded = false,
+}) => {
+  const { expanded, toggleExpanded } = useToolExpansion(defaultExpanded);
+
+  const action = args.action;
+  const errorResult = isToolErrorResult(result) ? result : null;
+  const success = extractHeartbeatSuccess(result);
+  const settings: HeartbeatSettings | null = success?.settings ?? null;
+  const summary = success?.summary ?? null;
+
+  const verb =
+    action === "get"
+      ? "Read heartbeat"
+      : action === "unset"
+        ? "Clear heartbeat"
+        : "Schedule heartbeat";
+
+  const live = settings?.enabled ?? false;
+  const ctx = CONTEXT_MODES[settings?.contextMode ?? HEARTBEAT_DEFAULT_CONTEXT_MODE];
+
+  // Header pill: live cadence (green), paused (amber), or cleared/not-set (muted).
+  let badge: { tone: BadgeTone; label: string } | null = null;
+  if (action === "unset") {
+    badge = { tone: "cleared", label: "Cleared" };
+  } else if (settings) {
+    badge = settings.enabled
+      ? { tone: "enabled", label: `Every ${formatHeartbeatIntervalShort(settings.intervalMs)}` }
+      : { tone: "disabled", label: "Paused" };
+  } else if (action === "get" && status === "completed") {
+    badge = { tone: "cleared", label: "Not set" };
+  }
+
+  return (
+    <ToolContainer expanded={expanded} className="@container">
+      <ToolHeader onClick={toggleExpanded}>
+        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
+        <ToolIcon toolName="heartbeat" />
+        <span className="text-secondary font-medium whitespace-nowrap">{verb}</span>
+        {badge && <HeartbeatBadge tone={badge.tone} label={badge.label} />}
+        {summary && (
+          <span className="text-foreground hidden truncate italic @sm:inline">{summary}</span>
+        )}
+        <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
+      </ToolHeader>
+
+      {expanded && (
+        <ToolDetails>
+          {errorResult && <ErrorBox>{errorResult.error}</ErrorBox>}
+
+          {settings && (
+            <div className="bg-code-bg space-y-3 rounded px-3 py-2.5 text-[11px] leading-relaxed">
+              <PulseTrace live={live} />
+
+              <dl className="grid grid-cols-2 gap-x-6 gap-y-3">
+                <HeartbeatStat
+                  label="State"
+                  value={
+                    <span className={live ? "text-success" : "text-warning"}>
+                      {live ? "Enabled" : "Paused"}
+                    </span>
+                  }
+                />
+                <HeartbeatStat
+                  label="Cadence"
+                  value={
+                    <span className="counter-nums">
+                      every {formatHeartbeatInterval(settings.intervalMs)}
+                    </span>
+                  }
+                />
+                <HeartbeatStat label="Context" value={ctx.label} />
+                <HeartbeatStat label="Trigger" value="When idle" />
+              </dl>
+
+              <div className="text-muted text-[10.5px] leading-relaxed">
+                {ctx.blurb}.
+                {live
+                  ? " Fires only after the workspace goes idle for the interval — deferred while you're actively working."
+                  : " No check-ins will run until re-enabled."}
+              </div>
+
+              {settings.message && (
+                <div>
+                  <div className="text-secondary mb-1 text-[10px] tracking-wide uppercase">
+                    Check-in prompt
+                  </div>
+                  <div className="text-foreground border-l-2 border-white/10 pl-2.5 italic">
+                    {settings.message}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {action === "unset" && !errorResult && (
+            <div className="text-muted px-3 py-2 text-[11px]">
+              Recurring check-ins removed for this workspace.
+            </div>
+          )}
+
+          {action === "get" && !settings && !errorResult && status === "completed" && (
+            <div className="text-muted px-3 py-2 text-[11px] italic">
+              No heartbeat is configured for this workspace.
+            </div>
+          )}
+
+          {status === "executing" && (
+            <div className="text-muted px-3 py-2 text-[11px] italic">
+              Updating heartbeat settings…
+            </div>
+          )}
+        </ToolDetails>
+      )}
+    </ToolContainer>
+  );
+};

--- a/src/browser/features/Tools/HeartbeatToolCall.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.tsx
@@ -227,9 +227,9 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
     badge = { tone: "cleared", label: "Not set" };
   }
 
-  // Which detail block (if any) the resolved result drives. When none applies and the
-  // call isn't executing or errored, fall back to the requested args so the expanded body
-  // is never blank (interrupted/in-flight, or a degraded success with null settings).
+  // Which detail block (if any) the resolved result drives. When none applies (and there's
+  // no error) we fall back to the requested args — including while executing — so the
+  // expanded body always shows what the agent is scheduling, never a blank panel.
   const hasResolvedDetail =
     Boolean(settings) || success?.action === "unset" || (success?.action === "get" && !settings);
 
@@ -315,14 +315,12 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
             </div>
           )}
 
+          {!errorResult && !hasResolvedDetail && <RequestedArgs args={props.args} />}
+
           {status === "executing" && (
             <div className="text-muted px-3 py-2 text-[11px] italic">
               Updating heartbeat settings…
             </div>
-          )}
-
-          {!errorResult && !hasResolvedDetail && status !== "executing" && (
-            <RequestedArgs args={props.args} />
           )}
         </ToolDetails>
       )}

--- a/src/browser/features/Tools/HeartbeatToolCall.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.tsx
@@ -249,7 +249,11 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
                   <div className="text-secondary mb-1 text-[10px] tracking-wide uppercase">
                     Check-in prompt
                   </div>
-                  <div className="text-foreground border-l-2 border-white/10 pl-2.5 italic">
+                  {/* Custom messages come from a multiline textarea and can contain long
+                      URLs/paths — preserve newlines and break long tokens (with a scroll cap)
+                      so the card never overflows its container on narrow/mobile widths, as the
+                      generic tool-output fallback did. */}
+                  <div className="text-foreground max-h-[200px] overflow-y-auto border-l-2 border-white/10 pl-2.5 break-words whitespace-pre-wrap italic">
                     {customMessage}
                   </div>
                 </div>

--- a/src/browser/features/Tools/HeartbeatToolCall.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.tsx
@@ -18,11 +18,7 @@ import {
 } from "./Shared/toolUtils";
 import { HeartbeatToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 import type { HeartbeatToolArgs, HeartbeatToolResult } from "@/common/types/tools";
-import {
-  HEARTBEAT_DEFAULT_CONTEXT_MODE,
-  HEARTBEAT_DEFAULT_MESSAGE_BODY,
-  type HeartbeatContextMode,
-} from "@/constants/heartbeat";
+import { HEARTBEAT_DEFAULT_CONTEXT_MODE, type HeartbeatContextMode } from "@/constants/heartbeat";
 
 /**
  * Transcript card for the `heartbeat` tool — the agent's recurring, idle-gated
@@ -177,23 +173,25 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
 
   const live = settings?.enabled ?? false;
   const ctx = CONTEXT_MODES[settings?.contextMode ?? HEARTBEAT_DEFAULT_CONTEXT_MODE];
-  // WorkspaceService only persists `message` when a custom one is provided, so the
-  // common case has no stored text — fall back to the built-in default body and mark
-  // it as such, rather than hiding the prompt section entirely. An empty string means
-  // the custom message was explicitly cleared, so treat that as "no custom prompt" too.
-  const message = settings?.message ?? "";
-  const hasCustomMessage = message.length > 0;
-  const promptBody = hasCustomMessage ? message : HEARTBEAT_DEFAULT_MESSAGE_BODY;
+  // Only a custom `message` is stored per workspace; an empty string means it was
+  // explicitly cleared. When there's no custom text the effective prompt is the
+  // app-level default (`config.heartbeatDefaultPrompt`) or the built-in body — neither
+  // of which the tool result carries — so we render a neutral "uses the default" note
+  // rather than risk showing a prompt different from the one that will actually run.
+  const customMessage = settings?.message ?? "";
+  const hasCustomMessage = customMessage.length > 0;
 
-  // Header pill: live cadence (green), paused (amber), or cleared/not-set (muted).
+  // Header pill — only once a successful result is in hand (live cadence green, paused
+  // amber, cleared/not-set muted). Gating on `success` avoids confirming a state before
+  // the tool has actually completed.
   let badge: { tone: BadgeTone; label: string } | null = null;
-  if (action === "unset") {
+  if (success?.action === "unset") {
     badge = { tone: "cleared", label: "Cleared" };
   } else if (settings) {
     badge = settings.enabled
       ? { tone: "enabled", label: `Every ${formatHeartbeatIntervalShort(settings.intervalMs)}` }
       : { tone: "disabled", label: "Paused" };
-  } else if (action === "get" && status === "completed") {
+  } else if (success?.action === "get") {
     badge = { tone: "cleared", label: "Not set" };
   }
 
@@ -246,27 +244,30 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
                   : " No check-ins will run until re-enabled."}
               </div>
 
-              <div>
-                <div className="text-secondary mb-1 text-[10px] tracking-wide uppercase">
-                  Check-in prompt
-                  {!hasCustomMessage && (
-                    <span className="text-muted tracking-normal normal-case"> · default</span>
-                  )}
+              {hasCustomMessage ? (
+                <div>
+                  <div className="text-secondary mb-1 text-[10px] tracking-wide uppercase">
+                    Check-in prompt
+                  </div>
+                  <div className="text-foreground border-l-2 border-white/10 pl-2.5 italic">
+                    {customMessage}
+                  </div>
                 </div>
-                <div className="text-foreground border-l-2 border-white/10 pl-2.5 italic">
-                  {promptBody}
+              ) : (
+                <div className="text-muted text-[10.5px] italic">
+                  Uses the default check-in prompt.
                 </div>
-              </div>
+              )}
             </div>
           )}
 
-          {action === "unset" && !errorResult && (
+          {success?.action === "unset" && (
             <div className="text-muted px-3 py-2 text-[11px]">
               Recurring check-ins removed for this workspace.
             </div>
           )}
 
-          {action === "get" && !settings && !errorResult && status === "completed" && (
+          {success?.action === "get" && !settings && (
             <div className="text-muted px-3 py-2 text-[11px] italic">
               No heartbeat is configured for this workspace.
             </div>

--- a/src/browser/features/Tools/HeartbeatToolCall.tsx
+++ b/src/browser/features/Tools/HeartbeatToolCall.tsx
@@ -18,7 +18,11 @@ import {
 } from "./Shared/toolUtils";
 import { HeartbeatToolResultSchema } from "@/common/utils/tools/toolDefinitions";
 import type { HeartbeatToolArgs, HeartbeatToolResult } from "@/common/types/tools";
-import { HEARTBEAT_DEFAULT_CONTEXT_MODE, type HeartbeatContextMode } from "@/constants/heartbeat";
+import {
+  HEARTBEAT_DEFAULT_CONTEXT_MODE,
+  HEARTBEAT_DEFAULT_MESSAGE_BODY,
+  type HeartbeatContextMode,
+} from "@/constants/heartbeat";
 
 /**
  * Transcript card for the `heartbeat` tool — the agent's recurring, idle-gated
@@ -87,21 +91,21 @@ const BADGE_CLASSES: Record<BadgeTone, string> = {
   cleared: "bg-white/5 text-secondary border-white/10",
 };
 
-const HeartbeatBadge: React.FC<{ tone: BadgeTone; label: string }> = ({ tone, label }) => (
+const HeartbeatBadge: React.FC<{ tone: BadgeTone; label: string }> = (props) => (
   <span
     className={cn(
       "inline-flex shrink-0 items-center gap-1.5 rounded-full border px-1.5 py-0.5",
       "text-[10px] font-medium leading-none tracking-wide uppercase",
-      BADGE_CLASSES[tone]
+      BADGE_CLASSES[props.tone]
     )}
   >
-    {tone === "enabled" ? (
+    {props.tone === "enabled" ? (
       // Pulsing dot signals a live, ticking schedule; CSS gates it on reduced-motion.
       <span className="heartbeat-dot bg-success inline-block h-1.5 w-1.5 rounded-full" />
     ) : (
       <Activity aria-hidden="true" className="h-2.5 w-2.5" />
     )}
-    {label}
+    {props.label}
   </span>
 );
 
@@ -109,7 +113,7 @@ const HeartbeatBadge: React.FC<{ tone: BadgeTone; label: string }> = ({ tone, la
 const PULSE_TRACE_POINTS =
   "0,14 40,14 50,14 54,5 58,23 62,14 96,14 160,14 166,14 170,5 174,23 178,14 212,14 240,14";
 
-const PulseTrace: React.FC<{ live: boolean }> = ({ live }) => (
+const PulseTrace: React.FC<{ live: boolean }> = (props) => (
   <svg
     viewBox="0 0 240 28"
     preserveAspectRatio="none"
@@ -129,20 +133,20 @@ const PulseTrace: React.FC<{ live: boolean }> = ({ live }) => (
     <polyline
       points={PULSE_TRACE_POINTS}
       fill="none"
-      stroke={live ? "var(--color-success)" : "var(--color-warning)"}
+      stroke={props.live ? "var(--color-success)" : "var(--color-warning)"}
       strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className={live ? "heartbeat-trace" : undefined}
-      opacity={live ? 1 : 0.55}
+      className={props.live ? "heartbeat-trace" : undefined}
+      opacity={props.live ? 1 : 0.55}
     />
   </svg>
 );
 
-const HeartbeatStat: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => (
+const HeartbeatStat: React.FC<{ label: string; value: React.ReactNode }> = (props) => (
   <div className="flex flex-col gap-0.5">
-    <dt className="text-secondary text-[10px] tracking-wide uppercase">{label}</dt>
-    <dd className="text-foreground leading-tight">{value}</dd>
+    <dt className="text-secondary text-[10px] tracking-wide uppercase">{props.label}</dt>
+    <dd className="text-foreground leading-tight">{props.value}</dd>
   </div>
 );
 
@@ -154,17 +158,13 @@ interface HeartbeatToolCallProps {
   defaultExpanded?: boolean;
 }
 
-export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = ({
-  args,
-  result,
-  status = "pending",
-  defaultExpanded = false,
-}) => {
-  const { expanded, toggleExpanded } = useToolExpansion(defaultExpanded);
+export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = (props) => {
+  const status = props.status ?? "pending";
+  const { expanded, toggleExpanded } = useToolExpansion(props.defaultExpanded ?? false);
 
-  const action = args.action;
-  const errorResult = isToolErrorResult(result) ? result : null;
-  const success = extractHeartbeatSuccess(result);
+  const action = props.args.action;
+  const errorResult = isToolErrorResult(props.result) ? props.result : null;
+  const success = extractHeartbeatSuccess(props.result);
   const settings: HeartbeatSettings | null = success?.settings ?? null;
   const summary = success?.summary ?? null;
 
@@ -177,6 +177,13 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = ({
 
   const live = settings?.enabled ?? false;
   const ctx = CONTEXT_MODES[settings?.contextMode ?? HEARTBEAT_DEFAULT_CONTEXT_MODE];
+  // WorkspaceService only persists `message` when a custom one is provided, so the
+  // common case has no stored text — fall back to the built-in default body and mark
+  // it as such, rather than hiding the prompt section entirely. An empty string means
+  // the custom message was explicitly cleared, so treat that as "no custom prompt" too.
+  const message = settings?.message ?? "";
+  const hasCustomMessage = message.length > 0;
+  const promptBody = hasCustomMessage ? message : HEARTBEAT_DEFAULT_MESSAGE_BODY;
 
   // Header pill: live cadence (green), paused (amber), or cleared/not-set (muted).
   let badge: { tone: BadgeTone; label: string } | null = null;
@@ -239,16 +246,17 @@ export const HeartbeatToolCall: React.FC<HeartbeatToolCallProps> = ({
                   : " No check-ins will run until re-enabled."}
               </div>
 
-              {settings.message && (
-                <div>
-                  <div className="text-secondary mb-1 text-[10px] tracking-wide uppercase">
-                    Check-in prompt
-                  </div>
-                  <div className="text-foreground border-l-2 border-white/10 pl-2.5 italic">
-                    {settings.message}
-                  </div>
+              <div>
+                <div className="text-secondary mb-1 text-[10px] tracking-wide uppercase">
+                  Check-in prompt
+                  {!hasCustomMessage && (
+                    <span className="text-muted tracking-normal normal-case"> · default</span>
+                  )}
                 </div>
-              )}
+                <div className="text-foreground border-l-2 border-white/10 pl-2.5 italic">
+                  {promptBody}
+                </div>
+              </div>
             </div>
           )}
 

--- a/src/browser/features/Tools/Shared/ToolPrimitives.tsx
+++ b/src/browser/features/Tools/Shared/ToolPrimitives.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/browser/features/Messages/TranscriptQuoteBoundary";
 import type { LucideIcon } from "lucide-react";
 import {
+  Activity,
   ArrowDownUp,
   Bell,
   BookOpen,
@@ -271,6 +272,9 @@ export const TOOL_NAME_TO_ICON: Partial<Record<string, LucideIcon>> = {
   set_goal: Target,
   get_goal: Target,
   complete_goal: CircleCheck,
+  // Activity (ECG line) rather than HeartPulse: it matches the scanning pulse-trace
+  // motif inside the HeartbeatToolCall card. The config menu uses HeartPulse.
+  heartbeat: Activity,
 };
 
 export const ToolIcon: React.FC<ToolIconProps> = ({ toolName, emoji, emojiSpin, className }) => {

--- a/src/browser/features/Tools/Shared/getToolComponent.test.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.test.ts
@@ -11,6 +11,7 @@ import { GoogleSearchToolCall } from "../GoogleSearchToolCall";
 import { SetGoalToolCall } from "../SetGoalToolCall";
 import { WorkflowResumeToolCall, WorkflowRunToolCall } from "../WorkflowRunToolCall";
 import { GetGoalToolCall } from "../GetGoalToolCall";
+import { HeartbeatToolCall } from "../HeartbeatToolCall";
 import { getToolComponent } from "./getToolComponent";
 
 describe("getToolComponent", () => {
@@ -90,6 +91,20 @@ describe("getToolComponent", () => {
   test("complete_goal falls back to GenericToolCall when summary is empty (zod min(1) fails)", () => {
     const component = getToolComponent("complete_goal", { summary: "" });
     expect(component).toBe(GenericToolCall);
+  });
+
+  test("returns HeartbeatToolCall for heartbeat", () => {
+    expect(getToolComponent("heartbeat", { action: "get" })).toBe(HeartbeatToolCall);
+    expect(getToolComponent("heartbeat", { action: "set", intervalMs: 30 * 60_000 })).toBe(
+      HeartbeatToolCall
+    );
+  });
+
+  test("heartbeat falls back to GenericToolCall when intervalMs is out of range", () => {
+    // 30s is below HEARTBEAT_MIN_INTERVAL_MS (5min); the schema's .min() rejects it.
+    expect(getToolComponent("heartbeat", { action: "set", intervalMs: 30_000 })).toBe(
+      GenericToolCall
+    );
   });
 
   test("falls back to GenericToolCall when args validation fails", () => {

--- a/src/browser/features/Tools/Shared/getToolComponent.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.ts
@@ -44,6 +44,7 @@ import {
 import { TaskApplyGitPatchToolCall } from "../TaskApplyGitPatchToolCall";
 import { SetGoalToolCall } from "../SetGoalToolCall";
 import { GetGoalToolCall } from "../GetGoalToolCall";
+import { HeartbeatToolCall } from "../HeartbeatToolCall";
 import { WorkflowResumeToolCall, WorkflowRunToolCall } from "../WorkflowRunToolCall";
 import { CompleteGoalToolCall } from "../CompleteGoalToolCall";
 
@@ -200,6 +201,7 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
     component: CompleteGoalToolCall,
     schema: TOOL_DEFINITIONS.complete_goal.schema,
   },
+  heartbeat: { component: HeartbeatToolCall, schema: TOOL_DEFINITIONS.heartbeat.schema },
   review_pane_update: {
     component: ReviewPaneUpdateToolCall,
     schema: TOOL_DEFINITIONS.review_pane_update.schema,

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -2446,7 +2446,9 @@ input[type="checkbox"] {
 
 @keyframes heartbeat-trace-scan {
   to {
-    stroke-dashoffset: -240;
+    /* Multiple of the 9px dash period (stroke-dasharray: 4 5) so the pattern aligns
+       across the loop boundary and scrolls seamlessly instead of jumping each cycle. */
+    stroke-dashoffset: -243;
   }
 }
 

--- a/src/browser/styles/globals.css
+++ b/src/browser/styles/globals.css
@@ -2430,6 +2430,43 @@ input[type="checkbox"] {
   }
 }
 
+/* HeartbeatToolCall: pulsing "live" dot + scanning ECG trace. Conveys an
+   actively-ticking schedule; both are gated on reduced-motion below. */
+@keyframes heartbeat-dot-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.75);
+    opacity: 0.35;
+  }
+}
+
+@keyframes heartbeat-trace-scan {
+  to {
+    stroke-dashoffset: -240;
+  }
+}
+
+.heartbeat-dot {
+  transform-origin: center;
+  animation: heartbeat-dot-pulse 1.7s ease-in-out infinite;
+}
+
+.heartbeat-trace {
+  stroke-dasharray: 4 5;
+  animation: heartbeat-trace-scan 4.5s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .heartbeat-dot,
+  .heartbeat-trace {
+    animation: none;
+  }
+}
+
 /* Animated dashed connector for active sub-agents */
 @keyframes connector-dash-scroll {
   from {

--- a/src/constants/heartbeat.test.ts
+++ b/src/constants/heartbeat.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { formatHeartbeatInterval, formatHeartbeatIntervalShort } from "./HeartbeatToolCall";
+import { formatHeartbeatInterval, formatHeartbeatIntervalShort } from "./heartbeat";
 
 describe("formatHeartbeatInterval", () => {
-  test("pluralizes minutes and prefers whole hours", () => {
+  test("renders whole hours and pluralizes minutes", () => {
     expect(formatHeartbeatInterval(60_000)).toBe("1 minute");
     expect(formatHeartbeatInterval(30 * 60_000)).toBe("30 minutes");
     expect(formatHeartbeatInterval(3_600_000)).toBe("1 hour");
     expect(formatHeartbeatInterval(2 * 3_600_000)).toBe("2 hours");
   });
 
-  test("falls back to milliseconds for sub-minute values", () => {
-    expect(formatHeartbeatInterval(30_000)).toBe("30000 ms");
+  test("rounds in-range non-whole-minute intervals instead of emitting raw ms", () => {
+    expect(formatHeartbeatInterval(5 * 60_000 + 1)).toBe("5 minutes");
+    expect(formatHeartbeatIntervalShort(5 * 60_000 + 1)).toBe("5m");
   });
 });
 

--- a/src/constants/heartbeat.ts
+++ b/src/constants/heartbeat.ts
@@ -13,3 +13,32 @@ export const HEARTBEAT_RESET_BOUNDARY_MESSAGE =
 // instruction body, not the scheduler-generated runtime context.
 export const HEARTBEAT_DEFAULT_MESSAGE_BODY =
   "Check in on the current state of this workspace — review any pending work, check for stale context, and determine if any action is needed. If everything looks good, briefly confirm the workspace status.";
+
+const HEARTBEAT_MS_PER_MINUTE = 60 * 1000;
+const HEARTBEAT_MS_PER_HOUR = 60 * HEARTBEAT_MS_PER_MINUTE;
+
+/**
+ * Human-readable heartbeat cadence, e.g. "30 minutes", "2 hours", "1 hour".
+ *
+ * Total over any positive interval: whole hours render as hours; everything else
+ * rounds to the nearest minute. Rounding (rather than a raw "<ms> ms" fallback) keeps
+ * an in-range but non-whole-minute intervalMs from leaking a millisecond count into the
+ * UI/summary. Shared by the backend result summary (src/node/services/tools/heartbeat.ts)
+ * and the HeartbeatToolCall card so the two never drift.
+ */
+export function formatHeartbeatInterval(intervalMs: number): string {
+  if (intervalMs % HEARTBEAT_MS_PER_HOUR === 0) {
+    const hours = intervalMs / HEARTBEAT_MS_PER_HOUR;
+    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+  }
+  const minutes = Math.max(1, Math.round(intervalMs / HEARTBEAT_MS_PER_MINUTE));
+  return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+}
+
+/** Compact cadence for the header pill, e.g. "30m", "2h". Rounds like {@link formatHeartbeatInterval}. */
+export function formatHeartbeatIntervalShort(intervalMs: number): string {
+  if (intervalMs % HEARTBEAT_MS_PER_HOUR === 0) {
+    return `${intervalMs / HEARTBEAT_MS_PER_HOUR}h`;
+  }
+  return `${Math.max(1, Math.round(intervalMs / HEARTBEAT_MS_PER_MINUTE))}m`;
+}

--- a/src/node/services/tools/heartbeat.ts
+++ b/src/node/services/tools/heartbeat.ts
@@ -1,5 +1,4 @@
 import { tool } from "ai";
-import assert from "@/common/utils/assert";
 import type {
   ToolFactory,
   WorkspaceHeartbeatSettings,
@@ -8,7 +7,7 @@ import type {
 import { TOOL_DEFINITIONS } from "@/common/utils/tools/toolDefinitions";
 import type { HeartbeatToolArgs, HeartbeatToolResult } from "@/common/types/tools";
 import { getErrorMessage } from "@/common/utils/errors";
-import { HEARTBEAT_MAX_INTERVAL_MS, HEARTBEAT_MIN_INTERVAL_MS } from "@/constants/heartbeat";
+import { formatHeartbeatInterval } from "@/constants/heartbeat";
 import { requireWorkspaceId } from "./toolUtils";
 
 function hasProvided<K extends keyof HeartbeatToolArgs>(
@@ -16,27 +15,6 @@ function hasProvided<K extends keyof HeartbeatToolArgs>(
   key: K
 ): args is HeartbeatToolArgs & { [P in K]-?: NonNullable<HeartbeatToolArgs[P]> } {
   return Object.prototype.hasOwnProperty.call(args, key) && args[key] != null;
-}
-
-function formatInterval(intervalMs: number): string {
-  assert(
-    Number.isInteger(intervalMs) &&
-      intervalMs >= HEARTBEAT_MIN_INTERVAL_MS &&
-      intervalMs <= HEARTBEAT_MAX_INTERVAL_MS,
-    "formatInterval requires a supported heartbeat interval"
-  );
-
-  const minuteMs = 60 * 1000;
-  const hourMs = 60 * minuteMs;
-  if (intervalMs % hourMs === 0) {
-    const hours = intervalMs / hourMs;
-    return `${hours} ${hours === 1 ? "hour" : "hours"}`;
-  }
-  if (intervalMs % minuteMs === 0) {
-    const minutes = intervalMs / minuteMs;
-    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
-  }
-  return `${intervalMs} ms`;
 }
 
 function summarize(
@@ -52,7 +30,7 @@ function summarize(
   }
 
   const status = settings.enabled ? "enabled" : "disabled";
-  return `Heartbeat is ${status} for this workspace at ${formatInterval(settings.intervalMs)}.`;
+  return `Heartbeat is ${status} for this workspace at ${formatHeartbeatInterval(settings.intervalMs)}.`;
 }
 
 // Build the shared success payload for every heartbeat action so the get/set/unset branches


### PR DESCRIPTION
## Summary

Render the `heartbeat` tool — the agent's recurring, idle-gated self check-in — with a dedicated transcript card (`HeartbeatToolCall`) instead of the generic fallback. The header is a glanceable status pill (live cadence / paused / cleared); expanding reveals a scanning ECG pulse trace, the State/Cadence/Context/Trigger stats, and the check-in prompt.

## Background

The `heartbeat` tool already exists end-to-end (`HeartbeatToolArgsSchema` / `HeartbeatToolResultSchema`, the config modal, the slash command), but agent `heartbeat` tool calls in the transcript fell back to `GenericToolCall` — just raw args/result JSON. This implements the proposed `Heartbeat Tool Call.html` design as a real card so the schedule reads at a glance.

## Implementation

- `HeartbeatToolCall.tsx` mirrors `GetGoalToolCall`: shared `ToolPrimitives`, `useToolExpansion`, and `StatusIndicator`/`getStatusDisplay`. The result is validated against `HeartbeatToolResultSchema` before use, so a malformed persisted transcript degrades to "no settings" rather than throwing (self-healing).
- Registered `heartbeat` in `getToolComponent`, and added the `Activity` (ECG) icon to `TOOL_NAME_TO_ICON` to match the card's pulse-trace motif (the config menu keeps `HeartPulse`).
- Added reduced-motion-gated `heartbeat-dot-pulse` / `heartbeat-trace-scan` keyframes to `globals.css`, following the existing keyframe + utility-class convention.
- Design-fidelity note: the mockup's `text-foreground-secondary` is an undefined token in the app (renders nothing), so muted text maps to the real `text-secondary` / `text-muted`.

## Validation

- Registry wiring test: valid args → `HeartbeatToolCall`; out-of-range `intervalMs` → `GenericToolCall`.
- Interval formatter unit tests (hour/minute boundaries, singular/plural).
- 8 Storybook stories cover the design states. Chromatic snapshots are **disabled** on the file because the repo-wide snapshot budget (`tests/ui/storybook/budget.test.ts`) is already at its ceiling; the stories still render under local Storybook and the CI Storybook test-runner. Flip to a single mode once the budget is raised.

## Risks

Low. Additive — a new entry in the tool-component registry and an icon-map key; no existing tool rendering changes. Worst case for the new card is a degraded/empty detail section on a malformed result, which is handled defensively.
