### PR TITLE
🤖 feat: continue interrupted stream by clicking the interrupted splitter

### DIFF
--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1260,7 +1260,13 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
         )}
         {isAtCutoff && <EditCutoffBarrier />}
         {interruptedBarrierMessageIds.has(message.id) && (
-          <InterruptedBarrier workspaceId={workspaceId} />
+          // Only the divider on the resume target (history tail) is clickable;
+          // resumeStream always continues the tail, so older partial dividers
+          // must stay decorative to avoid resuming the wrong turn.
+          <InterruptedBarrier
+            workspaceId={workspaceId}
+            resumable={message.id === lastRetryCandidateMessage?.id}
+          />
         )}
       </React.Fragment>
     );

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1065,12 +1065,17 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
   // divider on the writable resume target is interactive.
   const { resume: resumeInterruptedStreamAsync, error: resumeInterruptedError } = useResumeStream(
     workspaceId,
-    { autoRetryOnFailure: false }
+    { autoRetryOnFailure: false, resetKey: lastRetryCandidateMessage?.id }
   );
   // Adapt the async resume to the void-returning shape the click/keybind props expect.
   const resumeInterruptedStream = () => void resumeInterruptedStreamAsync();
+  // The divider is the resume affordance only when the warning RetryBarrier is
+  // NOT shown (the user-aborted / suppressed case). When RetryBarrier is visible,
+  // its Retry button owns resume — with temporary auto-retry-on-failure recovery —
+  // so the divider stays decorative to avoid bypassing that recovery.
   const interruptedTailResumable =
     !transcriptOnly &&
+    !showRetryBarrierUI &&
     lastRetryCandidateMessage != null &&
     interruptedBarrierMessageIds.has(lastRetryCandidateMessage.id);
   const transcriptTailItems: TranscriptTailStackItem[] = [];

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1058,21 +1058,15 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     }
   }
 
-  // Resume is owned here (not in the divider) so the click and keybind paths
-  // share one instance/error, and so unmounting a transient divider can't cancel
-  // an in-flight retry. autoRetryOnFailure:false keeps the user-abort "continue
-  // once" semantic. resumeStream always continues the history tail, so only the
-  // divider on the writable resume target is interactive.
+  // Owned here so the click and keybind paths share one resume/error. resetKey is
+  // the resume target, so error/spinner reset when the interrupted turn changes.
   const { resume: resumeInterruptedStreamAsync, error: resumeInterruptedError } = useResumeStream(
     workspaceId,
-    { autoRetryOnFailure: false, resetKey: lastRetryCandidateMessage?.id }
+    lastRetryCandidateMessage?.id
   );
-  // Adapt the async resume to the void-returning shape the click/keybind props expect.
   const resumeInterruptedStream = () => void resumeInterruptedStreamAsync();
-  // The divider is the resume affordance only when the warning RetryBarrier is
-  // NOT shown (the user-aborted / suppressed case). When RetryBarrier is visible,
-  // its Retry button owns resume — with temporary auto-retry-on-failure recovery —
-  // so the divider stays decorative to avoid bypassing that recovery.
+  // Resumable only on the writable tail and only when RetryBarrier is suppressed
+  // (user-aborted case). When RetryBarrier is visible, its button owns resume.
   const interruptedTailResumable =
     !transcriptOnly &&
     !showRetryBarrierUI &&

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1259,7 +1259,9 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
           />
         )}
         {isAtCutoff && <EditCutoffBarrier />}
-        {interruptedBarrierMessageIds.has(message.id) && <InterruptedBarrier />}
+        {interruptedBarrierMessageIds.has(message.id) && (
+          <InterruptedBarrier workspaceId={workspaceId} />
+        )}
       </React.Fragment>
     );
   };

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -18,6 +18,7 @@ import { MarkdownRenderer } from "@/browser/features/Messages/MarkdownRenderer";
 import { useTranscriptContextMenu } from "@/browser/features/Messages/useTranscriptContextMenu";
 import type { UserMessageNavigation } from "@/browser/features/Messages/UserMessage";
 import { InterruptedBarrier } from "@/browser/features/Messages/ChatBarrier/InterruptedBarrier";
+import { useResumeStream } from "@/browser/hooks/useResumeStream";
 import { EditCutoffBarrier } from "@/browser/features/Messages/ChatBarrier/EditCutoffBarrier";
 import { StreamingBarrier } from "@/browser/features/Messages/ChatBarrier/StreamingBarrier";
 import { RetryBarrier } from "@/browser/features/Messages/ChatBarrier/RetryBarrier";
@@ -1056,6 +1057,22 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
       interruptedBarrierMessageIds.add(message.id);
     }
   }
+
+  // Resume is owned here (not in the divider) so the click and keybind paths
+  // share one instance/error, and so unmounting a transient divider can't cancel
+  // an in-flight retry. autoRetryOnFailure:false keeps the user-abort "continue
+  // once" semantic. resumeStream always continues the history tail, so only the
+  // divider on the writable resume target is interactive.
+  const { resume: resumeInterruptedStreamAsync, error: resumeInterruptedError } = useResumeStream(
+    workspaceId,
+    { autoRetryOnFailure: false }
+  );
+  // Adapt the async resume to the void-returning shape the click/keybind props expect.
+  const resumeInterruptedStream = () => void resumeInterruptedStreamAsync();
+  const interruptedTailResumable =
+    !transcriptOnly &&
+    lastRetryCandidateMessage != null &&
+    interruptedBarrierMessageIds.has(lastRetryCandidateMessage.id);
   const transcriptTailItems: TranscriptTailStackItem[] = [];
   if (shouldMountRetryBarrier) {
     transcriptTailItems.push(
@@ -1126,6 +1143,8 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     aggregator,
     setEditingMessage,
     vimEnabled,
+    canResumeInterruptedStream: interruptedTailResumable,
+    resumeInterruptedStream,
   });
 
   // Clear editing state if the message being edited no longer exists
@@ -1260,13 +1279,10 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
         )}
         {isAtCutoff && <EditCutoffBarrier />}
         {interruptedBarrierMessageIds.has(message.id) && (
-          // Only the divider on the resume target (history tail) is clickable;
-          // resumeStream always continues the tail, so older partial dividers
-          // must stay decorative to avoid resuming the wrong turn. Transcript-only
-          // (archived, no-checkout) workspaces are read-only, so resume stays off.
           <InterruptedBarrier
-            workspaceId={workspaceId}
-            resumable={!transcriptOnly && message.id === lastRetryCandidateMessage?.id}
+            resumable={interruptedTailResumable && message.id === lastRetryCandidateMessage?.id}
+            onResume={resumeInterruptedStream}
+            error={resumeInterruptedError}
           />
         )}
       </React.Fragment>

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -48,6 +48,7 @@ import {
   getInterruptionContext,
   getLastMainRetryCandidateMessage,
   getLastNonDecorativeMessage,
+  isPreTokenInterruptedUserTurn,
 } from "@/common/utils/messages/retryEligibility";
 import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { formatKeybind, KEYBINDS } from "@/browser/utils/ui/keybinds";
@@ -1056,6 +1057,19 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
     ) {
       interruptedBarrierMessageIds.add(message.id);
     }
+  }
+  // A turn interrupted before its first token leaves the user message as the tail
+  // with no assistant row, so the loop above never marks it. Mark it here (subject
+  // to the same hydration/auto-retry/streaming suppression) so the divider still
+  // offers to continue. interruptedTailResumable/render both key off this set.
+  if (
+    !isHydratingTranscript &&
+    !isAutoRetryActive &&
+    !shouldShowStreamingBarrier &&
+    lastRetryCandidateMessage != null &&
+    isPreTokenInterruptedUserTurn(lastRetryCandidateMessage, workspaceState.lastAbortReason)
+  ) {
+    interruptedBarrierMessageIds.add(lastRetryCandidateMessage.id);
   }
 
   // Owned here so the click and keybind paths share one resume/error. resetKey is

--- a/src/browser/components/ChatPane/ChatPane.tsx
+++ b/src/browser/components/ChatPane/ChatPane.tsx
@@ -1262,10 +1262,11 @@ const ChatPaneContent: React.FC<ChatPaneContentProps> = (props) => {
         {interruptedBarrierMessageIds.has(message.id) && (
           // Only the divider on the resume target (history tail) is clickable;
           // resumeStream always continues the tail, so older partial dividers
-          // must stay decorative to avoid resuming the wrong turn.
+          // must stay decorative to avoid resuming the wrong turn. Transcript-only
+          // (archived, no-checkout) workspaces are read-only, so resume stays off.
           <InterruptedBarrier
             workspaceId={workspaceId}
-            resumable={message.id === lastRetryCandidateMessage?.id}
+            resumable={!transcriptOnly && message.id === lastRetryCandidateMessage?.id}
           />
         )}
       </React.Fragment>

--- a/src/browser/features/Messages/ChatBarrier/BaseBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/BaseBarrier.tsx
@@ -6,13 +6,25 @@ interface BaseBarrierProps {
   color: string;
   animate?: boolean;
   className?: string;
+  /**
+   * When provided, the centered label becomes a clickable affordance (the
+   * gradient lines stay inert). The label gains a hover underline and pointer
+   * cursor; nothing else about the barrier changes visually.
+   */
+  onClick?: () => void;
+  /** Accessible label for the clickable variant (defaults to `text`). */
+  ariaLabel?: string;
 }
+
+const LABEL_CLASS = "font-mono text-[10px] tracking-wide whitespace-nowrap uppercase";
 
 export const BaseBarrier: React.FC<BaseBarrierProps> = ({
   text,
   color,
   animate = false,
   className,
+  onClick,
+  ariaLabel,
 }) => {
   return (
     <div
@@ -28,12 +40,24 @@ export const BaseBarrier: React.FC<BaseBarrierProps> = ({
           background: `linear-gradient(to right, transparent, ${color} 20%, ${color} 80%, transparent)`,
         }}
       />
-      <div
-        className="font-mono text-[10px] tracking-wide whitespace-nowrap uppercase"
-        style={{ color }}
-      >
-        {text}
-      </div>
+      {onClick ? (
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={ariaLabel ?? text}
+          className={cn(
+            LABEL_CLASS,
+            "m-0 cursor-pointer border-none bg-transparent p-0 leading-none hover:underline"
+          )}
+          style={{ color }}
+        >
+          {text}
+        </button>
+      ) : (
+        <div className={LABEL_CLASS} style={{ color }}>
+          {text}
+        </div>
+      )}
       <div
         className="h-px flex-1 opacity-30"
         style={{

--- a/src/browser/features/Messages/ChatBarrier/BaseBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/BaseBarrier.tsx
@@ -6,11 +6,7 @@ interface BaseBarrierProps {
   color: string;
   animate?: boolean;
   className?: string;
-  /**
-   * When provided, the centered label becomes a clickable affordance (the
-   * gradient lines stay inert). The label gains a hover underline and pointer
-   * cursor; nothing else about the barrier changes visually.
-   */
+  /** When set, the centered label becomes a clickable button (gradient lines stay inert). */
   onClick?: () => void;
   /** Accessible label for the clickable variant (defaults to `text`). */
   ariaLabel?: string;

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.test.tsx
@@ -31,7 +31,11 @@ function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): Mock
 
 let currentWorkspaceState = createWorkspaceState();
 
-let resumeStreamResult: { success: true; data: { started: boolean } } = {
+type ResumeStreamResult =
+  | { success: true; data: { started: boolean } }
+  | { success: false; error: { type: "runtime_start_failed"; message: string } };
+
+let resumeStreamResult: ResumeStreamResult = {
   success: true,
   data: { started: true },
 };
@@ -119,5 +123,21 @@ describe("InterruptedBarrier", () => {
 
     expect(view.queryByRole("button")).toBeNull();
     expect(view.getByText("interrupted")).toBeTruthy();
+  });
+
+  test("surfaces a resume failure so the click is not a silent no-op", async () => {
+    resumeStreamResult = {
+      success: false,
+      error: { type: "runtime_start_failed", message: "Runtime failed to start" },
+    };
+
+    const view = render(<InterruptedBarrier workspaceId="ws-1" resumable />);
+
+    fireEvent.click(view.getByRole("button", { name: "Continue interrupted response" }));
+
+    await waitFor(() => {
+      expect(view.getByText("Couldn't continue:")).toBeTruthy();
+    });
+    expect(view.getByText(/Runtime failed to start/)).toBeTruthy();
   });
 });

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.test.tsx
@@ -1,85 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { GlobalWindow } from "happy-dom";
-
-import type * as WorkspaceStoreModule from "@/browser/stores/WorkspaceStore";
-
-interface MockWorkspaceState {
-  autoRetryStatus: null;
-  isStreamStarting: boolean;
-  canInterrupt: boolean;
-  messages: Array<Record<string, unknown>>;
-}
-
-function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): MockWorkspaceState {
-  return {
-    autoRetryStatus: null,
-    isStreamStarting: false,
-    canInterrupt: false,
-    messages: [
-      {
-        type: "user",
-        id: "user-1",
-        historyId: "user-1",
-        content: "Hello",
-        historySequence: 1,
-      },
-    ],
-    ...overrides,
-  };
-}
-
-let currentWorkspaceState = createWorkspaceState();
-
-type ResumeStreamResult =
-  | { success: true; data: { started: boolean } }
-  | { success: false; error: { type: "runtime_start_failed"; message: string } };
-
-let resumeStreamResult: ResumeStreamResult = {
-  success: true,
-  data: { started: true },
-};
-const resumeStream = mock((_input: unknown) => Promise.resolve(resumeStreamResult));
-const setAutoRetryEnabled = mock((input: unknown) =>
-  Promise.resolve({
-    success: true as const,
-    data: {
-      previousEnabled: true,
-      enabled:
-        typeof input === "object" && input !== null && "enabled" in input
-          ? ((input as { enabled?: boolean }).enabled ?? true)
-          : true,
-    },
-  })
-);
-
-void mock.module("@/browser/contexts/API", () => ({
-  useAPI: () => ({
-    api: {
-      workspace: {
-        resumeStream,
-        setAutoRetryEnabled,
-      },
-    },
-    status: "connected" as const,
-    error: null,
-    authenticate: () => undefined,
-    retry: () => undefined,
-  }),
-}));
-
-/* eslint-disable @typescript-eslint/no-require-imports */
-const actualWorkspaceStore =
-  require("@/browser/stores/WorkspaceStore?real=1") as typeof WorkspaceStoreModule;
-/* eslint-enable @typescript-eslint/no-require-imports */
-
-void mock.module("@/browser/stores/WorkspaceStore", () => ({
-  ...actualWorkspaceStore,
-  useWorkspaceState: () => currentWorkspaceState,
-  useWorkspaceStoreRaw: () => ({
-    getWorkspaceState: (_workspaceId: string) => currentWorkspaceState,
-  }),
-}));
 
 import { InterruptedBarrier } from "./InterruptedBarrier";
 
@@ -87,57 +8,44 @@ describe("InterruptedBarrier", () => {
   beforeEach(() => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
-
-    currentWorkspaceState = createWorkspaceState();
-    resumeStreamResult = { success: true, data: { started: true } };
-    resumeStream.mockClear();
-    setAutoRetryEnabled.mockClear();
   });
 
   afterEach(() => {
     cleanup();
-    mock.restore();
     globalThis.window = undefined as unknown as Window & typeof globalThis;
     globalThis.document = undefined as unknown as Document;
   });
 
-  test("clicking the resumable interrupted label resumes the tail without touching auto-retry", async () => {
-    const view = render(<InterruptedBarrier workspaceId="ws-1" resumable />);
-
-    const label = view.getByRole("button", { name: "Continue interrupted response" });
-    fireEvent.click(label);
-
-    await waitFor(() => {
-      expect(resumeStream).toHaveBeenCalledTimes(1);
-    });
-
-    // A user-initiated (Esc) interrupt means "continue once" — it must NOT flip
-    // the auto-retry preference, so the unmount-on-auto-retry path can't cancel
-    // an in-flight scheduled retry.
-    expect(setAutoRetryEnabled).not.toHaveBeenCalled();
-    expect(resumeStream.mock.calls[0]?.[0]).toMatchObject({ workspaceId: "ws-1" });
-  });
-
-  test("a non-resumable divider renders no clickable control", () => {
-    const view = render(<InterruptedBarrier workspaceId="ws-1" resumable={false} />);
-
-    expect(view.queryByRole("button")).toBeNull();
-    expect(view.getByText("interrupted")).toBeTruthy();
-  });
-
-  test("surfaces a resume failure so the click is not a silent no-op", async () => {
-    resumeStreamResult = {
-      success: false,
-      error: { type: "runtime_start_failed", message: "Runtime failed to start" },
-    };
-
-    const view = render(<InterruptedBarrier workspaceId="ws-1" resumable />);
+  test("clicking the resumable label invokes onResume", () => {
+    const onResume = mock(() => undefined);
+    const view = render(<InterruptedBarrier resumable onResume={onResume} />);
 
     fireEvent.click(view.getByRole("button", { name: "Continue interrupted response" }));
 
-    await waitFor(() => {
-      expect(view.getByText("Couldn't continue:")).toBeTruthy();
-    });
+    expect(onResume).toHaveBeenCalledTimes(1);
+  });
+
+  test("a non-resumable divider renders no clickable control", () => {
+    const onResume = mock(() => undefined);
+    const view = render(<InterruptedBarrier resumable={false} onResume={onResume} />);
+
+    expect(view.queryByRole("button")).toBeNull();
+    expect(view.getByText("interrupted")).toBeTruthy();
+    expect(onResume).not.toHaveBeenCalled();
+  });
+
+  test("surfaces a resume failure so the action is not a silent no-op", () => {
+    const view = render(
+      <InterruptedBarrier resumable onResume={() => undefined} error="Runtime failed to start" />
+    );
+
+    expect(view.getByText("Couldn't continue:")).toBeTruthy();
     expect(view.getByText(/Runtime failed to start/)).toBeTruthy();
+  });
+
+  test("does not surface an error on a non-resumable divider", () => {
+    const view = render(<InterruptedBarrier resumable={false} error="ignored" />);
+
+    expect(view.queryByText("Couldn't continue:")).toBeNull();
   });
 });

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.test.tsx
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+
+import type * as WorkspaceStoreModule from "@/browser/stores/WorkspaceStore";
+
+interface MockWorkspaceState {
+  autoRetryStatus: null;
+  isStreamStarting: boolean;
+  canInterrupt: boolean;
+  messages: Array<Record<string, unknown>>;
+}
+
+function createWorkspaceState(overrides: Partial<MockWorkspaceState> = {}): MockWorkspaceState {
+  return {
+    autoRetryStatus: null,
+    isStreamStarting: false,
+    canInterrupt: false,
+    messages: [
+      {
+        type: "user",
+        id: "user-1",
+        historyId: "user-1",
+        content: "Hello",
+        historySequence: 1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+let currentWorkspaceState = createWorkspaceState();
+
+let resumeStreamResult: { success: true; data: { started: boolean } } = {
+  success: true,
+  data: { started: true },
+};
+const resumeStream = mock((_input: unknown) => Promise.resolve(resumeStreamResult));
+const setAutoRetryEnabled = mock((input: unknown) =>
+  Promise.resolve({
+    success: true as const,
+    data: {
+      previousEnabled: true,
+      enabled:
+        typeof input === "object" && input !== null && "enabled" in input
+          ? ((input as { enabled?: boolean }).enabled ?? true)
+          : true,
+    },
+  })
+);
+
+void mock.module("@/browser/contexts/API", () => ({
+  useAPI: () => ({
+    api: {
+      workspace: {
+        resumeStream,
+        setAutoRetryEnabled,
+      },
+    },
+    status: "connected" as const,
+    error: null,
+    authenticate: () => undefined,
+    retry: () => undefined,
+  }),
+}));
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const actualWorkspaceStore =
+  require("@/browser/stores/WorkspaceStore?real=1") as typeof WorkspaceStoreModule;
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+void mock.module("@/browser/stores/WorkspaceStore", () => ({
+  ...actualWorkspaceStore,
+  useWorkspaceState: () => currentWorkspaceState,
+  useWorkspaceStoreRaw: () => ({
+    getWorkspaceState: (_workspaceId: string) => currentWorkspaceState,
+  }),
+}));
+
+import { InterruptedBarrier } from "./InterruptedBarrier";
+
+describe("InterruptedBarrier", () => {
+  beforeEach(() => {
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+
+    currentWorkspaceState = createWorkspaceState();
+    resumeStreamResult = { success: true, data: { started: true } };
+    resumeStream.mockClear();
+    setAutoRetryEnabled.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+  });
+
+  test("clicking the interrupted label resumes the stream", async () => {
+    const view = render(<InterruptedBarrier workspaceId="ws-1" />);
+
+    const label = view.getByRole("button", { name: "Continue interrupted response" });
+    fireEvent.click(label);
+
+    await waitFor(() => {
+      expect(resumeStream).toHaveBeenCalledTimes(1);
+    });
+
+    // Temporarily enables auto-retry (persist:false) before resuming, mirroring
+    // the RetryBarrier / backend auto-retry flow.
+    expect(setAutoRetryEnabled).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      enabled: true,
+      persist: false,
+    });
+    expect(resumeStream.mock.calls[0]?.[0]).toMatchObject({ workspaceId: "ws-1" });
+  });
+});

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.test.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.test.tsx
@@ -97,8 +97,8 @@ describe("InterruptedBarrier", () => {
     globalThis.document = undefined as unknown as Document;
   });
 
-  test("clicking the interrupted label resumes the stream", async () => {
-    const view = render(<InterruptedBarrier workspaceId="ws-1" />);
+  test("clicking the resumable interrupted label resumes the tail without touching auto-retry", async () => {
+    const view = render(<InterruptedBarrier workspaceId="ws-1" resumable />);
 
     const label = view.getByRole("button", { name: "Continue interrupted response" });
     fireEvent.click(label);
@@ -107,13 +107,17 @@ describe("InterruptedBarrier", () => {
       expect(resumeStream).toHaveBeenCalledTimes(1);
     });
 
-    // Temporarily enables auto-retry (persist:false) before resuming, mirroring
-    // the RetryBarrier / backend auto-retry flow.
-    expect(setAutoRetryEnabled).toHaveBeenCalledWith({
-      workspaceId: "ws-1",
-      enabled: true,
-      persist: false,
-    });
+    // A user-initiated (Esc) interrupt means "continue once" — it must NOT flip
+    // the auto-retry preference, so the unmount-on-auto-retry path can't cancel
+    // an in-flight scheduled retry.
+    expect(setAutoRetryEnabled).not.toHaveBeenCalled();
     expect(resumeStream.mock.calls[0]?.[0]).toMatchObject({ workspaceId: "ws-1" });
+  });
+
+  test("a non-resumable divider renders no clickable control", () => {
+    const view = render(<InterruptedBarrier workspaceId="ws-1" resumable={false} />);
+
+    expect(view.queryByRole("button")).toBeNull();
+    expect(view.getByText("interrupted")).toBeTruthy();
   });
 });

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
@@ -25,14 +25,23 @@ interface InterruptedBarrierProps {
  */
 export const InterruptedBarrier: React.FC<InterruptedBarrierProps> = (props) => {
   // resume() internally guards against re-entrancy while a resume is in flight.
-  const { resume } = useResumeStream(props.workspaceId, { autoRetryOnFailure: false });
+  const { resume, error } = useResumeStream(props.workspaceId, { autoRetryOnFailure: false });
   return (
-    <BaseBarrier
-      text="interrupted"
-      color="var(--color-interrupted)"
-      className={props.className}
-      onClick={props.resumable ? () => void resume() : undefined}
-      ariaLabel={props.resumable ? "Continue interrupted response" : undefined}
-    />
+    <>
+      <BaseBarrier
+        text="interrupted"
+        color="var(--color-interrupted)"
+        className={props.className}
+        onClick={props.resumable ? () => void resume() : undefined}
+        ariaLabel={props.resumable ? "Continue interrupted response" : undefined}
+      />
+      {props.resumable && error && (
+        // This divider is the only continue affordance for a user-aborted stream,
+        // so a resume failure must be visible or the click looks like a no-op.
+        <div className="font-primary text-foreground/80 text-center text-[12px]">
+          <span className="text-warning font-semibold">Couldn&apos;t continue:</span> {error}
+        </div>
+      )}
+    </>
   );
 };

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
@@ -2,13 +2,9 @@ import React from "react";
 import { BaseBarrier } from "./BaseBarrier";
 
 interface InterruptedBarrierProps {
-  /**
-   * Whether this divider sits on the resumable turn (the history tail) and the
-   * workspace is writable. resumeStream always continues the tail, so only the
-   * tail divider is clickable; older partial dividers stay decorative.
-   */
+  /** True on the writable resume target (history tail); only then is the label clickable. */
   resumable?: boolean;
-  /** Resume/continue handler (owned by ChatPane); used only when `resumable`. */
+  /** Resume handler (owned by ChatPane); used only when `resumable`. */
   onResume?: () => void;
   /** Last resume failure, surfaced inline so a click/keybind isn't a silent no-op. */
   error?: string | null;
@@ -16,12 +12,9 @@ interface InterruptedBarrierProps {
 }
 
 /**
- * "interrupted" divider shown on a partial assistant turn. When it sits on the
- * resumable tail, clicking the label continues the stream from where it stopped
- * (same backend path as RetryBarrier / auto-retry). This is the only continue
- * affordance for user-initiated (Esc) interrupts, where RetryBarrier is
- * suppressed. The resume action and its error are owned by ChatPane so the
- * keybind path and click path share one source of truth.
+ * "interrupted" divider on a partial assistant turn. On the resumable tail the
+ * label continues the stream (the only continue affordance for Esc interrupts,
+ * where RetryBarrier is suppressed).
  */
 export const InterruptedBarrier: React.FC<InterruptedBarrierProps> = (props) => {
   return (
@@ -34,8 +27,7 @@ export const InterruptedBarrier: React.FC<InterruptedBarrierProps> = (props) => 
         ariaLabel={props.resumable ? "Continue interrupted response" : undefined}
       />
       {props.resumable && props.error && (
-        // This divider is the only continue affordance for a user-aborted stream,
-        // so a resume failure must be visible or the action looks like a no-op.
+        // Surface failures: this is the only continue affordance for an Esc interrupt.
         <div className="font-primary text-foreground/80 text-center text-[12px]">
           <span className="text-warning font-semibold">Couldn&apos;t continue:</span> {props.error}
         </div>

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
@@ -4,27 +4,35 @@ import { useResumeStream } from "@/browser/hooks/useResumeStream";
 
 interface InterruptedBarrierProps {
   workspaceId: string;
+  /**
+   * Whether this divider sits on the current resume target (the history tail).
+   * resumeStream always continues the tail, so only the tail divider is made
+   * clickable — older partial dividers stay decorative to avoid resuming the
+   * wrong turn.
+   */
+  resumable?: boolean;
   className?: string;
 }
 
 /**
- * Decorative "interrupted" divider shown on a partial assistant turn. Clicking
- * the label continues the stream from where it stopped, identical to the
- * RetryBarrier's Retry button and the backend auto-retry path (resumeStream).
- * This is the only continue affordance for user-initiated (Esc) interrupts,
- * where the RetryBarrier is intentionally suppressed.
+ * "interrupted" divider shown on a partial assistant turn. When it sits on the
+ * resumable tail, clicking the label continues the stream from where it stopped
+ * (same backend path as RetryBarrier / auto-retry). It is the only continue
+ * affordance for user-initiated (Esc) interrupts, where RetryBarrier is
+ * suppressed. autoRetryOnFailure is disabled because ChatPane unmounts this
+ * divider once auto-retry becomes active; see useResumeStream for why that
+ * matters.
  */
 export const InterruptedBarrier: React.FC<InterruptedBarrierProps> = (props) => {
-  // resume() internally guards against re-entrancy while a resume is in flight,
-  // so we always keep the clickable label mounted (no button<->div remount flicker).
-  const { resume } = useResumeStream(props.workspaceId);
+  // resume() internally guards against re-entrancy while a resume is in flight.
+  const { resume } = useResumeStream(props.workspaceId, { autoRetryOnFailure: false });
   return (
     <BaseBarrier
       text="interrupted"
       color="var(--color-interrupted)"
       className={props.className}
-      onClick={() => void resume()}
-      ariaLabel="Continue interrupted response"
+      onClick={props.resumable ? () => void resume() : undefined}
+      ariaLabel={props.resumable ? "Continue interrupted response" : undefined}
     />
   );
 };

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
@@ -1,10 +1,30 @@
 import React from "react";
 import { BaseBarrier } from "./BaseBarrier";
+import { useResumeStream } from "@/browser/hooks/useResumeStream";
 
 interface InterruptedBarrierProps {
+  workspaceId: string;
   className?: string;
 }
 
-export const InterruptedBarrier: React.FC<InterruptedBarrierProps> = ({ className }) => {
-  return <BaseBarrier text="interrupted" color="var(--color-interrupted)" className={className} />;
+/**
+ * Decorative "interrupted" divider shown on a partial assistant turn. Clicking
+ * the label continues the stream from where it stopped, identical to the
+ * RetryBarrier's Retry button and the backend auto-retry path (resumeStream).
+ * This is the only continue affordance for user-initiated (Esc) interrupts,
+ * where the RetryBarrier is intentionally suppressed.
+ */
+export const InterruptedBarrier: React.FC<InterruptedBarrierProps> = (props) => {
+  // resume() internally guards against re-entrancy while a resume is in flight,
+  // so we always keep the clickable label mounted (no button<->div remount flicker).
+  const { resume } = useResumeStream(props.workspaceId);
+  return (
+    <BaseBarrier
+      text="interrupted"
+      color="var(--color-interrupted)"
+      className={props.className}
+      onClick={() => void resume()}
+      ariaLabel="Continue interrupted response"
+    />
+  );
 };

--- a/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/InterruptedBarrier.tsx
@@ -1,45 +1,43 @@
 import React from "react";
 import { BaseBarrier } from "./BaseBarrier";
-import { useResumeStream } from "@/browser/hooks/useResumeStream";
 
 interface InterruptedBarrierProps {
-  workspaceId: string;
   /**
-   * Whether this divider sits on the current resume target (the history tail).
-   * resumeStream always continues the tail, so only the tail divider is made
-   * clickable — older partial dividers stay decorative to avoid resuming the
-   * wrong turn.
+   * Whether this divider sits on the resumable turn (the history tail) and the
+   * workspace is writable. resumeStream always continues the tail, so only the
+   * tail divider is clickable; older partial dividers stay decorative.
    */
   resumable?: boolean;
+  /** Resume/continue handler (owned by ChatPane); used only when `resumable`. */
+  onResume?: () => void;
+  /** Last resume failure, surfaced inline so a click/keybind isn't a silent no-op. */
+  error?: string | null;
   className?: string;
 }
 
 /**
  * "interrupted" divider shown on a partial assistant turn. When it sits on the
  * resumable tail, clicking the label continues the stream from where it stopped
- * (same backend path as RetryBarrier / auto-retry). It is the only continue
+ * (same backend path as RetryBarrier / auto-retry). This is the only continue
  * affordance for user-initiated (Esc) interrupts, where RetryBarrier is
- * suppressed. autoRetryOnFailure is disabled because ChatPane unmounts this
- * divider once auto-retry becomes active; see useResumeStream for why that
- * matters.
+ * suppressed. The resume action and its error are owned by ChatPane so the
+ * keybind path and click path share one source of truth.
  */
 export const InterruptedBarrier: React.FC<InterruptedBarrierProps> = (props) => {
-  // resume() internally guards against re-entrancy while a resume is in flight.
-  const { resume, error } = useResumeStream(props.workspaceId, { autoRetryOnFailure: false });
   return (
     <>
       <BaseBarrier
         text="interrupted"
         color="var(--color-interrupted)"
         className={props.className}
-        onClick={props.resumable ? () => void resume() : undefined}
+        onClick={props.resumable ? props.onResume : undefined}
         ariaLabel={props.resumable ? "Continue interrupted response" : undefined}
       />
-      {props.resumable && error && (
+      {props.resumable && props.error && (
         // This divider is the only continue affordance for a user-aborted stream,
-        // so a resume failure must be visible or the click looks like a no-op.
+        // so a resume failure must be visible or the action looks like a no-op.
         <div className="font-primary text-foreground/80 text-center text-[12px]">
-          <span className="text-warning font-semibold">Couldn&apos;t continue:</span> {error}
+          <span className="text-warning font-semibold">Couldn&apos;t continue:</span> {props.error}
         </div>
       )}
     </>

--- a/src/browser/features/Messages/ChatBarrier/RetryBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/RetryBarrier.tsx
@@ -1,15 +1,12 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { useAPI } from "@/browser/contexts/API";
 import { useWorkspaceState } from "@/browser/stores/WorkspaceStore";
+import { useResumeStream } from "@/browser/hooks/useResumeStream";
 import { getLastMainRetryCandidateMessage } from "@/common/utils/messages/retryEligibility";
 import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
 import { VIM_ENABLED_KEY } from "@/common/constants/storage";
-import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
-import { applyCompactionOverrides } from "@/browser/utils/messages/compactionOptions";
-import { formatSendMessageError } from "@/common/utils/errors/formatSendError";
-import { getErrorMessage } from "@/common/utils/errors";
 
 interface RetryBarrierProps {
   workspaceId: string;
@@ -20,8 +17,12 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
   const { api } = useAPI();
   const workspaceState = useWorkspaceState(props.workspaceId);
   const [countdown, setCountdown] = useState(0);
-  const [manualRetryError, setManualRetryError] = useState<string | null>(null);
-  const [isManualRetrying, setIsManualRetrying] = useState(false);
+  const {
+    resume,
+    isResuming: isManualRetrying,
+    error: manualRetryError,
+    clearError: clearManualRetryError,
+  } = useResumeStream(props.workspaceId);
 
   const [vimEnabled] = usePersistedState<boolean>(VIM_ENABLED_KEY, false, { listener: true });
   const stopKeybind = formatKeybind(
@@ -33,101 +34,6 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
   const isAutoRetryActive =
     autoRetryStatus?.type === "auto-retry-scheduled" ||
     autoRetryStatus?.type === "auto-retry-starting";
-
-  const manualRetryRollbackWorkspaceIdRef = useRef<string | null>(null);
-  const manualRetryRollbackPendingRef = useRef(false);
-  const manualRetryRollbackArmedRef = useRef(false);
-  const manualRetryRollbackBaselineMessageCountRef = useRef<number | null>(null);
-  const apiRef = useRef(api);
-
-  useEffect(() => {
-    apiRef.current = api;
-  }, [api]);
-
-  const rollbackManualRetryAutoRetryIfNeeded = useCallback(
-    async (options?: { suppressErrors?: boolean }): Promise<void> => {
-      if (!manualRetryRollbackPendingRef.current) {
-        return;
-      }
-
-      const rollbackWorkspaceId = manualRetryRollbackWorkspaceIdRef.current;
-      manualRetryRollbackPendingRef.current = false;
-      manualRetryRollbackArmedRef.current = false;
-      manualRetryRollbackBaselineMessageCountRef.current = null;
-      manualRetryRollbackWorkspaceIdRef.current = null;
-
-      const activeApi = apiRef.current;
-      if (!activeApi || !rollbackWorkspaceId) {
-        return;
-      }
-
-      const rollbackResult = await activeApi.workspace.setAutoRetryEnabled?.({
-        workspaceId: rollbackWorkspaceId,
-        enabled: false,
-        persist: false,
-      });
-      if (rollbackResult && !rollbackResult.success && !options?.suppressErrors) {
-        setManualRetryError(rollbackResult.error);
-      }
-    },
-    []
-  );
-
-  useEffect(() => {
-    if (!manualRetryRollbackPendingRef.current) {
-      return;
-    }
-
-    const rollbackWorkspaceId = manualRetryRollbackWorkspaceIdRef.current;
-    if (!rollbackWorkspaceId || rollbackWorkspaceId === props.workspaceId) {
-      return;
-    }
-
-    void rollbackManualRetryAutoRetryIfNeeded();
-  }, [props.workspaceId, rollbackManualRetryAutoRetryIfNeeded]);
-
-  useEffect(() => {
-    return () => {
-      if (!manualRetryRollbackPendingRef.current) {
-        return;
-      }
-
-      void rollbackManualRetryAutoRetryIfNeeded({ suppressErrors: true });
-    };
-  }, [rollbackManualRetryAutoRetryIfNeeded]);
-
-  useEffect(() => {
-    if (!manualRetryRollbackPendingRef.current) {
-      return;
-    }
-
-    const autoRetryActive =
-      autoRetryStatus?.type === "auto-retry-scheduled" ||
-      autoRetryStatus?.type === "auto-retry-starting";
-    const streamInFlight = workspaceState.isStreamStarting || workspaceState.canInterrupt;
-
-    // Mirror ask_user rollback semantics: keep temporary enablement while the resumed
-    // stream/retry attempt is in flight, then restore preference after terminal outcome.
-    if (autoRetryActive || streamInFlight) {
-      manualRetryRollbackArmedRef.current = true;
-      return;
-    }
-
-    const baselineMessageCount = manualRetryRollbackBaselineMessageCountRef.current;
-    const hasObservedPostRetryMessage =
-      baselineMessageCount !== null && workspaceState.messages.length > baselineMessageCount;
-    if (!manualRetryRollbackArmedRef.current && !hasObservedPostRetryMessage) {
-      return;
-    }
-
-    void rollbackManualRetryAutoRetryIfNeeded();
-  }, [
-    autoRetryStatus,
-    workspaceState.isStreamStarting,
-    workspaceState.canInterrupt,
-    workspaceState.messages.length,
-    rollbackManualRetryAutoRetryIfNeeded,
-  ]);
 
   useEffect(() => {
     if (!isAutoRetryScheduled) {
@@ -148,94 +54,19 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
 
   useEffect(() => {
     if (props.visible === false) {
-      setManualRetryError(null);
+      clearManualRetryError();
     }
-  }, [props.visible]);
+  }, [props.visible, clearManualRetryError]);
 
   useEffect(() => {
     if (isAutoRetryActive) {
-      setManualRetryError(null);
+      clearManualRetryError();
     }
-  }, [isAutoRetryActive]);
-  const handleManualRetry = async () => {
-    if (!api) {
-      setManualRetryError("Not connected to server");
-      return;
-    }
-
-    if (isManualRetrying) {
-      return;
-    }
-
-    setIsManualRetrying(true);
-    setManualRetryError(null);
-
-    try {
-      let options = getSendOptionsFromStorage(props.workspaceId);
-      const lastUserMessage = [...workspaceState.messages]
-        .reverse()
-        .find(
-          (message): message is Extract<typeof message, { type: "user" }> => message.type === "user"
-        );
-
-      if (lastUserMessage?.compactionRequest) {
-        options = applyCompactionOverrides(options, lastUserMessage.compactionRequest.parsed);
-      }
-
-      const enableResult = await api.workspace.setAutoRetryEnabled?.({
-        workspaceId: props.workspaceId,
-        enabled: true,
-        persist: false,
-      });
-      if (enableResult && !enableResult.success) {
-        setManualRetryError(enableResult.error);
-        return;
-      }
-
-      if (enableResult?.success && enableResult.data.previousEnabled === false) {
-        // Manual retry temporarily enables auto-retry for this resumed attempt.
-        // Restore only when stream/retry outcome is terminal.
-        manualRetryRollbackWorkspaceIdRef.current = props.workspaceId;
-        manualRetryRollbackPendingRef.current = true;
-        manualRetryRollbackArmedRef.current = false;
-        manualRetryRollbackBaselineMessageCountRef.current = workspaceState.messages.length;
-      }
-
-      const resumeResult = await api.workspace.resumeStream({
-        workspaceId: props.workspaceId,
-        options,
-      });
-
-      if (!resumeResult.success) {
-        const formatted = formatSendMessageError(resumeResult.error);
-        const details = formatted.resolutionHint
-          ? `${formatted.message} ${formatted.resolutionHint}`
-          : formatted.message;
-        setManualRetryError(details);
-
-        // Keep preference consistent when resume fails before retry/stream events.
-        await rollbackManualRetryAutoRetryIfNeeded();
-        return;
-      }
-
-      if (
-        manualRetryRollbackPendingRef.current &&
-        !manualRetryRollbackArmedRef.current &&
-        resumeResult.data.started === false
-      ) {
-        await rollbackManualRetryAutoRetryIfNeeded();
-      }
-    } catch (error) {
-      setManualRetryError(getErrorMessage(error));
-      await rollbackManualRetryAutoRetryIfNeeded();
-    } finally {
-      setIsManualRetrying(false);
-    }
-  };
+  }, [isAutoRetryActive, clearManualRetryError]);
 
   const handleStopAutoRetry = () => {
     setCountdown(0);
-    setManualRetryError(null);
+    clearManualRetryError();
     void api?.workspace.setAutoRetryEnabled?.({ workspaceId: props.workspaceId, enabled: false });
   };
 
@@ -264,7 +95,7 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
       className="bg-warning font-primary text-background cursor-pointer rounded border-none px-4 py-2 text-xs font-semibold whitespace-nowrap transition-all duration-200 hover:-translate-y-px hover:brightness-120 active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-50"
       disabled={isManualRetrying}
       onClick={() => {
-        void handleManualRetry();
+        void resume();
       }}
     >
       Retry

--- a/src/browser/features/Messages/ChatBarrier/RetryBarrier.tsx
+++ b/src/browser/features/Messages/ChatBarrier/RetryBarrier.tsx
@@ -1,12 +1,15 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { usePersistedState } from "@/browser/hooks/usePersistedState";
 import { useAPI } from "@/browser/contexts/API";
 import { useWorkspaceState } from "@/browser/stores/WorkspaceStore";
-import { useResumeStream } from "@/browser/hooks/useResumeStream";
 import { getLastMainRetryCandidateMessage } from "@/common/utils/messages/retryEligibility";
 import { KEYBINDS, formatKeybind } from "@/browser/utils/ui/keybinds";
 import { VIM_ENABLED_KEY } from "@/common/constants/storage";
+import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
+import { applyCompactionOverrides } from "@/browser/utils/messages/compactionOptions";
+import { formatSendMessageError } from "@/common/utils/errors/formatSendError";
+import { getErrorMessage } from "@/common/utils/errors";
 
 interface RetryBarrierProps {
   workspaceId: string;
@@ -17,12 +20,8 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
   const { api } = useAPI();
   const workspaceState = useWorkspaceState(props.workspaceId);
   const [countdown, setCountdown] = useState(0);
-  const {
-    resume,
-    isResuming: isManualRetrying,
-    error: manualRetryError,
-    clearError: clearManualRetryError,
-  } = useResumeStream(props.workspaceId);
+  const [manualRetryError, setManualRetryError] = useState<string | null>(null);
+  const [isManualRetrying, setIsManualRetrying] = useState(false);
 
   const [vimEnabled] = usePersistedState<boolean>(VIM_ENABLED_KEY, false, { listener: true });
   const stopKeybind = formatKeybind(
@@ -34,6 +33,101 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
   const isAutoRetryActive =
     autoRetryStatus?.type === "auto-retry-scheduled" ||
     autoRetryStatus?.type === "auto-retry-starting";
+
+  const manualRetryRollbackWorkspaceIdRef = useRef<string | null>(null);
+  const manualRetryRollbackPendingRef = useRef(false);
+  const manualRetryRollbackArmedRef = useRef(false);
+  const manualRetryRollbackBaselineMessageCountRef = useRef<number | null>(null);
+  const apiRef = useRef(api);
+
+  useEffect(() => {
+    apiRef.current = api;
+  }, [api]);
+
+  const rollbackManualRetryAutoRetryIfNeeded = useCallback(
+    async (options?: { suppressErrors?: boolean }): Promise<void> => {
+      if (!manualRetryRollbackPendingRef.current) {
+        return;
+      }
+
+      const rollbackWorkspaceId = manualRetryRollbackWorkspaceIdRef.current;
+      manualRetryRollbackPendingRef.current = false;
+      manualRetryRollbackArmedRef.current = false;
+      manualRetryRollbackBaselineMessageCountRef.current = null;
+      manualRetryRollbackWorkspaceIdRef.current = null;
+
+      const activeApi = apiRef.current;
+      if (!activeApi || !rollbackWorkspaceId) {
+        return;
+      }
+
+      const rollbackResult = await activeApi.workspace.setAutoRetryEnabled?.({
+        workspaceId: rollbackWorkspaceId,
+        enabled: false,
+        persist: false,
+      });
+      if (rollbackResult && !rollbackResult.success && !options?.suppressErrors) {
+        setManualRetryError(rollbackResult.error);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!manualRetryRollbackPendingRef.current) {
+      return;
+    }
+
+    const rollbackWorkspaceId = manualRetryRollbackWorkspaceIdRef.current;
+    if (!rollbackWorkspaceId || rollbackWorkspaceId === props.workspaceId) {
+      return;
+    }
+
+    void rollbackManualRetryAutoRetryIfNeeded();
+  }, [props.workspaceId, rollbackManualRetryAutoRetryIfNeeded]);
+
+  useEffect(() => {
+    return () => {
+      if (!manualRetryRollbackPendingRef.current) {
+        return;
+      }
+
+      void rollbackManualRetryAutoRetryIfNeeded({ suppressErrors: true });
+    };
+  }, [rollbackManualRetryAutoRetryIfNeeded]);
+
+  useEffect(() => {
+    if (!manualRetryRollbackPendingRef.current) {
+      return;
+    }
+
+    const autoRetryActive =
+      autoRetryStatus?.type === "auto-retry-scheduled" ||
+      autoRetryStatus?.type === "auto-retry-starting";
+    const streamInFlight = workspaceState.isStreamStarting || workspaceState.canInterrupt;
+
+    // Mirror ask_user rollback semantics: keep temporary enablement while the resumed
+    // stream/retry attempt is in flight, then restore preference after terminal outcome.
+    if (autoRetryActive || streamInFlight) {
+      manualRetryRollbackArmedRef.current = true;
+      return;
+    }
+
+    const baselineMessageCount = manualRetryRollbackBaselineMessageCountRef.current;
+    const hasObservedPostRetryMessage =
+      baselineMessageCount !== null && workspaceState.messages.length > baselineMessageCount;
+    if (!manualRetryRollbackArmedRef.current && !hasObservedPostRetryMessage) {
+      return;
+    }
+
+    void rollbackManualRetryAutoRetryIfNeeded();
+  }, [
+    autoRetryStatus,
+    workspaceState.isStreamStarting,
+    workspaceState.canInterrupt,
+    workspaceState.messages.length,
+    rollbackManualRetryAutoRetryIfNeeded,
+  ]);
 
   useEffect(() => {
     if (!isAutoRetryScheduled) {
@@ -54,19 +148,94 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
 
   useEffect(() => {
     if (props.visible === false) {
-      clearManualRetryError();
+      setManualRetryError(null);
     }
-  }, [props.visible, clearManualRetryError]);
+  }, [props.visible]);
 
   useEffect(() => {
     if (isAutoRetryActive) {
-      clearManualRetryError();
+      setManualRetryError(null);
     }
-  }, [isAutoRetryActive, clearManualRetryError]);
+  }, [isAutoRetryActive]);
+  const handleManualRetry = async () => {
+    if (!api) {
+      setManualRetryError("Not connected to server");
+      return;
+    }
+
+    if (isManualRetrying) {
+      return;
+    }
+
+    setIsManualRetrying(true);
+    setManualRetryError(null);
+
+    try {
+      let options = getSendOptionsFromStorage(props.workspaceId);
+      const lastUserMessage = [...workspaceState.messages]
+        .reverse()
+        .find(
+          (message): message is Extract<typeof message, { type: "user" }> => message.type === "user"
+        );
+
+      if (lastUserMessage?.compactionRequest) {
+        options = applyCompactionOverrides(options, lastUserMessage.compactionRequest.parsed);
+      }
+
+      const enableResult = await api.workspace.setAutoRetryEnabled?.({
+        workspaceId: props.workspaceId,
+        enabled: true,
+        persist: false,
+      });
+      if (enableResult && !enableResult.success) {
+        setManualRetryError(enableResult.error);
+        return;
+      }
+
+      if (enableResult?.success && enableResult.data.previousEnabled === false) {
+        // Manual retry temporarily enables auto-retry for this resumed attempt.
+        // Restore only when stream/retry outcome is terminal.
+        manualRetryRollbackWorkspaceIdRef.current = props.workspaceId;
+        manualRetryRollbackPendingRef.current = true;
+        manualRetryRollbackArmedRef.current = false;
+        manualRetryRollbackBaselineMessageCountRef.current = workspaceState.messages.length;
+      }
+
+      const resumeResult = await api.workspace.resumeStream({
+        workspaceId: props.workspaceId,
+        options,
+      });
+
+      if (!resumeResult.success) {
+        const formatted = formatSendMessageError(resumeResult.error);
+        const details = formatted.resolutionHint
+          ? `${formatted.message} ${formatted.resolutionHint}`
+          : formatted.message;
+        setManualRetryError(details);
+
+        // Keep preference consistent when resume fails before retry/stream events.
+        await rollbackManualRetryAutoRetryIfNeeded();
+        return;
+      }
+
+      if (
+        manualRetryRollbackPendingRef.current &&
+        !manualRetryRollbackArmedRef.current &&
+        resumeResult.data.started === false
+      ) {
+        await rollbackManualRetryAutoRetryIfNeeded();
+      }
+    } catch (error) {
+      setManualRetryError(getErrorMessage(error));
+      await rollbackManualRetryAutoRetryIfNeeded();
+    } finally {
+      setIsManualRetrying(false);
+    }
+  };
 
   const handleStopAutoRetry = () => {
     setCountdown(0);
-    clearManualRetryError();
+    setManualRetryError(null);
     void api?.workspace.setAutoRetryEnabled?.({ workspaceId: props.workspaceId, enabled: false });
   };
 
@@ -95,7 +264,7 @@ export const RetryBarrier: React.FC<RetryBarrierProps> = (props) => {
       className="bg-warning font-primary text-background cursor-pointer rounded border-none px-4 py-2 text-xs font-semibold whitespace-nowrap transition-all duration-200 hover:-translate-y-px hover:brightness-120 active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-50"
       disabled={isManualRetrying}
       onClick={() => {
-        void resume();
+        void handleManualRetry();
       }}
     >
       Retry

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -118,6 +118,7 @@ const KEYBIND_GROUPS: Array<{ label: string; keys: Array<keyof typeof KEYBINDS> 
       "CANCEL",
       "INTERRUPT_STREAM_NORMAL",
       "INTERRUPT_STREAM_VIM",
+      "RESUME_STREAM",
       "TOGGLE_VOICE_INPUT",
     ],
   },

--- a/src/browser/features/Settings/Sections/KeybindsSection.tsx
+++ b/src/browser/features/Settings/Sections/KeybindsSection.tsx
@@ -17,6 +17,7 @@ const KEYBIND_LABELS: Record<keyof typeof KEYBINDS, string> = {
   SAVE_EDIT: "Save edit",
   INTERRUPT_STREAM_VIM: "Interrupt stream (Vim mode)",
   INTERRUPT_STREAM_NORMAL: "Interrupt stream",
+  RESUME_STREAM: "Continue interrupted stream",
   FOCUS_INPUT_I: "Focus input (i)",
   FOCUS_INPUT_A: "Focus input (a)",
   NEW_WORKSPACE: "New workspace",

--- a/src/browser/hooks/useAIViewKeybinds.test.tsx
+++ b/src/browser/hooks/useAIViewKeybinds.test.tsx
@@ -421,4 +421,70 @@ describe("useAIViewKeybinds", () => {
 
     expect(interruptStream.mock.calls.length).toBe(0);
   });
+
+  test("Ctrl+Shift+Enter resumes when a resumable interrupted turn is shown", () => {
+    const resumeInterruptedStream = mock(() => undefined);
+    const chatInputAPI: RefObject<ChatInputAPI | null> = { current: null };
+
+    renderUseAIViewKeybinds({
+      workspaceId: "ws",
+      canInterrupt: false,
+      showRetryBarrier: false,
+      chatInputAPI,
+      jumpToBottom: () => undefined,
+      loadOlderHistory: null,
+      handleOpenTerminal: () => undefined,
+      handleOpenInEditor: () => undefined,
+      aggregator: undefined,
+      setEditingMessage: () => undefined,
+      vimEnabled: false,
+      canResumeInterruptedStream: true,
+      resumeInterruptedStream,
+    });
+
+    document.body.dispatchEvent(
+      new window.KeyboardEvent("keydown", {
+        key: "Enter",
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    expect(resumeInterruptedStream.mock.calls.length).toBe(1);
+  });
+
+  test("Ctrl+Shift+Enter does nothing when no resumable turn is shown", () => {
+    const resumeInterruptedStream = mock(() => undefined);
+    const chatInputAPI: RefObject<ChatInputAPI | null> = { current: null };
+
+    renderUseAIViewKeybinds({
+      workspaceId: "ws",
+      canInterrupt: false,
+      showRetryBarrier: false,
+      chatInputAPI,
+      jumpToBottom: () => undefined,
+      loadOlderHistory: null,
+      handleOpenTerminal: () => undefined,
+      handleOpenInEditor: () => undefined,
+      aggregator: undefined,
+      setEditingMessage: () => undefined,
+      vimEnabled: false,
+      canResumeInterruptedStream: false,
+      resumeInterruptedStream,
+    });
+
+    document.body.dispatchEvent(
+      new window.KeyboardEvent("keydown", {
+        key: "Enter",
+        ctrlKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    expect(resumeInterruptedStream.mock.calls.length).toBe(0);
+  });
 });

--- a/src/browser/hooks/useAIViewKeybinds.test.tsx
+++ b/src/browser/hooks/useAIViewKeybinds.test.tsx
@@ -422,7 +422,7 @@ describe("useAIViewKeybinds", () => {
     expect(interruptStream.mock.calls.length).toBe(0);
   });
 
-  test("Ctrl+Shift+Enter resumes when a resumable interrupted turn is shown", () => {
+  test("Shift+R resumes when a resumable interrupted turn is shown", () => {
     const resumeInterruptedStream = mock(() => undefined);
     const chatInputAPI: RefObject<ChatInputAPI | null> = { current: null };
 
@@ -444,8 +444,7 @@ describe("useAIViewKeybinds", () => {
 
     document.body.dispatchEvent(
       new window.KeyboardEvent("keydown", {
-        key: "Enter",
-        ctrlKey: true,
+        key: "R",
         shiftKey: true,
         bubbles: true,
         cancelable: true,
@@ -455,7 +454,7 @@ describe("useAIViewKeybinds", () => {
     expect(resumeInterruptedStream.mock.calls.length).toBe(1);
   });
 
-  test("Ctrl+Shift+Enter does nothing when no resumable turn is shown", () => {
+  test("Shift+R does nothing when no resumable turn is shown", () => {
     const resumeInterruptedStream = mock(() => undefined);
     const chatInputAPI: RefObject<ChatInputAPI | null> = { current: null };
 
@@ -477,8 +476,45 @@ describe("useAIViewKeybinds", () => {
 
     document.body.dispatchEvent(
       new window.KeyboardEvent("keydown", {
-        key: "Enter",
-        ctrlKey: true,
+        key: "R",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+
+    expect(resumeInterruptedStream.mock.calls.length).toBe(0);
+  });
+
+  test("Shift+R does not resume while typing in an input (types normally)", () => {
+    const resumeInterruptedStream = mock(() => undefined);
+    const chatInputAPI: RefObject<ChatInputAPI | null> = { current: null };
+
+    renderUseAIViewKeybinds({
+      workspaceId: "ws",
+      canInterrupt: false,
+      showRetryBarrier: false,
+      chatInputAPI,
+      jumpToBottom: () => undefined,
+      loadOlderHistory: null,
+      handleOpenTerminal: () => undefined,
+      handleOpenInEditor: () => undefined,
+      aggregator: undefined,
+      setEditingMessage: () => undefined,
+      vimEnabled: false,
+      canResumeInterruptedStream: true,
+      resumeInterruptedStream,
+    });
+
+    // Composer/terminal are editable elements, so the transcript-scoped key must
+    // type "R" instead of resuming.
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    input.dispatchEvent(
+      new window.KeyboardEvent("keydown", {
+        key: "R",
         shiftKey: true,
         bubbles: true,
         cancelable: true,

--- a/src/browser/hooks/useAIViewKeybinds.ts
+++ b/src/browser/hooks/useAIViewKeybinds.ts
@@ -26,11 +26,16 @@ interface UseAIViewKeybindsParams {
   aggregator: StreamingMessageAggregator | undefined; // For compaction detection
   setEditingMessage: (editing: EditingMessageState | undefined) => void;
   vimEnabled: boolean; // For vim-aware interrupt keybind
+  // RESUME_STREAM keybind: continue an interrupted stream. Optional so the hook
+  // stays drop-in for callers/tests that don't surface a resume affordance.
+  canResumeInterruptedStream?: boolean; // Whether a resumable interrupted turn is shown
+  resumeInterruptedStream?: () => void; // Continue the interrupted stream
 }
 
 /**
  * Manages keyboard shortcuts for AIView:
  * - Esc (non-vim) or Ctrl+C (vim): Interrupt stream (Escape skips text inputs by default)
+ * - Ctrl/Cmd+Shift+Enter: Resume an interrupted stream (when a resumable turn is shown)
  * - Ctrl+I: Focus chat input
  * - Shift+H: Load older transcript messages (when available)
  * - Shift+G: Jump to bottom
@@ -52,6 +57,8 @@ export function useAIViewKeybinds({
   aggregator,
   setEditingMessage,
   vimEnabled,
+  canResumeInterruptedStream = false,
+  resumeInterruptedStream,
 }: UseAIViewKeybindsParams): void {
   const { api } = useAPI();
 
@@ -140,6 +147,18 @@ export function useAIViewKeybinds({
         return;
       }
 
+      // Resume an interrupted stream (inverse of the interrupt keybind). Only
+      // acts when a resumable interrupted turn is shown; otherwise falls through.
+      if (
+        matchesKeybind(e, KEYBINDS.RESUME_STREAM) &&
+        canResumeInterruptedStream &&
+        resumeInterruptedStream
+      ) {
+        e.preventDefault();
+        if (!dialogOpen) resumeInterruptedStream();
+        return;
+      }
+
       // Don't handle other shortcuts if user is typing in an input field
       if (dialogOpen || isEditableElement(e.target)) {
         return;
@@ -180,6 +199,8 @@ export function useAIViewKeybinds({
     aggregator,
     setEditingMessage,
     vimEnabled,
+    canResumeInterruptedStream,
+    resumeInterruptedStream,
     api,
   ]);
 }

--- a/src/browser/hooks/useAIViewKeybinds.ts
+++ b/src/browser/hooks/useAIViewKeybinds.ts
@@ -35,7 +35,7 @@ interface UseAIViewKeybindsParams {
 /**
  * Manages keyboard shortcuts for AIView:
  * - Esc (non-vim) or Ctrl+C (vim): Interrupt stream (Escape skips text inputs by default)
- * - Ctrl/Cmd+Shift+Enter: Resume an interrupted stream (when a resumable turn is shown)
+ * - Shift+R: Resume an interrupted stream (when a resumable turn is shown)
  * - Ctrl+I: Focus chat input
  * - Shift+H: Load older transcript messages (when available)
  * - Shift+G: Jump to bottom
@@ -147,20 +147,21 @@ export function useAIViewKeybinds({
         return;
       }
 
-      // Resume an interrupted stream (inverse of the interrupt keybind). Only
-      // acts when a resumable interrupted turn is shown; otherwise falls through.
+      // Don't handle other shortcuts if user is typing in an input field
+      if (dialogOpen || isEditableElement(e.target)) {
+        return;
+      }
+
+      // Resume an interrupted stream. Like Shift+G/Shift+H, this is a
+      // transcript-scoped key: gated below the editable guard so Shift+R types
+      // normally while composing. Only acts when a resumable turn is shown.
       if (
         matchesKeybind(e, KEYBINDS.RESUME_STREAM) &&
         canResumeInterruptedStream &&
         resumeInterruptedStream
       ) {
         e.preventDefault();
-        if (!dialogOpen) resumeInterruptedStream();
-        return;
-      }
-
-      // Don't handle other shortcuts if user is typing in an input field
-      if (dialogOpen || isEditableElement(e.target)) {
+        resumeInterruptedStream();
         return;
       }
 

--- a/src/browser/hooks/useResumeStream.test.tsx
+++ b/src/browser/hooks/useResumeStream.test.tsx
@@ -49,11 +49,11 @@ void mock.module("@/browser/stores/WorkspaceStore", () => ({
   useWorkspaceStoreRaw: () => ({ getWorkspaceState: () => currentWorkspaceState }),
 }));
 
-import { useResumeStream, type UseResumeStreamOptions } from "./useResumeStream";
+import { useResumeStream } from "./useResumeStream";
 
-const Harness: React.FC<{ workspaceId?: string; options?: UseResumeStreamOptions }> = (props) => {
-  const { resume, error } = useResumeStream(props.workspaceId ?? "ws-1", props.options);
-  // (workspaceId/options come straight from props so tests can rerender with new identity)
+// workspaceId/resetKey come straight from props so tests can rerender with new identity.
+const Harness: React.FC<{ workspaceId?: string; resetKey?: string | null }> = (props) => {
+  const { resume, error } = useResumeStream(props.workspaceId ?? "ws-1", props.resetKey);
   return (
     <div>
       <button type="button" onClick={() => void resume()}>
@@ -80,20 +80,7 @@ describe("useResumeStream", () => {
     globalThis.document = undefined as unknown as Document;
   });
 
-  test("autoRetryOnFailure:false resumes without touching the auto-retry preference", async () => {
-    const view = render(<Harness options={{ autoRetryOnFailure: false }} />);
-
-    fireEvent.click(view.getByText("resume"));
-
-    await waitFor(() => {
-      expect(resumeStream).toHaveBeenCalledTimes(1);
-    });
-    // The whole point of the option: never enable/disable auto-retry, so the
-    // caller (e.g. a transient divider) can't cancel a scheduled retry on unmount.
-    expect(setAutoRetryEnabled).not.toHaveBeenCalled();
-  });
-
-  test("default enables auto-retry for the resumed attempt", async () => {
+  test("resumes the stream without touching the auto-retry preference", async () => {
     const view = render(<Harness />);
 
     fireEvent.click(view.getByText("resume"));
@@ -101,11 +88,10 @@ describe("useResumeStream", () => {
     await waitFor(() => {
       expect(resumeStream).toHaveBeenCalledTimes(1);
     });
-    expect(setAutoRetryEnabled).toHaveBeenCalledWith({
-      workspaceId: "ws-1",
-      enabled: true,
-      persist: false,
-    });
+    // A user-initiated (Esc) interrupt means "continue once": never enable/disable
+    // auto-retry, so a transient divider can't cancel a scheduled retry on unmount.
+    expect(setAutoRetryEnabled).not.toHaveBeenCalled();
+    expect(resumeStream.mock.calls[0]?.[0]).toMatchObject({ workspaceId: "ws-1" });
   });
 
   test("clears the error when workspaceId changes (no cross-workspace bleed)", async () => {
@@ -114,7 +100,7 @@ describe("useResumeStream", () => {
       error: { type: "runtime_start_failed", message: "Runtime failed to start" },
     };
 
-    const view = render(<Harness workspaceId="ws-A" options={{ autoRetryOnFailure: false }} />);
+    const view = render(<Harness workspaceId="ws-A" />);
     fireEvent.click(view.getByText("resume"));
 
     await waitFor(() => {
@@ -122,7 +108,7 @@ describe("useResumeStream", () => {
     });
 
     // Same always-mounted hook now serves a different workspace: its error must reset.
-    view.rerender(<Harness workspaceId="ws-B" options={{ autoRetryOnFailure: false }} />);
+    view.rerender(<Harness workspaceId="ws-B" />);
 
     expect(view.queryByTestId("resume-error")).toBeNull();
   });
@@ -133,9 +119,7 @@ describe("useResumeStream", () => {
       error: { type: "runtime_start_failed", message: "Runtime failed to start" },
     };
 
-    const view = render(
-      <Harness workspaceId="ws-1" options={{ autoRetryOnFailure: false, resetKey: "turn-1" }} />
-    );
+    const view = render(<Harness workspaceId="ws-1" resetKey="turn-1" />);
     fireEvent.click(view.getByText("resume"));
 
     await waitFor(() => {
@@ -143,9 +127,7 @@ describe("useResumeStream", () => {
     });
 
     // A later interrupted turn in the same workspace must not inherit the old error.
-    view.rerender(
-      <Harness workspaceId="ws-1" options={{ autoRetryOnFailure: false, resetKey: "turn-2" }} />
-    );
+    view.rerender(<Harness workspaceId="ws-1" resetKey="turn-2" />);
 
     expect(view.queryByTestId("resume-error")).toBeNull();
   });

--- a/src/browser/hooks/useResumeStream.test.tsx
+++ b/src/browser/hooks/useResumeStream.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+
+import type * as WorkspaceStoreModule from "@/browser/stores/WorkspaceStore";
+
+interface MockWorkspaceState {
+  autoRetryStatus: null;
+  isStreamStarting: boolean;
+  canInterrupt: boolean;
+  messages: Array<Record<string, unknown>>;
+}
+
+const currentWorkspaceState: MockWorkspaceState = {
+  autoRetryStatus: null,
+  isStreamStarting: false,
+  canInterrupt: false,
+  messages: [{ type: "user", id: "user-1", content: "Hi", historySequence: 1 }],
+};
+
+const resumeStream = mock((_input: unknown) =>
+  Promise.resolve({ success: true as const, data: { started: true } })
+);
+const setAutoRetryEnabled = mock((_input: unknown) =>
+  Promise.resolve({ success: true as const, data: { previousEnabled: false, enabled: true } })
+);
+
+void mock.module("@/browser/contexts/API", () => ({
+  useAPI: () => ({
+    api: { workspace: { resumeStream, setAutoRetryEnabled } },
+    status: "connected" as const,
+    error: null,
+    authenticate: () => undefined,
+    retry: () => undefined,
+  }),
+}));
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const actualWorkspaceStore =
+  require("@/browser/stores/WorkspaceStore?real=1") as typeof WorkspaceStoreModule;
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+void mock.module("@/browser/stores/WorkspaceStore", () => ({
+  ...actualWorkspaceStore,
+  useWorkspaceState: () => currentWorkspaceState,
+  useWorkspaceStoreRaw: () => ({ getWorkspaceState: () => currentWorkspaceState }),
+}));
+
+import { useResumeStream, type UseResumeStreamOptions } from "./useResumeStream";
+
+const Harness: React.FC<{ options?: UseResumeStreamOptions }> = (props) => {
+  const { resume } = useResumeStream("ws-1", props.options);
+  return (
+    <button type="button" onClick={() => void resume()}>
+      resume
+    </button>
+  );
+};
+
+describe("useResumeStream", () => {
+  beforeEach(() => {
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+    resumeStream.mockClear();
+    setAutoRetryEnabled.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.restore();
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+  });
+
+  test("autoRetryOnFailure:false resumes without touching the auto-retry preference", async () => {
+    const view = render(<Harness options={{ autoRetryOnFailure: false }} />);
+
+    fireEvent.click(view.getByText("resume"));
+
+    await waitFor(() => {
+      expect(resumeStream).toHaveBeenCalledTimes(1);
+    });
+    // The whole point of the option: never enable/disable auto-retry, so the
+    // caller (e.g. a transient divider) can't cancel a scheduled retry on unmount.
+    expect(setAutoRetryEnabled).not.toHaveBeenCalled();
+  });
+
+  test("default enables auto-retry for the resumed attempt", async () => {
+    const view = render(<Harness />);
+
+    fireEvent.click(view.getByText("resume"));
+
+    await waitFor(() => {
+      expect(resumeStream).toHaveBeenCalledTimes(1);
+    });
+    expect(setAutoRetryEnabled).toHaveBeenCalledWith({
+      workspaceId: "ws-1",
+      enabled: true,
+      persist: false,
+    });
+  });
+});

--- a/src/browser/hooks/useResumeStream.test.tsx
+++ b/src/browser/hooks/useResumeStream.test.tsx
@@ -19,9 +19,11 @@ const currentWorkspaceState: MockWorkspaceState = {
   messages: [{ type: "user", id: "user-1", content: "Hi", historySequence: 1 }],
 };
 
-const resumeStream = mock((_input: unknown) =>
-  Promise.resolve({ success: true as const, data: { started: true } })
-);
+type ResumeStreamResult =
+  | { success: true; data: { started: boolean } }
+  | { success: false; error: { type: "runtime_start_failed"; message: string } };
+let resumeStreamResult: ResumeStreamResult = { success: true, data: { started: true } };
+const resumeStream = mock((_input: unknown) => Promise.resolve(resumeStreamResult));
 const setAutoRetryEnabled = mock((_input: unknown) =>
   Promise.resolve({ success: true as const, data: { previousEnabled: false, enabled: true } })
 );
@@ -49,12 +51,15 @@ void mock.module("@/browser/stores/WorkspaceStore", () => ({
 
 import { useResumeStream, type UseResumeStreamOptions } from "./useResumeStream";
 
-const Harness: React.FC<{ options?: UseResumeStreamOptions }> = (props) => {
-  const { resume } = useResumeStream("ws-1", props.options);
+const Harness: React.FC<{ workspaceId?: string; options?: UseResumeStreamOptions }> = (props) => {
+  const { resume, error } = useResumeStream(props.workspaceId ?? "ws-1", props.options);
   return (
-    <button type="button" onClick={() => void resume()}>
-      resume
-    </button>
+    <div>
+      <button type="button" onClick={() => void resume()}>
+        resume
+      </button>
+      {error && <div data-testid="resume-error">{error}</div>}
+    </div>
   );
 };
 
@@ -62,6 +67,7 @@ describe("useResumeStream", () => {
   beforeEach(() => {
     globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
     globalThis.document = globalThis.window.document;
+    resumeStreamResult = { success: true, data: { started: true } };
     resumeStream.mockClear();
     setAutoRetryEnabled.mockClear();
   });
@@ -99,5 +105,24 @@ describe("useResumeStream", () => {
       enabled: true,
       persist: false,
     });
+  });
+
+  test("clears the error when workspaceId changes (no cross-workspace bleed)", async () => {
+    resumeStreamResult = {
+      success: false,
+      error: { type: "runtime_start_failed", message: "Runtime failed to start" },
+    };
+
+    const view = render(<Harness workspaceId="ws-A" options={{ autoRetryOnFailure: false }} />);
+    fireEvent.click(view.getByText("resume"));
+
+    await waitFor(() => {
+      expect(view.getByTestId("resume-error")).toBeTruthy();
+    });
+
+    // Same always-mounted hook now serves a different workspace: its error must reset.
+    view.rerender(<Harness workspaceId="ws-B" options={{ autoRetryOnFailure: false }} />);
+
+    expect(view.queryByTestId("resume-error")).toBeNull();
   });
 });

--- a/src/browser/hooks/useResumeStream.test.tsx
+++ b/src/browser/hooks/useResumeStream.test.tsx
@@ -53,6 +53,7 @@ import { useResumeStream, type UseResumeStreamOptions } from "./useResumeStream"
 
 const Harness: React.FC<{ workspaceId?: string; options?: UseResumeStreamOptions }> = (props) => {
   const { resume, error } = useResumeStream(props.workspaceId ?? "ws-1", props.options);
+  // (workspaceId/options come straight from props so tests can rerender with new identity)
   return (
     <div>
       <button type="button" onClick={() => void resume()}>
@@ -122,6 +123,29 @@ describe("useResumeStream", () => {
 
     // Same always-mounted hook now serves a different workspace: its error must reset.
     view.rerender(<Harness workspaceId="ws-B" options={{ autoRetryOnFailure: false }} />);
+
+    expect(view.queryByTestId("resume-error")).toBeNull();
+  });
+
+  test("clears the error when the resume target (resetKey) changes in the same workspace", async () => {
+    resumeStreamResult = {
+      success: false,
+      error: { type: "runtime_start_failed", message: "Runtime failed to start" },
+    };
+
+    const view = render(
+      <Harness workspaceId="ws-1" options={{ autoRetryOnFailure: false, resetKey: "turn-1" }} />
+    );
+    fireEvent.click(view.getByText("resume"));
+
+    await waitFor(() => {
+      expect(view.getByTestId("resume-error")).toBeTruthy();
+    });
+
+    // A later interrupted turn in the same workspace must not inherit the old error.
+    view.rerender(
+      <Harness workspaceId="ws-1" options={{ autoRetryOnFailure: false, resetKey: "turn-2" }} />
+    );
 
     expect(view.queryByTestId("resume-error")).toBeNull();
   });

--- a/src/browser/hooks/useResumeStream.ts
+++ b/src/browser/hooks/useResumeStream.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useAPI } from "@/browser/contexts/API";
 import { useWorkspaceState } from "@/browser/stores/WorkspaceStore";
 import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
@@ -7,73 +7,40 @@ import { formatSendMessageError } from "@/common/utils/errors/formatSendError";
 import { getErrorMessage } from "@/common/utils/errors";
 
 export interface UseResumeStreamResult {
-  /** Resume/continue the interrupted (or failed) stream from where it stopped. */
+  /** Continue the interrupted stream from where it stopped. */
   resume: () => Promise<void>;
   /** True while a resume request is in flight; guards against double-trigger. */
   isResuming: boolean;
   /** Last resume error, if any. */
   error: string | null;
-  /** Clear the current error. */
-  clearError: () => void;
-}
-
-export interface UseResumeStreamOptions {
-  /**
-   * When true (default), the resumed attempt temporarily enables auto-retry
-   * (persist:false) so transient failures keep retrying, then restores the
-   * user's preference once the attempt reaches a terminal outcome. This is the
-   * RetryBarrier semantic (it stays mounted across the whole lifecycle).
-   *
-   * Set false for callers that may unmount mid-attempt (e.g. the interrupted
-   * divider, which ChatPane hides once auto-retry becomes active): a user
-   * pressing Esc asked to stop, so "continue once" is the correct semantic, and
-   * skipping the enable+rollback avoids canceling an in-flight scheduled retry
-   * on unmount. Auto-retry-enabled users still get backend recovery because the
-   * backend consults the persisted preference on failure regardless.
-   */
-  autoRetryOnFailure?: boolean;
-
-  /**
-   * Extra identity for the transient UI state (error/isResuming) beyond
-   * workspaceId. When this changes, the hook resets that state so a stale error
-   * can't appear against a different target. The divider passes the resume
-   * target message id, so a failed continue on one interrupted turn never bleeds
-   * onto a later interrupted turn in the same workspace.
-   */
-  resetKey?: string | null;
 }
 
 /**
- * Shared "continue from where it stopped" flow used by both the RetryBarrier
- * button (system/error interrupts) and the InterruptedBarrier splitter
- * (user-initiated interrupts via Esc).
+ * One-shot "continue from where it stopped" for the interrupted divider and its
+ * keybind. A user who pressed Esc asked to stop, so this never flips the
+ * auto-retry preference (RetryBarrier owns its own auto-retry recovery for
+ * system/error interrupts). resumeStream does no history shaping; the model just
+ * continues the partial assistant turn. Auto-retry-enabled users still get
+ * backend recovery, since the backend consults the persisted preference on failure.
  *
- * Both entry points must behave identically to the backend auto-retry path:
- * resumeStream does no history shaping, so the model simply continues the
- * partial assistant turn (plus an ephemeral [CONTINUE] sentinel injected at
- * transform time). The only client-side responsibility is temporarily enabling
- * auto-retry for the resumed attempt without silently flipping the user's
- * persisted preference.
+ * `resetKey` (the resume target message id) augments the identity so transient
+ * state can't bleed across workspaces or across interrupted turns.
  */
 export function useResumeStream(
   workspaceId: string,
-  options?: UseResumeStreamOptions
+  resetKey?: string | null
 ): UseResumeStreamResult {
-  const autoRetryOnFailure = options?.autoRetryOnFailure ?? true;
   const { api } = useAPI();
   const workspaceState = useWorkspaceState(workspaceId);
   const [error, setError] = useState<string | null>(null);
   const [isResuming, setIsResuming] = useState(false);
 
-  // ChatPane owns this hook and stays mounted across workspace switches (and
-  // across changing resume targets), so transient UI state (error, isResuming)
-  // must not bleed across either. Identity = workspaceId + optional resetKey.
-  // Reset during render when identity changes (React's "adjust state during
-  // render" pattern — no effect needed), and track the latest identity so a
-  // resume that resolves after a switch/target change can't write onto it.
-  const identity = `${workspaceId}\u0000${options?.resetKey ?? ""}`;
-  const latestIdentityRef = useRef(identity);
-  latestIdentityRef.current = identity;
+  // ChatPane owns this hook and stays mounted across workspace/target changes, so
+  // reset transient state when identity changes (adjust-during-render, no effect)
+  // and track the live identity so a late-resolving resume can't write onto it.
+  const identity = `${workspaceId}\u0000${resetKey ?? ""}`;
+  const latestIdentity = useRef(identity);
+  latestIdentity.current = identity;
   const [trackedIdentity, setTrackedIdentity] = useState(identity);
   if (identity !== trackedIdentity) {
     setTrackedIdentity(identity);
@@ -81,133 +48,22 @@ export function useResumeStream(
     setIsResuming(false);
   }
 
-  const autoRetryStatus = workspaceState.autoRetryStatus;
-
-  // Manual resume temporarily enables auto-retry (persist:false) so the resumed
-  // attempt is retried on transient failure, then restores the user's preference
-  // once the attempt reaches a terminal outcome. These refs drive that rollback.
-  const rollbackWorkspaceIdRef = useRef<string | null>(null);
-  const rollbackPendingRef = useRef(false);
-  const rollbackArmedRef = useRef(false);
-  const rollbackBaselineMessageCountRef = useRef<number | null>(null);
-  const apiRef = useRef(api);
-
-  useEffect(() => {
-    apiRef.current = api;
-  }, [api]);
-
-  const rollbackAutoRetryIfNeeded = useCallback(
-    async (options?: { suppressErrors?: boolean }): Promise<void> => {
-      if (!rollbackPendingRef.current) {
-        return;
-      }
-
-      const rollbackWorkspaceId = rollbackWorkspaceIdRef.current;
-      rollbackPendingRef.current = false;
-      rollbackArmedRef.current = false;
-      rollbackBaselineMessageCountRef.current = null;
-      rollbackWorkspaceIdRef.current = null;
-
-      const activeApi = apiRef.current;
-      if (!activeApi || !rollbackWorkspaceId) {
-        return;
-      }
-
-      const rollbackResult = await activeApi.workspace.setAutoRetryEnabled?.({
-        workspaceId: rollbackWorkspaceId,
-        enabled: false,
-        persist: false,
-      });
-      if (rollbackResult && !rollbackResult.success && !options?.suppressErrors) {
-        setError(rollbackResult.error);
-      }
-    },
-    []
-  );
-
-  // Workspace switched while a rollback was pending: restore in the previous workspace.
-  useEffect(() => {
-    if (!rollbackPendingRef.current) {
-      return;
-    }
-
-    const rollbackWorkspaceId = rollbackWorkspaceIdRef.current;
-    if (!rollbackWorkspaceId || rollbackWorkspaceId === workspaceId) {
-      return;
-    }
-
-    void rollbackAutoRetryIfNeeded();
-  }, [workspaceId, rollbackAutoRetryIfNeeded]);
-
-  // Unmount: restore preference best-effort.
-  useEffect(() => {
-    return () => {
-      if (!rollbackPendingRef.current) {
-        return;
-      }
-
-      void rollbackAutoRetryIfNeeded({ suppressErrors: true });
-    };
-  }, [rollbackAutoRetryIfNeeded]);
-
-  useEffect(() => {
-    if (!rollbackPendingRef.current) {
-      return;
-    }
-
-    const autoRetryActive =
-      autoRetryStatus?.type === "auto-retry-scheduled" ||
-      autoRetryStatus?.type === "auto-retry-starting";
-    const streamInFlight = workspaceState.isStreamStarting || workspaceState.canInterrupt;
-
-    // Mirror ask_user rollback semantics: keep temporary enablement while the resumed
-    // stream/retry attempt is in flight, then restore preference after terminal outcome.
-    if (autoRetryActive || streamInFlight) {
-      rollbackArmedRef.current = true;
-      return;
-    }
-
-    const baselineMessageCount = rollbackBaselineMessageCountRef.current;
-    const hasObservedPostRetryMessage =
-      baselineMessageCount !== null && workspaceState.messages.length > baselineMessageCount;
-    if (!rollbackArmedRef.current && !hasObservedPostRetryMessage) {
-      return;
-    }
-
-    void rollbackAutoRetryIfNeeded();
-  }, [
-    autoRetryStatus,
-    workspaceState.isStreamStarting,
-    workspaceState.canInterrupt,
-    workspaceState.messages.length,
-    rollbackAutoRetryIfNeeded,
-  ]);
-
-  const clearError = useCallback(() => {
-    setError(null);
-  }, []);
-
   const resume = async (): Promise<void> => {
     if (!api) {
       setError("Not connected to server");
       return;
     }
-
     if (isResuming) {
       return;
     }
 
     const startedForIdentity = identity;
-    // Drop state updates if the workspace or resume target changed before this
-    // resolved, so a stale resume can't surface its error/spinner on a different
-    // workspace or interrupted turn.
     const applyIfCurrent = (apply: () => void): void => {
-      if (latestIdentityRef.current === startedForIdentity) apply();
+      if (latestIdentity.current === startedForIdentity) apply();
     };
 
     setIsResuming(true);
     setError(null);
-
     try {
       let options = getSendOptionsFromStorage(workspaceId);
       const lastUserMessage = [...workspaceState.messages]
@@ -215,63 +71,27 @@ export function useResumeStream(
         .find(
           (message): message is Extract<typeof message, { type: "user" }> => message.type === "user"
         );
-
       if (lastUserMessage?.compactionRequest) {
         options = applyCompactionOverrides(options, lastUserMessage.compactionRequest.parsed);
       }
 
-      if (autoRetryOnFailure) {
-        const enableResult = await api.workspace.setAutoRetryEnabled?.({
-          workspaceId,
-          enabled: true,
-          persist: false,
-        });
-        if (enableResult && !enableResult.success) {
-          applyIfCurrent(() => setError(enableResult.error));
-          return;
-        }
-
-        if (enableResult?.success && enableResult.data.previousEnabled === false) {
-          // Manual resume temporarily enables auto-retry for this resumed attempt.
-          // Restore only when stream/retry outcome is terminal.
-          rollbackWorkspaceIdRef.current = workspaceId;
-          rollbackPendingRef.current = true;
-          rollbackArmedRef.current = false;
-          rollbackBaselineMessageCountRef.current = workspaceState.messages.length;
-        }
-      }
-
-      const resumeResult = await api.workspace.resumeStream({
-        workspaceId,
-        options,
-      });
-
-      if (!resumeResult.success) {
-        const formatted = formatSendMessageError(resumeResult.error);
-        const details = formatted.resolutionHint
-          ? `${formatted.message} ${formatted.resolutionHint}`
-          : formatted.message;
-        applyIfCurrent(() => setError(details));
-
-        // Keep preference consistent when resume fails before retry/stream events.
-        await rollbackAutoRetryIfNeeded();
-        return;
-      }
-
-      if (
-        rollbackPendingRef.current &&
-        !rollbackArmedRef.current &&
-        resumeResult.data.started === false
-      ) {
-        await rollbackAutoRetryIfNeeded();
+      const result = await api.workspace.resumeStream({ workspaceId, options });
+      if (!result.success) {
+        const formatted = formatSendMessageError(result.error);
+        applyIfCurrent(() =>
+          setError(
+            formatted.resolutionHint
+              ? `${formatted.message} ${formatted.resolutionHint}`
+              : formatted.message
+          )
+        );
       }
     } catch (err) {
       applyIfCurrent(() => setError(getErrorMessage(err)));
-      await rollbackAutoRetryIfNeeded();
     } finally {
       applyIfCurrent(() => setIsResuming(false));
     }
   };
 
-  return { resume, isResuming, error, clearError };
+  return { resume, isResuming, error };
 }

--- a/src/browser/hooks/useResumeStream.ts
+++ b/src/browser/hooks/useResumeStream.ts
@@ -17,6 +17,23 @@ export interface UseResumeStreamResult {
   clearError: () => void;
 }
 
+export interface UseResumeStreamOptions {
+  /**
+   * When true (default), the resumed attempt temporarily enables auto-retry
+   * (persist:false) so transient failures keep retrying, then restores the
+   * user's preference once the attempt reaches a terminal outcome. This is the
+   * RetryBarrier semantic (it stays mounted across the whole lifecycle).
+   *
+   * Set false for callers that may unmount mid-attempt (e.g. the interrupted
+   * divider, which ChatPane hides once auto-retry becomes active): a user
+   * pressing Esc asked to stop, so "continue once" is the correct semantic, and
+   * skipping the enable+rollback avoids canceling an in-flight scheduled retry
+   * on unmount. Auto-retry-enabled users still get backend recovery because the
+   * backend consults the persisted preference on failure regardless.
+   */
+  autoRetryOnFailure?: boolean;
+}
+
 /**
  * Shared "continue from where it stopped" flow used by both the RetryBarrier
  * button (system/error interrupts) and the InterruptedBarrier splitter
@@ -29,7 +46,11 @@ export interface UseResumeStreamResult {
  * auto-retry for the resumed attempt without silently flipping the user's
  * persisted preference.
  */
-export function useResumeStream(workspaceId: string): UseResumeStreamResult {
+export function useResumeStream(
+  workspaceId: string,
+  options?: UseResumeStreamOptions
+): UseResumeStreamResult {
+  const autoRetryOnFailure = options?.autoRetryOnFailure ?? true;
   const { api } = useAPI();
   const workspaceState = useWorkspaceState(workspaceId);
   const [error, setError] = useState<string | null>(null);
@@ -166,23 +187,25 @@ export function useResumeStream(workspaceId: string): UseResumeStreamResult {
         options = applyCompactionOverrides(options, lastUserMessage.compactionRequest.parsed);
       }
 
-      const enableResult = await api.workspace.setAutoRetryEnabled?.({
-        workspaceId,
-        enabled: true,
-        persist: false,
-      });
-      if (enableResult && !enableResult.success) {
-        setError(enableResult.error);
-        return;
-      }
+      if (autoRetryOnFailure) {
+        const enableResult = await api.workspace.setAutoRetryEnabled?.({
+          workspaceId,
+          enabled: true,
+          persist: false,
+        });
+        if (enableResult && !enableResult.success) {
+          setError(enableResult.error);
+          return;
+        }
 
-      if (enableResult?.success && enableResult.data.previousEnabled === false) {
-        // Manual resume temporarily enables auto-retry for this resumed attempt.
-        // Restore only when stream/retry outcome is terminal.
-        rollbackWorkspaceIdRef.current = workspaceId;
-        rollbackPendingRef.current = true;
-        rollbackArmedRef.current = false;
-        rollbackBaselineMessageCountRef.current = workspaceState.messages.length;
+        if (enableResult?.success && enableResult.data.previousEnabled === false) {
+          // Manual resume temporarily enables auto-retry for this resumed attempt.
+          // Restore only when stream/retry outcome is terminal.
+          rollbackWorkspaceIdRef.current = workspaceId;
+          rollbackPendingRef.current = true;
+          rollbackArmedRef.current = false;
+          rollbackBaselineMessageCountRef.current = workspaceState.messages.length;
+        }
       }
 
       const resumeResult = await api.workspace.resumeStream({

--- a/src/browser/hooks/useResumeStream.ts
+++ b/src/browser/hooks/useResumeStream.ts
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAPI } from "@/browser/contexts/API";
+import { useWorkspaceState } from "@/browser/stores/WorkspaceStore";
+import { getSendOptionsFromStorage } from "@/browser/utils/messages/sendOptions";
+import { applyCompactionOverrides } from "@/browser/utils/messages/compactionOptions";
+import { formatSendMessageError } from "@/common/utils/errors/formatSendError";
+import { getErrorMessage } from "@/common/utils/errors";
+
+export interface UseResumeStreamResult {
+  /** Resume/continue the interrupted (or failed) stream from where it stopped. */
+  resume: () => Promise<void>;
+  /** True while a resume request is in flight; guards against double-trigger. */
+  isResuming: boolean;
+  /** Last resume error, if any. */
+  error: string | null;
+  /** Clear the current error. */
+  clearError: () => void;
+}
+
+/**
+ * Shared "continue from where it stopped" flow used by both the RetryBarrier
+ * button (system/error interrupts) and the InterruptedBarrier splitter
+ * (user-initiated interrupts via Esc).
+ *
+ * Both entry points must behave identically to the backend auto-retry path:
+ * resumeStream does no history shaping, so the model simply continues the
+ * partial assistant turn (plus an ephemeral [CONTINUE] sentinel injected at
+ * transform time). The only client-side responsibility is temporarily enabling
+ * auto-retry for the resumed attempt without silently flipping the user's
+ * persisted preference.
+ */
+export function useResumeStream(workspaceId: string): UseResumeStreamResult {
+  const { api } = useAPI();
+  const workspaceState = useWorkspaceState(workspaceId);
+  const [error, setError] = useState<string | null>(null);
+  const [isResuming, setIsResuming] = useState(false);
+
+  const autoRetryStatus = workspaceState.autoRetryStatus;
+
+  // Manual resume temporarily enables auto-retry (persist:false) so the resumed
+  // attempt is retried on transient failure, then restores the user's preference
+  // once the attempt reaches a terminal outcome. These refs drive that rollback.
+  const rollbackWorkspaceIdRef = useRef<string | null>(null);
+  const rollbackPendingRef = useRef(false);
+  const rollbackArmedRef = useRef(false);
+  const rollbackBaselineMessageCountRef = useRef<number | null>(null);
+  const apiRef = useRef(api);
+
+  useEffect(() => {
+    apiRef.current = api;
+  }, [api]);
+
+  const rollbackAutoRetryIfNeeded = useCallback(
+    async (options?: { suppressErrors?: boolean }): Promise<void> => {
+      if (!rollbackPendingRef.current) {
+        return;
+      }
+
+      const rollbackWorkspaceId = rollbackWorkspaceIdRef.current;
+      rollbackPendingRef.current = false;
+      rollbackArmedRef.current = false;
+      rollbackBaselineMessageCountRef.current = null;
+      rollbackWorkspaceIdRef.current = null;
+
+      const activeApi = apiRef.current;
+      if (!activeApi || !rollbackWorkspaceId) {
+        return;
+      }
+
+      const rollbackResult = await activeApi.workspace.setAutoRetryEnabled?.({
+        workspaceId: rollbackWorkspaceId,
+        enabled: false,
+        persist: false,
+      });
+      if (rollbackResult && !rollbackResult.success && !options?.suppressErrors) {
+        setError(rollbackResult.error);
+      }
+    },
+    []
+  );
+
+  // Workspace switched while a rollback was pending: restore in the previous workspace.
+  useEffect(() => {
+    if (!rollbackPendingRef.current) {
+      return;
+    }
+
+    const rollbackWorkspaceId = rollbackWorkspaceIdRef.current;
+    if (!rollbackWorkspaceId || rollbackWorkspaceId === workspaceId) {
+      return;
+    }
+
+    void rollbackAutoRetryIfNeeded();
+  }, [workspaceId, rollbackAutoRetryIfNeeded]);
+
+  // Unmount: restore preference best-effort.
+  useEffect(() => {
+    return () => {
+      if (!rollbackPendingRef.current) {
+        return;
+      }
+
+      void rollbackAutoRetryIfNeeded({ suppressErrors: true });
+    };
+  }, [rollbackAutoRetryIfNeeded]);
+
+  useEffect(() => {
+    if (!rollbackPendingRef.current) {
+      return;
+    }
+
+    const autoRetryActive =
+      autoRetryStatus?.type === "auto-retry-scheduled" ||
+      autoRetryStatus?.type === "auto-retry-starting";
+    const streamInFlight = workspaceState.isStreamStarting || workspaceState.canInterrupt;
+
+    // Mirror ask_user rollback semantics: keep temporary enablement while the resumed
+    // stream/retry attempt is in flight, then restore preference after terminal outcome.
+    if (autoRetryActive || streamInFlight) {
+      rollbackArmedRef.current = true;
+      return;
+    }
+
+    const baselineMessageCount = rollbackBaselineMessageCountRef.current;
+    const hasObservedPostRetryMessage =
+      baselineMessageCount !== null && workspaceState.messages.length > baselineMessageCount;
+    if (!rollbackArmedRef.current && !hasObservedPostRetryMessage) {
+      return;
+    }
+
+    void rollbackAutoRetryIfNeeded();
+  }, [
+    autoRetryStatus,
+    workspaceState.isStreamStarting,
+    workspaceState.canInterrupt,
+    workspaceState.messages.length,
+    rollbackAutoRetryIfNeeded,
+  ]);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  const resume = async (): Promise<void> => {
+    if (!api) {
+      setError("Not connected to server");
+      return;
+    }
+
+    if (isResuming) {
+      return;
+    }
+
+    setIsResuming(true);
+    setError(null);
+
+    try {
+      let options = getSendOptionsFromStorage(workspaceId);
+      const lastUserMessage = [...workspaceState.messages]
+        .reverse()
+        .find(
+          (message): message is Extract<typeof message, { type: "user" }> => message.type === "user"
+        );
+
+      if (lastUserMessage?.compactionRequest) {
+        options = applyCompactionOverrides(options, lastUserMessage.compactionRequest.parsed);
+      }
+
+      const enableResult = await api.workspace.setAutoRetryEnabled?.({
+        workspaceId,
+        enabled: true,
+        persist: false,
+      });
+      if (enableResult && !enableResult.success) {
+        setError(enableResult.error);
+        return;
+      }
+
+      if (enableResult?.success && enableResult.data.previousEnabled === false) {
+        // Manual resume temporarily enables auto-retry for this resumed attempt.
+        // Restore only when stream/retry outcome is terminal.
+        rollbackWorkspaceIdRef.current = workspaceId;
+        rollbackPendingRef.current = true;
+        rollbackArmedRef.current = false;
+        rollbackBaselineMessageCountRef.current = workspaceState.messages.length;
+      }
+
+      const resumeResult = await api.workspace.resumeStream({
+        workspaceId,
+        options,
+      });
+
+      if (!resumeResult.success) {
+        const formatted = formatSendMessageError(resumeResult.error);
+        const details = formatted.resolutionHint
+          ? `${formatted.message} ${formatted.resolutionHint}`
+          : formatted.message;
+        setError(details);
+
+        // Keep preference consistent when resume fails before retry/stream events.
+        await rollbackAutoRetryIfNeeded();
+        return;
+      }
+
+      if (
+        rollbackPendingRef.current &&
+        !rollbackArmedRef.current &&
+        resumeResult.data.started === false
+      ) {
+        await rollbackAutoRetryIfNeeded();
+      }
+    } catch (err) {
+      setError(getErrorMessage(err));
+      await rollbackAutoRetryIfNeeded();
+    } finally {
+      setIsResuming(false);
+    }
+  };
+
+  return { resume, isResuming, error, clearError };
+}

--- a/src/browser/hooks/useResumeStream.ts
+++ b/src/browser/hooks/useResumeStream.ts
@@ -56,6 +56,20 @@ export function useResumeStream(
   const [error, setError] = useState<string | null>(null);
   const [isResuming, setIsResuming] = useState(false);
 
+  // ChatPane owns this hook and stays mounted across workspace switches, so
+  // transient per-workspace UI state (error, isResuming) must not bleed into the
+  // next workspace. Reset during render on workspaceId change (React's
+  // "adjust state during render" pattern — no effect needed), and track the
+  // latest id so a resume that resolves after a switch can't write onto it.
+  const latestWorkspaceIdRef = useRef(workspaceId);
+  latestWorkspaceIdRef.current = workspaceId;
+  const [trackedWorkspaceId, setTrackedWorkspaceId] = useState(workspaceId);
+  if (workspaceId !== trackedWorkspaceId) {
+    setTrackedWorkspaceId(workspaceId);
+    setError(null);
+    setIsResuming(false);
+  }
+
   const autoRetryStatus = workspaceState.autoRetryStatus;
 
   // Manual resume temporarily enables auto-retry (persist:false) so the resumed
@@ -172,6 +186,13 @@ export function useResumeStream(
       return;
     }
 
+    const startedFor = workspaceId;
+    // Drop state updates if the user switched workspaces before this resolved,
+    // so a stale resume can't surface its error/spinner on a different workspace.
+    const applyIfCurrent = (apply: () => void): void => {
+      if (latestWorkspaceIdRef.current === startedFor) apply();
+    };
+
     setIsResuming(true);
     setError(null);
 
@@ -194,7 +215,7 @@ export function useResumeStream(
           persist: false,
         });
         if (enableResult && !enableResult.success) {
-          setError(enableResult.error);
+          applyIfCurrent(() => setError(enableResult.error));
           return;
         }
 
@@ -218,7 +239,7 @@ export function useResumeStream(
         const details = formatted.resolutionHint
           ? `${formatted.message} ${formatted.resolutionHint}`
           : formatted.message;
-        setError(details);
+        applyIfCurrent(() => setError(details));
 
         // Keep preference consistent when resume fails before retry/stream events.
         await rollbackAutoRetryIfNeeded();
@@ -233,10 +254,10 @@ export function useResumeStream(
         await rollbackAutoRetryIfNeeded();
       }
     } catch (err) {
-      setError(getErrorMessage(err));
+      applyIfCurrent(() => setError(getErrorMessage(err)));
       await rollbackAutoRetryIfNeeded();
     } finally {
-      setIsResuming(false);
+      applyIfCurrent(() => setIsResuming(false));
     }
   };
 

--- a/src/browser/hooks/useResumeStream.ts
+++ b/src/browser/hooks/useResumeStream.ts
@@ -32,6 +32,15 @@ export interface UseResumeStreamOptions {
    * backend consults the persisted preference on failure regardless.
    */
   autoRetryOnFailure?: boolean;
+
+  /**
+   * Extra identity for the transient UI state (error/isResuming) beyond
+   * workspaceId. When this changes, the hook resets that state so a stale error
+   * can't appear against a different target. The divider passes the resume
+   * target message id, so a failed continue on one interrupted turn never bleeds
+   * onto a later interrupted turn in the same workspace.
+   */
+  resetKey?: string | null;
 }
 
 /**
@@ -56,16 +65,18 @@ export function useResumeStream(
   const [error, setError] = useState<string | null>(null);
   const [isResuming, setIsResuming] = useState(false);
 
-  // ChatPane owns this hook and stays mounted across workspace switches, so
-  // transient per-workspace UI state (error, isResuming) must not bleed into the
-  // next workspace. Reset during render on workspaceId change (React's
-  // "adjust state during render" pattern — no effect needed), and track the
-  // latest id so a resume that resolves after a switch can't write onto it.
-  const latestWorkspaceIdRef = useRef(workspaceId);
-  latestWorkspaceIdRef.current = workspaceId;
-  const [trackedWorkspaceId, setTrackedWorkspaceId] = useState(workspaceId);
-  if (workspaceId !== trackedWorkspaceId) {
-    setTrackedWorkspaceId(workspaceId);
+  // ChatPane owns this hook and stays mounted across workspace switches (and
+  // across changing resume targets), so transient UI state (error, isResuming)
+  // must not bleed across either. Identity = workspaceId + optional resetKey.
+  // Reset during render when identity changes (React's "adjust state during
+  // render" pattern — no effect needed), and track the latest identity so a
+  // resume that resolves after a switch/target change can't write onto it.
+  const identity = `${workspaceId}\u0000${options?.resetKey ?? ""}`;
+  const latestIdentityRef = useRef(identity);
+  latestIdentityRef.current = identity;
+  const [trackedIdentity, setTrackedIdentity] = useState(identity);
+  if (identity !== trackedIdentity) {
+    setTrackedIdentity(identity);
     setError(null);
     setIsResuming(false);
   }
@@ -186,11 +197,12 @@ export function useResumeStream(
       return;
     }
 
-    const startedFor = workspaceId;
-    // Drop state updates if the user switched workspaces before this resolved,
-    // so a stale resume can't surface its error/spinner on a different workspace.
+    const startedForIdentity = identity;
+    // Drop state updates if the workspace or resume target changed before this
+    // resolved, so a stale resume can't surface its error/spinner on a different
+    // workspace or interrupted turn.
     const applyIfCurrent = (apply: () => void): void => {
-      if (latestWorkspaceIdRef.current === startedFor) apply();
+      if (latestIdentityRef.current === startedForIdentity) apply();
     };
 
     setIsResuming(true);

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -323,9 +323,7 @@ export const KEYBINDS = {
   INTERRUPT_STREAM_VIM: { key: "c", ctrl: true, macCtrlBehavior: "control" },
   INTERRUPT_STREAM_NORMAL: { key: "Escape" },
 
-  /** Continue/resume an interrupted stream from where it stopped */
-  // The inverse of the interrupt keybind: continues a user-aborted (Esc) turn,
-  // matching the interrupted divider's click action.
+  /** Continue an interrupted stream (inverse of the interrupt keybind) */
   RESUME_STREAM: { key: "Enter", ctrl: true, shift: true, macCtrlBehavior: "command" },
 
   /** Focus chat input */

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -323,6 +323,11 @@ export const KEYBINDS = {
   INTERRUPT_STREAM_VIM: { key: "c", ctrl: true, macCtrlBehavior: "control" },
   INTERRUPT_STREAM_NORMAL: { key: "Escape" },
 
+  /** Continue/resume an interrupted stream from where it stopped */
+  // The inverse of the interrupt keybind: continues a user-aborted (Esc) turn,
+  // matching the interrupted divider's click action.
+  RESUME_STREAM: { key: "Enter", ctrl: true, shift: true, macCtrlBehavior: "command" },
+
   /** Focus chat input */
   FOCUS_INPUT_I: { key: "i" },
 

--- a/src/browser/utils/ui/keybinds.ts
+++ b/src/browser/utils/ui/keybinds.ts
@@ -323,8 +323,8 @@ export const KEYBINDS = {
   INTERRUPT_STREAM_VIM: { key: "c", ctrl: true, macCtrlBehavior: "control" },
   INTERRUPT_STREAM_NORMAL: { key: "Escape" },
 
-  /** Continue an interrupted stream (inverse of the interrupt keybind) */
-  RESUME_STREAM: { key: "Enter", ctrl: true, shift: true, macCtrlBehavior: "command" },
+  /** Continue an interrupted stream (R = resume; transcript-focused, like Shift+G) */
+  RESUME_STREAM: { key: "R", shift: true },
 
   /** Focus chat input */
   FOCUS_INPUT_I: { key: "i" },

--- a/src/common/utils/messages/retryEligibility.test.ts
+++ b/src/common/utils/messages/retryEligibility.test.ts
@@ -4,6 +4,7 @@ import {
   hasInterruptedStream,
   isEligibleForAutoRetry,
   isNonRetryableSendError,
+  isPreTokenInterruptedUserTurn,
   PENDING_STREAM_START_GRACE_PERIOD_MS,
 } from "./retryEligibility";
 import type { DisplayedMessage } from "@/common/types/message";
@@ -569,4 +570,39 @@ describe("isNonRetryableSendError", () => {
       expect(isNonRetryableSendError(error)).toBe(expected);
     });
   }
+});
+
+describe("isPreTokenInterruptedUserTurn", () => {
+  it("is true for a trailing user message aborted by the user (pre-token interrupt)", () => {
+    // No assistant row yet, so the partial-message divider path can't fire; the
+    // user must still be able to continue the stopped turn.
+    expect(isPreTokenInterruptedUserTurn(userMessage(), { reason: "user", at: Date.now() })).toBe(
+      true
+    );
+  });
+
+  it("is true for a startup abort (also suppresses RetryBarrier)", () => {
+    expect(
+      isPreTokenInterruptedUserTurn(userMessage(), { reason: "startup", at: Date.now() })
+    ).toBe(true);
+  });
+
+  it("is false for a system abort (RetryBarrier owns recovery)", () => {
+    expect(isPreTokenInterruptedUserTurn(userMessage(), { reason: "system", at: Date.now() })).toBe(
+      false
+    );
+  });
+
+  it("is false with no abort reason (app-restart case; RetryBarrier owns it)", () => {
+    expect(isPreTokenInterruptedUserTurn(userMessage(), null)).toBe(false);
+  });
+
+  it("is false when the tail is an assistant message (partial path handles it)", () => {
+    expect(
+      isPreTokenInterruptedUserTurn(assistantMessage({ isPartial: true }), {
+        reason: "user",
+        at: Date.now(),
+      })
+    ).toBe(false);
+  });
 });

--- a/src/common/utils/messages/retryEligibility.ts
+++ b/src/common/utils/messages/retryEligibility.ts
@@ -96,6 +96,19 @@ function shouldSuppressAutoRetry(
   return lastAbortReason?.reason === "user" || lastAbortReason?.reason === "startup";
 }
 
+/**
+ * True when a turn was interrupted before its first token: the transcript tail is
+ * the user message (no assistant/tool row yet) and the abort was user/startup
+ * (RetryBarrier suppressed). shouldShowInterruptedBarrier never marks a user
+ * message, so callers use this to still offer "continue" on the interrupted tail.
+ */
+export function isPreTokenInterruptedUserTurn(
+  tail: DisplayedMessage | undefined,
+  lastAbortReason: StreamAbortReasonSnapshot | null | undefined
+): boolean {
+  return tail?.type === "user" && shouldSuppressAutoRetry(lastAbortReason);
+}
+
 function isDecorativeTranscriptMessage(message: DisplayedMessage): boolean {
   return (
     message.type === "history-hidden" ||


### PR DESCRIPTION
## Summary

Clicking the "interrupted" splitter now continues the stream from where it stopped, identical to the existing RetryBarrier "Retry" button and the backend auto-retry path. There is also a keyboard shortcut (Ctrl/Cmd+Shift+Enter) for the same action. Previously the splitter was purely decorative, which left user-initiated (Esc) interrupts with no continue affordance at all — the warning RetryBarrier is intentionally suppressed for `reason: "user"` aborts, so only the subtle "interrupted" line showed and there was no way to resume short of typing a new message.

## Background

When a stream is interrupted, the backend keeps the partial assistant turn in history. Both manual Retry and auto-retry converge on `resumeStream`, which does no history shaping; the model simply continues its partial turn (plus an ephemeral `[CONTINUE]` sentinel injected at transform time, never persisted). The continue behavior already existed — it just wasn't reachable after a user-initiated Esc, because the RetryBarrier only mounts for system/error interrupts.

## Implementation

- Adds `useResumeStream(workspaceId, resetKey?)`, a small one-shot "continue from where it stopped" hook for the divider and its keybind. A user-aborted Esc means "continue once", so the hook never touches the auto-retry preference — auto-retry-enabled users still get backend recovery because the backend consults the persisted preference on failure. `RetryBarrier` is unchanged and keeps its own temporary-auto-retry recovery for system/error interrupts.
- Resume ownership for the divider lives in `ChatPane` (a single `useResumeStream` instance), so the click and keybind paths share one source of truth and one error value, and unmounting a transient divider can't cancel an in-flight retry. `InterruptedBarrier` is a presentational component receiving `resumable`/`onResume`/`error`. The hook's `resetKey` is the resume target message id, so a stale error/spinner resets when the interrupted turn changes (and on workspace switch, since `ChatPane` stays mounted), with a late-resolve guard so a slow resume can't write onto a different turn.
- Only the divider on the current resume target (history tail) is clickable, and only when the workspace is writable (`!transcriptOnly`) and the warning RetryBarrier is suppressed (`!showRetryBarrierUI`). `resumeStream` always continues the tail, so older partial dividers and archived transcripts stay decorative; when RetryBarrier is visible its button owns resume, so the divider can't bypass that recovery.
- Handles the pre-token case: when a user interrupts before the first token, the transcript tail is the user message with no assistant row, so `shouldShowInterruptedBarrier` never marks it. `isPreTokenInterruptedUserTurn(tail, lastAbortReason)` detects this (user/startup abort on a trailing user message) and `ChatPane` marks that message in the divider id set — under the same hydration/auto-retry/streaming suppression — so the stopped request is still continuable.
- `BaseBarrier` gains an optional `onClick`. When provided, only the centered label becomes a `<button>` with a hover underline and pointer cursor; the gradient lines and every other visual stay exactly as before. Barriers without `onClick` (e.g. `EditCutoffBarrier`) are unchanged.
- Adds the `RESUME_STREAM` keybind (Ctrl/Cmd+Shift+Enter, the inverse of the interrupt keybind), wired through `useAIViewKeybinds`. It fires only when a resumable interrupted turn is shown, and a keybind-triggered failure surfaces inline on the divider. The shortcut is listed in Settings > Keybinds; there is no inline hint on the divider, preserving its no-visual-change contract.

## Visual contract

No visual change except: hovering the "interrupted" label underlines it and shows a pointer cursor; a resume failure renders a small inline message below the divider. The gradient lines are inert.

## Risks

Low. The divider is presentational and the keybind only acts on a resumable interrupted turn. `RetryBarrier`'s resume/auto-retry recovery is untouched (no diff against the base). Resume + gating are covered by `useResumeStream`, `useAIViewKeybinds`, `InterruptedBarrier`, and `retryEligibility` tests. The new surface in `BaseBarrier` is the conditional `<button>`, scoped to callers that pass `onClick`.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$6.82`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=6.82 -->

