### PR TITLE
chore(design-sync): sync HeartbeatToolCall into the design system

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -161,7 +161,24 @@ needed; the cap is per-file 5 MB on both `_ds_bundle.js` and each `_preview/*.js
   changes, revisit the `tsconfig.ds.json` stubs.
 - **Per-file 5 MB cap** applies to BOTH `_ds_bundle.js` and each `_preview/*.js`.
   Bundle ~4.7 MB and previews ~3.3 MB leave thin headroom — adding components or
-  providers needs a fresh size measurement.
+  providers needs a fresh size measurement. (HeartbeatToolCall added: bundle 4.69 MB,
+  its preview 3.21 MB — still fits, headroom now ~0.3 MB.)
+- **HeartbeatToolCall (tool card):** owned preview has one cell per story (10, named to
+  match the story exports so `compare` pairs them — the stories import `meta.tsx` → the
+  whole app, so the preview is hand-authored like the other cards). `cfg.overrides`
+  uses `cardMode: "column"` because the `CustomMessageWrapping` story renders at a pinned
+  375px (narrower than a grid cell → `[GRID_OVERFLOW] wide`); column keeps all stories
+  full-width. All 10 stories grade `match`.
+- **WorkflowRun/Timeouts exclusion:** `WorkflowRunToolCall` is EXCLUDE_HEAVY via its
+  `WorkflowRun` segment, but `WorkflowRunToolCall.timeout.stories.tsx` titles to
+  `…/WorkflowRun/Timeouts` (segment `Timeouts`), which slips that exclusion and would pull
+  the heavy component (shiki/mermaid/recharts) into the bundle over cap. Fixed by adding
+  `"Timeouts"` to `gen-barrel.mjs` EXCLUDE_HEAVY (a **segment** exclusion, not a path one, so
+  the generated titleMap also nulls `Timeouts` and stays consistent with `cfg.titleMap "Timeouts": null`
+  — a path exclusion would drift). If WorkflowRun stories are retitled again, re-check this.
+- **`[FONT_MISSING]` "Ubuntu Mono":** pre-existing fallback in the `globals.css` monospace
+  stack (`… "Geist Mono", "Ubuntu Mono", "Consolas" …`). Geist Mono ships and wins, so
+  nothing renders in Ubuntu Mono — accepted (the unused fallback needs no @font-face).
 - **Accepted `close` grades (6 stories — isolated-preview limits, NOT defects):**
   the isolated single-component preview legitimately diverges from a story that is
   a gallery, a full-app scenario, a play-expanded interaction, or a mid-stream

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -29,6 +29,7 @@
     "Messages": null,
     "Task": null,
     "WorkflowRun": null,
+    "Timeouts": null,
     "ProposePlan": null,
     "Media": null,
     "AttachFile": null,
@@ -70,6 +71,7 @@
     "Compaction": "CompactingMessageContent",
     "ContextUsageIndicator": "ContextUsageIndicatorButton",
     "Goal": "GetGoalToolCall",
+    "Heartbeat": "HeartbeatToolCall",
     "HookOutput": "HookOutputDisplay",
     "Init": "InitMessage",
     "Streaming": "StreamingBarrierView",
@@ -162,6 +164,10 @@
     },
     "GetGoalToolCall": {
       "skip": []
+    },
+    "HeartbeatToolCall": {
+      "skip": [],
+      "cardMode": "column"
     },
     "InitMessage": {
       "skip": []

--- a/.design-sync/ds-barrel.ts
+++ b/.design-sync/ds-barrel.ts
@@ -17,6 +17,7 @@ export { Dialog } from "@/browser/components/Dialog/Dialog";
 export { GeneralSection } from "@/browser/features/Settings/Sections/GeneralSection";
 export { GetGoalToolCall } from "@/browser/features/Tools/GetGoalToolCall";
 export { GoalTab } from "@/browser/features/RightSidebar/GoalTab";
+export { HeartbeatToolCall } from "@/browser/features/Tools/HeartbeatToolCall";
 export { HookOutputDisplay } from "@/browser/features/Tools/Shared/HookOutputDisplay";
 export { InitMessage } from "@/browser/features/Messages/InitMessage";
 export { Input } from "@/browser/components/Input/Input";

--- a/.design-sync/gen-barrel.mjs
+++ b/.design-sync/gen-barrel.mjs
@@ -46,6 +46,10 @@ const EXCLUDE_HEAVY = [
   "Messages",
   "Task",
   "WorkflowRun",
+  // WorkflowRunToolCall's timeout stories title to ".../WorkflowRun/Timeouts" (segment
+  // "Timeouts"); exclude that segment too so the heavy component stays out — and so the
+  // generated titleMap nulls "Timeouts" (a path exclusion would not, drifting from config).
+  "Timeouts",
   "ProposePlan",
   "Media",
   "AttachFile",

--- a/.design-sync/previews/HeartbeatToolCall.tsx
+++ b/.design-sync/previews/HeartbeatToolCall.tsx
@@ -1,0 +1,217 @@
+import * as React from "react";
+import { MuxPreviewShell } from "../preview-harness";
+import { HeartbeatToolCall } from "@/browser/features/Tools/HeartbeatToolCall";
+
+// Isolated previews of the heartbeat tool-call card — one cell per story in
+// HeartbeatToolCall.stories.tsx, named to match the story exports so compare pairs them,
+// rendered with the same inline args/result/status. Hand-authored (not generated) because
+// the stories import meta.tsx → the whole app graph, which is over the bundle cap (see
+// .design-sync/NOTES.md "UI primitives / previews").
+
+const TASK_PROMPT =
+  "Check the CI run for the auth refactor. If it's green, open the PR; if it's red, " +
+  "summarize the first failure and stop.";
+const DEFAULT_BODY =
+  "Check in on the current state of this workspace — review any pending work, check for stale " +
+  "context, and determine if any action is needed. If everything looks good, briefly confirm the " +
+  "workspace status.";
+
+// Mirrors the stories' decorator chain (theme + tooltip provider, dark background, max-w-2xl).
+// `width` reproduces a story-level narrow wrapper (CustomMessageWrapping renders at 375px).
+const Shell = (props: { width?: string; children: React.ReactNode }) => (
+  <MuxPreviewShell>
+    <div className="bg-background p-6">
+      <div className="w-full max-w-2xl">
+        {props.width ? <div style={{ width: props.width }}>{props.children}</div> : props.children}
+      </div>
+    </div>
+  </MuxPreviewShell>
+);
+
+export const ScheduledEnabled = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{
+        action: "set",
+        enabled: true,
+        intervalMs: 30 * 60_000,
+        contextMode: "normal",
+        message: TASK_PROMPT,
+      }}
+      status="completed"
+      defaultExpanded
+      result={{
+        success: true,
+        action: "set",
+        configured: true,
+        settings: {
+          enabled: true,
+          intervalMs: 30 * 60_000,
+          contextMode: "normal",
+          message: TASK_PROMPT,
+        },
+        summary: "Heartbeat is enabled for this workspace at 30 minutes.",
+      }}
+    />
+  </Shell>
+);
+
+export const CustomMessageWrapping = () => (
+  <Shell width="375px">
+    <HeartbeatToolCall
+      args={{ action: "set", enabled: true, intervalMs: 1_800_000 }}
+      status="completed"
+      defaultExpanded
+      result={{
+        success: true,
+        action: "set",
+        configured: true,
+        settings: {
+          enabled: true,
+          intervalMs: 1_800_000,
+          contextMode: "normal",
+          message:
+            "Poll the deploy and report status.\n" +
+            "Logs: https://ci.example.com/runs/0123456789abcdef0123456789abcdef/jobs/deploy-prod-us-east-1/raw?download=true\n" +
+            "If it failed, summarize the first error and stop.",
+        },
+        summary: "Heartbeat is enabled for this workspace at 30 minutes.",
+      }}
+    />
+  </Shell>
+);
+
+export const LongCadenceCompact = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{ action: "set", enabled: true, intervalMs: 2 * 3_600_000, contextMode: "compact" }}
+      status="completed"
+      defaultExpanded
+      result={{
+        success: true,
+        action: "set",
+        configured: true,
+        settings: { enabled: true, intervalMs: 2 * 3_600_000, contextMode: "compact" },
+        summary: "Heartbeat is enabled for this workspace at 2 hours.",
+      }}
+    />
+  </Shell>
+);
+
+export const ReadReset = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{ action: "get" }}
+      status="completed"
+      defaultExpanded
+      result={{
+        success: true,
+        action: "get",
+        configured: true,
+        settings: {
+          enabled: true,
+          intervalMs: 3_600_000,
+          contextMode: "reset",
+          message: DEFAULT_BODY,
+        },
+        summary: "Heartbeat is enabled for this workspace at 1 hour.",
+      }}
+    />
+  </Shell>
+);
+
+export const Paused = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{ action: "set", enabled: false }}
+      status="completed"
+      defaultExpanded
+      result={{
+        success: true,
+        action: "set",
+        configured: true,
+        settings: {
+          enabled: false,
+          intervalMs: 30 * 60_000,
+          contextMode: "normal",
+          message: DEFAULT_BODY,
+        },
+        summary: "Heartbeat is disabled for this workspace at 30 minutes.",
+      }}
+    />
+  </Shell>
+);
+
+export const ReadNotConfigured = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{ action: "get" }}
+      status="completed"
+      defaultExpanded
+      result={{
+        success: true,
+        action: "get",
+        configured: false,
+        settings: null,
+        summary: "No heartbeat settings are configured for this workspace.",
+      }}
+    />
+  </Shell>
+);
+
+export const Cleared = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{ action: "unset" }}
+      status="completed"
+      defaultExpanded
+      result={{
+        success: true,
+        action: "unset",
+        configured: false,
+        settings: null,
+        summary: "Heartbeat settings removed for this workspace.",
+      }}
+    />
+  </Shell>
+);
+
+export const Executing = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{ action: "set", enabled: true, intervalMs: 30 * 60_000 }}
+      status="executing"
+      defaultExpanded
+    />
+  </Shell>
+);
+
+export const ErrorResult = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{ action: "set", enabled: true, intervalMs: 30 * 60_000 }}
+      status="failed"
+      defaultExpanded
+      result={{
+        success: false,
+        error: "Failed to update heartbeat settings: workspace configuration is unavailable.",
+      }}
+    />
+  </Shell>
+);
+
+export const Interrupted = () => (
+  <Shell>
+    <HeartbeatToolCall
+      args={{
+        action: "set",
+        enabled: true,
+        intervalMs: 2 * 3_600_000,
+        contextMode: "compact",
+        message: "Watch the long-running migration and report when it finishes.",
+      }}
+      status="interrupted"
+      defaultExpanded
+    />
+  </Shell>
+);


### PR DESCRIPTION
## Summary

Enroll the `HeartbeatToolCall` tool card into the design-system sync config so it ships to the Mux Design System (claude.ai/design) alongside the other tool cards (GetGoal, HookOutput, Todo). The card itself already merged in #3631; this is the `.design-sync` follow-up. The component has already been uploaded to the project — this commits the repo-side state so future re-syncs keep including it.

## Implementation

- **`ds-barrel.ts`** — export `HeartbeatToolCall` (matches `gen-barrel.mjs`'s convention; confirmed by re-running the generator).
- **`config.json`** — `titleMap` `"Heartbeat" → "HeartbeatToolCall"`; `overrides.HeartbeatToolCall.cardMode: "column"` (the `CustomMessageWrapping` story renders at a pinned 375px, wider than a grid cell, so column mode keeps all stories full-width and uncropped).
- **`gen-barrel.mjs`** — add `WorkflowRunToolCall.timeout` to `EXCLUDE_IMPORT`. The heavy `WorkflowRunToolCall` is excluded via its `"WorkflowRun"` title segment, but its timeout stories title to `.../WorkflowRun/Timeouts` (segment `Timeouts`), which slipped the segment exclusion and would have pulled shiki/mermaid/recharts into the bundle, over the 5 MB cap. Also `titleMap "Timeouts": null` to drop the sub-story from the converter.
- **`previews/HeartbeatToolCall.tsx`** — hand-authored isolated preview (one cell per story; the stories import the app via `meta.tsx`, so previews are hand-authored here, consistent with every other card).
- **`NOTES.md`** — re-sync risks for the above, plus the accepted Ubuntu Mono fallback-font note.

## Validation

- `/design-sync` re-sync ran clean: `package-validate` reports 34 components, 0 bad / 0 thin; bundle 4.69 MB and the new preview 3.21 MB are both under the 5 MB cap.
- All 10 `HeartbeatToolCall` stories graded `match` against the reference Storybook; the card is live in the project.

## Risks

Low — `.design-sync/` config/tooling only, no `src/` or runtime change. The `gen-barrel.mjs` edit narrows exclusion (keeps a heavy component out of the bundle); worst case is a design-system preview difference, caught by the sync's own validation.
