### PR TITLE
🤖 fix: clarify workflow slash command hints

### DIFF
--- a/src/browser/features/RightSidebar/Workflows/WorkflowEmptyState.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowEmptyState.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { BookOpen, Play, Workflow } from "lucide-react";
 
+import { SLASH_COMMAND_HINTS } from "@/common/constants/slashCommandHints";
 import type { AvailableWorkflow, WorkflowArgSummary } from "@/common/types/workflow";
 
 import { WorkflowScopeBadge } from "./WorkflowBadges";
@@ -231,11 +232,12 @@ export const WorkflowEmptyState: React.FC<WorkflowEmptyStateProps> = (props) => 
       )}
 
       <div className="text-muted pt-1 text-center text-[11.5px]">
-        Or start one from chat with{" "}
+        Start one from chat with{" "}
         <span className="border-border bg-surface-secondary rounded border px-1.5 py-px font-mono">
-          /
+          {`/workflow ${SLASH_COMMAND_HINTS.workflow}`}
         </span>
-        , or author one in <span className="text-content-secondary font-mono">.mux/workflows/</span>
+        ; workspace <span className="text-content-secondary font-mono">.js</span> workflows are
+        loaded by explicit path.
       </div>
     </div>
   );

--- a/src/browser/utils/slashCommands/ghostHint.test.ts
+++ b/src/browser/utils/slashCommands/ghostHint.test.ts
@@ -58,6 +58,17 @@ describe("getCommandGhostHint", () => {
     ).toBe(SLASH_COMMAND_HINTS.heartbeat);
   });
 
+  it("returns only workflow args after the typed /workflow command", () => {
+    const enabledExperiments = new Set<ExperimentId>([EXPERIMENT_IDS.DYNAMIC_WORKFLOWS]);
+
+    const hint = getCommandGhostHint("/workflow ", false, {
+      isExperimentEnabled: (experimentId) => enabledExperiments.has(experimentId),
+    });
+
+    expect(hint).toBe("<script_path> [args]");
+    expect(hint).not.toContain("/workflow");
+  });
+
   it("returns goal hints regardless of experiment state after GA", () => {
     expect(
       getCommandGhostHint("/goal ", false, {

--- a/src/browser/utils/slashCommands/registry.ts
+++ b/src/browser/utils/slashCommands/registry.ts
@@ -665,13 +665,13 @@ const btwCommandDefinition: SlashCommandDefinition = {
   },
 };
 
-const WORKFLOW_COMMAND_USAGE = "/workflow <script_path> [args]";
+const WORKFLOW_COMMAND_USAGE = `/workflow ${SLASH_COMMAND_HINTS.workflow}`;
 
 const workflowCommandDefinition: SlashCommandDefinition = {
   key: "workflow",
   description: "Run an explicit workflow by script path",
   experimentGate: EXPERIMENT_IDS.DYNAMIC_WORKFLOWS,
-  inputHint: WORKFLOW_COMMAND_USAGE,
+  inputHint: SLASH_COMMAND_HINTS.workflow,
   handler: ({ rawInput }): ParsedCommand => {
     const trimmed = rawInput.trim();
     if (!trimmed) {

--- a/src/common/constants/slashCommandHints.ts
+++ b/src/common/constants/slashCommandHints.ts
@@ -12,4 +12,5 @@ export const SLASH_COMMAND_HINTS = {
   heartbeat: "<minutes>|off",
   goal: "[-b <amount>] [--turns <n>] <objective>|budget <amount>|clear",
   btw: "<question>",
+  workflow: "<script_path> [args]",
 } as const satisfies Readonly<Record<string, string>>;


### PR DESCRIPTION
Summary

Clarifies the Workflows sidebar empty-state copy and `/workflow` slash-command ghost hint so both describe explicit workflow script-path invocation without implying a special workspace workflow directory.

Background

The previous sidebar text pointed users at `.mux/workflows/`, but workspace-file workflows are not discovered from that folder. They are loaded by explicit `.js` path, while the Workflows tab only lists workflow-bearing skills with a conventional `workflow.js` entry. The slash-command ghost hint also repeated `/workflow` after the user had already typed it.

Implementation

- Added a canonical workflow slash-command argument hint: `<script_path> [args]`.
- Reused that hint for the `/workflow` command usage, ghost text, and Workflows tab helper copy.
- Added a regression test that verifies the ghost hint shows only arguments after `/workflow `.

Validation

- `bun test src/browser/utils/slashCommands/ghostHint.test.ts`
- `bun test src/browser/utils/slashCommands/parser.test.ts`
- `bun x prettier --check src/common/constants/slashCommandHints.ts src/browser/utils/slashCommands/registry.ts src/browser/utils/slashCommands/ghostHint.test.ts src/browser/features/RightSidebar/Workflows/WorkflowEmptyState.tsx`
- `make typecheck`
- `env MUX_ESLINT_CONCURRENCY=1 make lint`
- `env MUX_ESLINT_CONCURRENCY=1 make static-check`
- Dogfooded in an isolated `make dev-server-sandbox` session with Agent Browser; captured screenshot and WebM evidence for the updated Workflows tab copy and slash-command hint.

Risks

Low. This changes display copy and shared command hint constants only; workflow resolution and execution behavior are unchanged.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$11.27`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=11.27 -->
