### PR TITLE
feat: add WorkspaceLifecycleToolCall transcript card

### DIFF
--- a/src/browser/features/Tools/Shared/ToolPrimitives.tsx
+++ b/src/browser/features/Tools/Shared/ToolPrimitives.tsx
@@ -19,6 +19,7 @@ import {
   GraduationCap,
   Hand,
   Keyboard,
+  Layers,
   Lightbulb,
   MessageCircleQuestion,
   Monitor,
@@ -269,6 +270,9 @@ export const TOOL_NAME_TO_ICON: Partial<Record<string, LucideIcon>> = {
   review_pane_get: ScanEye,
   analytics_query: Database,
   task_apply_git_patch: GitCommit,
+  // Layers (stacked planes) reads as "manage the stack of child workspaces" — matches the
+  // WorkspaceLifecycleToolCall card's glyph.
+  task_workspace_lifecycle: Layers,
   set_goal: Target,
   get_goal: Target,
   complete_goal: CircleCheck,

--- a/src/browser/features/Tools/Shared/getToolComponent.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.ts
@@ -42,6 +42,7 @@ import {
   TaskTerminateToolCall,
 } from "../TaskToolCall";
 import { TaskApplyGitPatchToolCall } from "../TaskApplyGitPatchToolCall";
+import { WorkspaceLifecycleToolCall } from "../WorkspaceLifecycleToolCall";
 import { SetGoalToolCall } from "../SetGoalToolCall";
 import { GetGoalToolCall } from "../GetGoalToolCall";
 import { HeartbeatToolCall } from "../HeartbeatToolCall";
@@ -182,6 +183,10 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   task_apply_git_patch: {
     component: TaskApplyGitPatchToolCall,
     schema: TOOL_DEFINITIONS.task_apply_git_patch.schema,
+  },
+  task_workspace_lifecycle: {
+    component: WorkspaceLifecycleToolCall,
+    schema: TOOL_DEFINITIONS.task_workspace_lifecycle.schema,
   },
   workflow_run: {
     component: WorkflowRunToolCall,

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.stories.tsx
@@ -1,0 +1,225 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { WorkspaceLifecycleToolCall } from "@/browser/features/Tools/WorkspaceLifecycleToolCall";
+import { CHROMATIC_DISABLED, lightweightMeta, StoryUiShell } from "@/browser/stories/meta.js";
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Chat/Tools/WorkspaceLifecycle",
+  component: WorkspaceLifecycleToolCall,
+  parameters: {
+    ...lightweightMeta.parameters,
+    // The repo-wide Chromatic snapshot budget (tests/ui/storybook/budget.test.ts) is already
+    // at its ceiling, so these states stay out of paid visual snapshots. They still render
+    // under local Storybook and the CI Storybook test-runner smoke pass. Flip to
+    // CHROMATIC_SINGLE_MODE once the budget is raised to add regression coverage.
+    chromatic: CHROMATIC_DISABLED,
+  },
+  decorators: [
+    (Story) => (
+      <StoryUiShell>
+        <div className="bg-background p-6">
+          <div className="w-full max-w-2xl">
+            <Story />
+          </div>
+        </div>
+      </StoryUiShell>
+    ),
+  ],
+} satisfies Meta<typeof WorkspaceLifecycleToolCall>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** archive · several owned workspaces all archived (uniform → solid "N archived" pill). */
+export const ArchiveMultiple: Story = {
+  args: {
+    args: {
+      action: "archive",
+      targets: [
+        { workspaceId: "24e33167af" },
+        { workspaceId: "4a92f76fbf" },
+        { workspaceId: "0b71c40e21" },
+      ],
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      results: [
+        { status: "archived", action: "archive", workspaceId: "24e33167af" },
+        { status: "archived", action: "archive", workspaceId: "4a92f76fbf" },
+        { status: "archived", action: "archive", workspaceId: "0b71c40e21" },
+      ],
+    },
+  },
+};
+
+/** remove · single workspace removed permanently (danger tone). */
+export const RemoveSingle: Story = {
+  args: {
+    args: { action: "remove", targets: [{ taskId: "wst_9f0c1d77aa" }] },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      results: [
+        {
+          status: "removed",
+          action: "remove",
+          taskId: "wst_9f0c1d77aa",
+          workspaceId: "9f0c1d77aa",
+        },
+      ],
+    },
+  },
+};
+
+/** delete_worktree · batch reclaim of disk for already-archived workspaces. */
+export const DeleteWorktreeBatch: Story = {
+  args: {
+    args: {
+      action: "delete_worktree",
+      targets: [{ workspaceId: "9f0c1d77aa" }, { workspaceId: "771be0c3d2" }],
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      results: [
+        { status: "deleted_worktree", action: "delete_worktree", workspaceId: "9f0c1d77aa" },
+        { status: "deleted_worktree", action: "delete_worktree", workspaceId: "771be0c3d2" },
+      ],
+    },
+  },
+};
+
+/** Mixed · one archived, one already archived (no-op), one not found (mixed → dot-chips). */
+export const PartialNotFound: Story = {
+  args: {
+    args: {
+      action: "archive",
+      targets: [
+        { workspaceId: "9f0c1d77aa" },
+        { workspaceId: "771be0c3d2" },
+        { workspaceId: "deadbeef00" },
+      ],
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      results: [
+        { status: "archived", action: "archive", workspaceId: "9f0c1d77aa" },
+        { status: "already_archived", action: "archive", workspaceId: "771be0c3d2" },
+        {
+          status: "not_found",
+          action: "archive",
+          workspaceId: "deadbeef00",
+          note: "Owned workspace metadata is already absent.",
+        },
+      ],
+    },
+  },
+};
+
+/**
+ * Blocked · requires_confirmation (untracked files would be lost) + an active turn. Pinned
+ * to a fixed ~375px container (the Storybook test-runner renders at desktop width and
+ * ignores viewport / Chromatic modes, so the narrow case must be forced with a wrapper) and
+ * a play that fails if a long workspace id / file path overflows instead of truncating.
+ */
+export const BlockedNeedsAction: Story = {
+  args: {
+    args: {
+      action: "archive",
+      targets: [
+        { workspaceId: "feature-billing-webhooks-experiment-very-long-id-001" },
+        { workspaceId: "4a92f76fbf" },
+      ],
+    },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      results: [
+        {
+          status: "requires_confirmation",
+          action: "archive",
+          workspaceId: "feature-billing-webhooks-experiment-very-long-id-001",
+          paths: [
+            "packages/server/src/very/deeply/nested/path/to/an/untracked/file/that/is/quite/long/scratch.local.ts",
+            ".env.local",
+          ],
+        },
+        {
+          status: "active",
+          action: "archive",
+          workspaceId: "4a92f76fbf",
+          activeTaskIds: ["wst_4a92f76fbf01"],
+        },
+      ],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div data-testid="wl-card-container" className="w-[375px]">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    if (!canvasElement.textContent?.includes("Confirm files")) {
+      throw new Error("WorkspaceLifecycle requires_confirmation row did not render");
+    }
+    const container = canvasElement.querySelector('[data-testid="wl-card-container"]');
+    if (!(container instanceof HTMLElement)) {
+      throw new Error("WorkspaceLifecycle story container not found");
+    }
+    // Let layout settle before measuring.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    );
+    if (container.scrollWidth > container.clientWidth + 1) {
+      throw new Error(
+        `WorkspaceLifecycle card overflowed its ${container.clientWidth}px container by ` +
+          `${container.scrollWidth - container.clientWidth}px`
+      );
+    }
+  },
+};
+
+/** Mid-flight, before the result arrives — falls back to the requested targets. */
+export const Executing: Story = {
+  args: {
+    args: {
+      action: "remove",
+      targets: [{ workspaceId: "24e33167af" }, { workspaceId: "4a92f76fbf" }],
+    },
+    status: "executing",
+    defaultExpanded: true,
+  },
+};
+
+/**
+ * Error · a thrown execute() surfaces as { success: false, error } (e.g. the tool ran
+ * outside an orchestrator context). Exercises the shared ErrorBox.
+ */
+export const ErrorResult: Story = {
+  args: {
+    args: { action: "remove", targets: [{ workspaceId: "24e33167af" }] },
+    status: "failed",
+    defaultExpanded: true,
+    result: {
+      success: false,
+      error: "task_workspace_lifecycle requires an orchestrator workspace context.",
+    },
+  },
+};
+
+/** Per-row failure · target is not a workspace this orchestrator owns. */
+export const InvalidScope: Story = {
+  args: {
+    args: { action: "remove", targets: [{ taskId: "wst_notmine00" }] },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      results: [{ status: "invalid_scope", action: "remove", taskId: "wst_notmine00" }],
+    },
+  },
+};

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
@@ -26,6 +26,7 @@ import {
   useToolExpansion,
   getStatusDisplay,
   isToolErrorResult,
+  unwrapResult,
   type ToolStatus,
 } from "./Shared/toolUtils";
 import { TaskWorkspaceLifecycleToolResultSchema } from "@/common/utils/tools/toolDefinitions";
@@ -382,8 +383,12 @@ export const WorkspaceLifecycleToolCall: React.FC<WorkspaceLifecycleToolCallProp
 
   const action = props.args.action;
   const meta = ACTION_META[action];
-  const errorResult = isToolErrorResult(props.result) ? props.result : null;
-  const rows = extractRows(props.result);
+  // Tool results may be persisted/emitted in the SDK JSON-container shape
+  // ({ type: "json", value: ... }); unwrap (idempotent for already-bare results) before
+  // parsing so a valid { results: [...] } payload isn't misread as malformed.
+  const result = unwrapResult(props.result);
+  const errorResult = isToolErrorResult(result) ? result : null;
+  const rows = extractRows(result);
   const executing = status === "executing";
 
   const total =

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
@@ -1,0 +1,445 @@
+import React from "react";
+import {
+  Archive,
+  Ban,
+  CircleX,
+  FolderX,
+  LoaderCircle,
+  type LucideIcon,
+  SearchX,
+  ShieldAlert,
+  Trash2,
+  TriangleAlert,
+} from "lucide-react";
+import { cn } from "@/common/lib/utils";
+import {
+  ToolContainer,
+  ToolHeader,
+  ExpandIcon,
+  StatusIndicator,
+  ToolDetails,
+  ToolIcon,
+  ErrorBox,
+  LoadingDots,
+} from "./Shared/ToolPrimitives";
+import {
+  useToolExpansion,
+  getStatusDisplay,
+  isToolErrorResult,
+  type ToolStatus,
+} from "./Shared/toolUtils";
+import { TaskWorkspaceLifecycleToolResultSchema } from "@/common/utils/tools/toolDefinitions";
+import type {
+  TaskWorkspaceLifecycleStatus,
+  TaskWorkspaceLifecycleTargetResult,
+  TaskWorkspaceLifecycleToolArgs,
+} from "@/common/types/tools";
+
+/**
+ * Transcript card for `task_workspace_lifecycle` — the tool a parent/orchestrator
+ * agent uses to reconcile the child workspaces it spun up via `task(kind="workspace")`
+ * by archiving them, deleting their on-disk worktree, or removing them entirely.
+ *
+ * Collapsed, it reads as a glanceable count of what changed (and whether anything is
+ * blocked or failed); expanded, it lists each target workspace with its per-target
+ * outcome. Mirrors the backend (TaskWorkspaceLifecycleToolResultSchema): the result is
+ * `{ results: [...] }` (no top-level `success`), each row discriminated on one of twelve
+ * lifecycle `status` values. A thrown execute() surfaces instead as `{ success: false,
+ * error }`, handled via the shared ErrorBox.
+ *
+ * Design intent ported from the "Workspace Lifecycle Tool Call" Mux Design System mockup;
+ * the mockup used a simplified placeholder schema (archive|delete, top-level success), so
+ * this card preserves its visual vocabulary while binding to the real status union.
+ */
+
+type Tone = "warn" | "danger" | "info" | "muted";
+
+// Tone → token classes. We honor the mockup's destructiveness coding rather than a flat
+// "green = done": archive is reversible (amber/warn), remove is irreversible (red/danger),
+// idempotent no-ops are muted, and "active" (a running turn blocks the action) reads as the
+// in-progress/pending tone. All tokens are defined in globals.css.
+const TONE_TEXT: Record<Tone, string> = {
+  warn: "text-warning",
+  danger: "text-danger",
+  info: "text-pending",
+  muted: "text-secondary",
+};
+const TONE_BADGE: Record<Tone, string> = {
+  warn: "bg-warning-overlay text-warning",
+  danger: "bg-danger-overlay text-danger",
+  info: "bg-pending/10 text-pending",
+  muted: "bg-white/5 text-secondary",
+};
+const TONE_DOT: Record<Tone, string> = {
+  warn: "bg-warning",
+  danger: "bg-danger",
+  info: "bg-pending",
+  muted: "bg-white/30",
+};
+
+// Header-summary buckets. "settled" = the workspace is in (or already in) the desired
+// state; "blocked" = the action needs a follow-up flag/step before it can proceed;
+// "failed" = ownership/scope error. The header pill takes the most severe bucket's tone.
+type OutcomeGroup = "settled" | "blocked" | "failed";
+const GROUP_TONE: Record<OutcomeGroup, Tone> = {
+  settled: "muted",
+  blocked: "warn",
+  failed: "danger",
+};
+
+interface StatusMeta {
+  /** Short badge label shown on each row and (for uniform results) in the header pill. */
+  label: string;
+  tone: Tone;
+  group: OutcomeGroup;
+  Icon: LucideIcon;
+}
+
+// Exhaustive map over the backend status union (Record<Enum,_> catches a missing case at
+// compile time if the schema gains a status).
+const STATUS_META: Record<TaskWorkspaceLifecycleStatus, StatusMeta> = {
+  archived: { label: "Archived", tone: "warn", group: "settled", Icon: Archive },
+  already_archived: { label: "Already archived", tone: "muted", group: "settled", Icon: Archive },
+  deleted_worktree: { label: "Worktree deleted", tone: "warn", group: "settled", Icon: FolderX },
+  already_transcript_only: {
+    label: "Worktree already gone",
+    tone: "muted",
+    group: "settled",
+    Icon: FolderX,
+  },
+  removed: { label: "Removed", tone: "danger", group: "settled", Icon: Trash2 },
+  already_removed: { label: "Already removed", tone: "muted", group: "settled", Icon: Trash2 },
+  not_found: { label: "Not found", tone: "muted", group: "settled", Icon: SearchX },
+  requires_archive: {
+    label: "Archive first",
+    tone: "warn",
+    group: "blocked",
+    Icon: TriangleAlert,
+  },
+  requires_confirmation: {
+    label: "Confirm files",
+    tone: "warn",
+    group: "blocked",
+    Icon: ShieldAlert,
+  },
+  active: { label: "Active turn", tone: "info", group: "blocked", Icon: LoaderCircle },
+  invalid_scope: { label: "Out of scope", tone: "danger", group: "failed", Icon: Ban },
+  error: { label: "Error", tone: "danger", group: "failed", Icon: CircleX },
+};
+
+/**
+ * Bucket per-target outcomes into the three header-summary groups. Exported so the
+ * classification (which states read as settled vs. needs-attention vs. failed — a
+ * user-visible severity decision, not just copy) can be tested directly.
+ */
+export function summarizeOutcomeGroups(
+  rows: TaskWorkspaceLifecycleTargetResult[]
+): Record<OutcomeGroup, number> {
+  const counts: Record<OutcomeGroup, number> = { settled: 0, blocked: 0, failed: 0 };
+  for (const row of rows) counts[STATUS_META[row.status].group] += 1;
+  return counts;
+}
+
+interface ActionMeta {
+  /** Header verb while the call is in flight. */
+  gerund: string;
+  /** Header verb once resolved (imperative, matching the house style of other tool cards). */
+  label: string;
+  /** Count unit; delete_worktree acts on the worktree, archive/remove on the workspace. */
+  unit: string;
+  /** Expanded footer explaining what the action does. */
+  note: string;
+}
+
+const ACTION_META: Record<TaskWorkspaceLifecycleToolArgs["action"], ActionMeta> = {
+  archive: {
+    gerund: "Archiving workspaces",
+    label: "Archive workspaces",
+    unit: "workspace",
+    note: "Archived workspaces are hidden from the active list and can be restored later.",
+  },
+  delete_worktree: {
+    gerund: "Deleting worktrees",
+    label: "Delete worktrees",
+    unit: "worktree",
+    note: "Deletes the on-disk worktree to reclaim space; the transcript is kept and the workspace stays archived.",
+  },
+  remove: {
+    gerund: "Removing workspaces",
+    label: "Remove workspaces",
+    unit: "workspace",
+    note: "Removed workspaces are deleted permanently, including transcript and session state.",
+  },
+};
+
+/**
+ * Narrow an arbitrary persisted result to the success payload. Results flow verbatim from
+ * transcripts, so we validate against the schema rather than trusting the shape — a
+ * malformed result simply renders the requested-args fallback instead of throwing
+ * (self-healing).
+ */
+function extractRows(result: unknown): TaskWorkspaceLifecycleTargetResult[] {
+  const parsed = TaskWorkspaceLifecycleToolResultSchema.safeParse(result);
+  return parsed.success ? parsed.data.results : [];
+}
+
+/** Human-readable identifier for a target: prefer the resolved workspace id. */
+function targetIdLabel(target: { taskId?: string | null; workspaceId?: string | null }): string {
+  return target.workspaceId ?? target.taskId ?? "workspace";
+}
+
+const Dot: React.FC<{ tone: Tone }> = (props) => (
+  <span className={cn("inline-block h-1.5 w-1.5 shrink-0 rounded-full", TONE_DOT[props.tone])} />
+);
+
+/** Compact header pill summarizing outcomes — the collapsed-card glance. */
+const HeaderBadge: React.FC<{ rows: TaskWorkspaceLifecycleTargetResult[]; executing: boolean }> = (
+  props
+) => {
+  const base =
+    "inline-flex shrink-0 items-center gap-2 rounded-full px-2 py-0.5 text-[10px] font-medium leading-none";
+
+  if (props.executing) {
+    return (
+      <span className={cn(base, "bg-white/5 text-secondary")}>
+        <LoadingDots>Working</LoadingDots>
+      </span>
+    );
+  }
+  if (props.rows.length === 0) return null;
+
+  // Uniform outcome → a single solid pill reading e.g. "3 archived" (the common case where
+  // every target landed the same way). Mixed → grouped dot-chips by severity.
+  const first = props.rows[0].status;
+  const uniform = props.rows.every((r) => r.status === first);
+  if (uniform) {
+    const meta = STATUS_META[first];
+    return (
+      <span className={cn(base, TONE_BADGE[meta.tone])}>
+        <Dot tone={meta.tone} />
+        <span className="counter-nums">{props.rows.length}</span>
+        <span className="lowercase">{meta.label}</span>
+      </span>
+    );
+  }
+
+  const counts = summarizeOutcomeGroups(props.rows);
+  const worst: Tone = counts.failed > 0 ? "danger" : counts.blocked > 0 ? "warn" : "muted";
+  const chips: Array<{ group: OutcomeGroup; n: number; label: string }> = [
+    { group: "settled", n: counts.settled, label: "done" },
+    { group: "blocked", n: counts.blocked, label: "blocked" },
+    { group: "failed", n: counts.failed, label: "failed" },
+  ];
+
+  return (
+    <span className={cn(base, TONE_BADGE[worst])}>
+      {chips
+        .filter((c) => c.n > 0)
+        .map((c) => (
+          <span key={c.group} className="inline-flex items-center gap-1.5">
+            <Dot tone={GROUP_TONE[c.group]} />
+            <span className="counter-nums">{c.n}</span>
+            <span className="text-secondary">{c.label}</span>
+          </span>
+        ))}
+    </span>
+  );
+};
+
+/** Per-row blocked-state hint: tells the agent the follow-up step that would unblock it. */
+function blockedHint(
+  status: TaskWorkspaceLifecycleStatus,
+  action: TaskWorkspaceLifecycleToolArgs["action"]
+): string | null {
+  switch (status) {
+    case "requires_archive":
+      return `Archive this workspace before ${action === "remove" ? "removing it" : "deleting its worktree"}.`;
+    case "requires_confirmation":
+      return "Re-run with these paths listed in acknowledged_untracked_paths to confirm.";
+    case "active":
+      return "Pass interrupt_active: true to act on a running turn.";
+    default:
+      return null;
+  }
+}
+
+// Labeled, scrollable list of identifiers (untracked paths or active task ids). Both are
+// repo-/runtime-controlled strings that can be long, so break-all + a capped scroll keep the
+// row from overflowing its container on narrow/mobile widths.
+const DetailList: React.FC<{ label: string; items: string[] }> = (props) => (
+  <div className="mt-1.5">
+    <div className="text-secondary mb-1 text-[10px] tracking-wide uppercase">{props.label}</div>
+    <ul className="bg-code-bg max-h-32 space-y-0.5 overflow-y-auto rounded px-2 py-1.5">
+      {props.items.map((item, i) => (
+        <li key={i} className="text-foreground break-all">
+          {item}
+        </li>
+      ))}
+    </ul>
+  </div>
+);
+
+const WorkspaceRow: React.FC<{
+  row: TaskWorkspaceLifecycleTargetResult;
+  action: TaskWorkspaceLifecycleToolArgs["action"];
+  last: boolean;
+}> = (props) => {
+  const row = props.row;
+  const meta = STATUS_META[row.status];
+  const Icon = meta.Icon;
+  const primary = targetIdLabel(row);
+  // Show the originating wst_… task id as a secondary line only when distinct from the
+  // primary (resolved) workspace id.
+  const secondary = row.taskId != null && row.taskId !== primary ? row.taskId : null;
+  const hint = blockedHint(row.status, props.action);
+
+  return (
+    <div className={cn("py-2", props.last ? "" : "border-b border-white/5")}>
+      <div className="flex items-center gap-2.5">
+        <span className={cn("inline-flex shrink-0 [&_svg]:size-3.5", TONE_TEXT[meta.tone])}>
+          <Icon aria-hidden="true" />
+        </span>
+        <span className="text-foreground min-w-0 flex-1 truncate">{primary}</span>
+        <span
+          className={cn(
+            "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium tracking-wide uppercase",
+            TONE_BADGE[meta.tone]
+          )}
+        >
+          {meta.label}
+        </span>
+      </div>
+
+      {/* Sub-lines align under the primary id (icon size-3.5 + gap-2.5 ≈ pl-6). */}
+      {secondary && (
+        <div className="text-secondary mt-0.5 truncate pl-6 text-[10px]">{secondary}</div>
+      )}
+      {row.error && <div className="text-danger mt-1 pl-6 break-words">{row.error}</div>}
+      {row.note && <div className="text-secondary mt-1 pl-6 break-words">{row.note}</div>}
+      <div className="pl-6">
+        {row.paths && row.paths.length > 0 && (
+          <DetailList
+            label={
+              row.status === "requires_confirmation"
+                ? "Untracked files that would be lost"
+                : "Paths"
+            }
+            items={row.paths}
+          />
+        )}
+        {row.activeTaskIds && row.activeTaskIds.length > 0 && (
+          <DetailList label="Active turns" items={row.activeTaskIds} />
+        )}
+        {hint && <div className="text-muted mt-1 text-[10.5px] italic">{hint}</div>}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Fallback when no parseable result rows exist yet (executing, interrupted, or a degraded
+ * result): surface what the agent requested so the expanded card is never blank.
+ */
+const RequestedTargets: React.FC<{
+  args: TaskWorkspaceLifecycleToolArgs;
+  meta: ActionMeta;
+  executing: boolean;
+}> = (props) => {
+  const targets = Array.isArray(props.args.targets) ? props.args.targets : [];
+  return (
+    <div className="bg-code-bg rounded px-3 py-2 text-[11px]">
+      {props.executing ? (
+        <div className="text-muted mb-1.5 italic">
+          {props.meta.gerund}
+          {targets.length > 0 ? ` (${targets.length})` : ""}
+          <LoadingDots />
+        </div>
+      ) : (
+        <div className="text-secondary mb-1.5 text-[10px] tracking-wide uppercase">Requested</div>
+      )}
+      <ul className="space-y-0.5">
+        {targets.map((t, i) => (
+          <li key={i} className="text-foreground break-all">
+            {targetIdLabel(t)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+interface WorkspaceLifecycleToolCallProps {
+  args: TaskWorkspaceLifecycleToolArgs;
+  result?: unknown;
+  status?: ToolStatus;
+  /** Initial expansion fallback (until the user toggles this tool in the workspace). */
+  defaultExpanded?: boolean;
+}
+
+export const WorkspaceLifecycleToolCall: React.FC<WorkspaceLifecycleToolCallProps> = (props) => {
+  const status = props.status ?? "pending";
+  const { expanded, toggleExpanded } = useToolExpansion(props.defaultExpanded ?? false);
+
+  const action = props.args.action;
+  const meta = ACTION_META[action];
+  const errorResult = isToolErrorResult(props.result) ? props.result : null;
+  const rows = extractRows(props.result);
+  const executing = status === "executing";
+
+  const total =
+    rows.length > 0
+      ? rows.length
+      : Array.isArray(props.args.targets)
+        ? props.args.targets.length
+        : 0;
+
+  return (
+    <ToolContainer expanded={expanded} className="@container">
+      <ToolHeader onClick={toggleExpanded}>
+        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
+        <ToolIcon toolName="task_workspace_lifecycle" />
+        <span className="text-secondary font-medium whitespace-nowrap">
+          {executing ? meta.gerund : meta.label}
+        </span>
+        {total > 0 && (
+          <span className="text-secondary counter-nums whitespace-nowrap">
+            {total} {meta.unit}
+            {total === 1 ? "" : "s"}
+          </span>
+        )}
+        {!errorResult && (rows.length > 0 || executing) && (
+          <HeaderBadge rows={rows} executing={executing} />
+        )}
+        <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
+      </ToolHeader>
+
+      {expanded && (
+        <ToolDetails>
+          {errorResult && <ErrorBox>{errorResult.error}</ErrorBox>}
+
+          {rows.length > 0 && (
+            <>
+              <div className="bg-code-bg rounded px-3 py-1.5">
+                <div className="flex flex-col">
+                  {rows.map((row, i) => (
+                    <WorkspaceRow
+                      key={row.workspaceId ?? row.taskId ?? i}
+                      row={row}
+                      action={action}
+                      last={i === rows.length - 1}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div className="text-muted mt-2 px-1 text-[10.5px] leading-relaxed">{meta.note}</div>
+            </>
+          )}
+
+          {rows.length === 0 && !errorResult && (
+            <RequestedTargets args={props.args} meta={meta} executing={executing} />
+          )}
+        </ToolDetails>
+      )}
+    </ToolContainer>
+  );
+};

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
@@ -398,11 +398,14 @@ export const WorkspaceLifecycleToolCall: React.FC<WorkspaceLifecycleToolCallProp
       <ToolHeader onClick={toggleExpanded}>
         <ExpandIcon expanded={expanded}>▶</ExpandIcon>
         <ToolIcon toolName="task_workspace_lifecycle" />
-        <span className="text-secondary font-medium whitespace-nowrap">
+        {/* Verb truncates as a last resort so the header never overflows; the count is
+            hidden on narrow containers (the badge already conveys it there), mirroring how
+            HeartbeatToolCall hides its secondary header text below @sm. */}
+        <span className="text-secondary min-w-0 truncate font-medium">
           {executing ? meta.gerund : meta.label}
         </span>
         {total > 0 && (
-          <span className="text-secondary counter-nums whitespace-nowrap">
+          <span className="text-secondary counter-nums hidden whitespace-nowrap @sm:inline">
             {total} {meta.unit}
             {total === 1 ? "" : "s"}
           </span>

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
@@ -25,7 +25,6 @@ import {
 import {
   useToolExpansion,
   getStatusDisplay,
-  isToolErrorResult,
   unwrapResult,
   type ToolStatus,
 } from "./Shared/toolUtils";
@@ -182,6 +181,21 @@ const ACTION_META: Record<TaskWorkspaceLifecycleToolArgs["action"], ActionMeta> 
 function extractRows(result: unknown): TaskWorkspaceLifecycleTargetResult[] {
   const parsed = TaskWorkspaceLifecycleToolResultSchema.safeParse(result);
   return parsed.success ? parsed.data.results : [];
+}
+
+/**
+ * Top-level failure message, if the result represents a failed call rather than a
+ * `{ results: [...] }` payload. Covers both the standard thrown shape
+ * (`{ success: false, error }`) and the nested code_execution/PTC shape (`{ error }` with no
+ * `success` flag, reconstructed by displayedMessageBuilder) — the latter reaches this card
+ * now that nested calls route here instead of GenericToolCall. A valid results payload has no
+ * top-level `error`, so successful batches (even with per-row errors) are unaffected.
+ */
+function extractErrorText(result: unknown): string | null {
+  if (result == null || typeof result !== "object") return null;
+  const record = result as Record<string, unknown>;
+  if (Array.isArray(record.results)) return null;
+  return typeof record.error === "string" ? record.error : null;
 }
 
 /** Human-readable identifier for a target: prefer the resolved workspace id. */
@@ -387,7 +401,7 @@ export const WorkspaceLifecycleToolCall: React.FC<WorkspaceLifecycleToolCallProp
   // ({ type: "json", value: ... }); unwrap (idempotent for already-bare results) before
   // parsing so a valid { results: [...] } payload isn't misread as malformed.
   const result = unwrapResult(props.result);
-  const errorResult = isToolErrorResult(result) ? result : null;
+  const errorText = extractErrorText(result);
   const rows = extractRows(result);
   const executing = status === "executing";
 
@@ -415,7 +429,7 @@ export const WorkspaceLifecycleToolCall: React.FC<WorkspaceLifecycleToolCallProp
             {total === 1 ? "" : "s"}
           </span>
         )}
-        {!errorResult && (rows.length > 0 || executing) && (
+        {!errorText && (rows.length > 0 || executing) && (
           <HeaderBadge rows={rows} executing={executing} />
         )}
         <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
@@ -423,7 +437,7 @@ export const WorkspaceLifecycleToolCall: React.FC<WorkspaceLifecycleToolCallProp
 
       {expanded && (
         <ToolDetails>
-          {errorResult && <ErrorBox>{errorResult.error}</ErrorBox>}
+          {errorText && <ErrorBox>{errorText}</ErrorBox>}
 
           {rows.length > 0 && (
             <>
@@ -443,7 +457,7 @@ export const WorkspaceLifecycleToolCall: React.FC<WorkspaceLifecycleToolCallProp
             </>
           )}
 
-          {rows.length === 0 && !errorResult && (
+          {rows.length === 0 && !errorText && (
             <RequestedTargets args={props.args} meta={meta} executing={executing} />
           )}
         </ToolDetails>

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx
@@ -138,6 +138,27 @@ describe("WorkspaceLifecycleToolCall", () => {
     expect(view.queryByText("arg-fallback-id")).not.toBeNull();
   });
 
+  test("unwraps a JSON-containered result before parsing", () => {
+    const view = renderWithProviders(
+      <WorkspaceLifecycleToolCall
+        args={{ action: "archive", targets: [{ workspaceId: "arg-target" }] }}
+        status="completed"
+        defaultExpanded
+        // SDK JSON-container shape — the real { results: [...] } is nested under `value`.
+        result={{
+          type: "json",
+          value: {
+            results: [{ status: "archived", action: "archive", workspaceId: "row-ws-unwrapped" }],
+          },
+        }}
+      />
+    );
+    // The row from the unwrapped payload renders; the requested-targets fallback (which would
+    // show the arg id) does not — i.e. the container was unwrapped, not treated as malformed.
+    expect(view.queryByText("row-ws-unwrapped")).not.toBeNull();
+    expect(view.queryByText("arg-target")).toBeNull();
+  });
+
   test("renders the shared error box for a thrown { success: false } result", () => {
     const view = renderWithProviders(
       <WorkspaceLifecycleToolCall

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+import type { ReactElement } from "react";
+
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { MessageListProvider } from "@/browser/features/Messages/MessageListContext";
+import { ToolNameProvider } from "@/browser/features/Messages/ToolNameContext";
+import type {
+  TaskWorkspaceLifecycleStatus,
+  TaskWorkspaceLifecycleTargetResult,
+} from "@/common/types/tools";
+import { summarizeOutcomeGroups, WorkspaceLifecycleToolCall } from "./WorkspaceLifecycleToolCall";
+
+const TEST_WORKSPACE_ID = "workspace-lifecycle-test";
+
+// ToolIcon renders a Radix Tooltip which requires a TooltipProvider and contexts.
+function renderWithProviders(ui: ReactElement) {
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <MessageListProvider value={{ workspaceId: TEST_WORKSPACE_ID, latestMessageId: null }}>
+        <ToolNameProvider toolName="task_workspace_lifecycle">
+          <TooltipProvider>{ui}</TooltipProvider>
+        </ToolNameProvider>
+      </MessageListProvider>
+    </ThemeProvider>
+  );
+}
+
+function row(
+  status: TaskWorkspaceLifecycleStatus,
+  extra: Partial<TaskWorkspaceLifecycleTargetResult> = {}
+): TaskWorkspaceLifecycleTargetResult {
+  // `status` is a runtime variable, so the literal can't be inferred as a single
+  // discriminated-union member; assert through a variable (not an object literal) to
+  // satisfy consistent-type-assertions.
+  const built = { status, action: "archive", workspaceId: "w", ...extra };
+  return built as unknown as TaskWorkspaceLifecycleTargetResult;
+}
+
+describe("summarizeOutcomeGroups", () => {
+  // Locks the severity classification: which lifecycle states read as "settled" (in the
+  // desired state), "blocked" (need a follow-up flag/step), or "failed" (scope/ownership
+  // error). This drives the collapsed header's tone and chip counts, so it is user-visible
+  // behavior — not prose.
+  const EXPECTED: Record<
+    TaskWorkspaceLifecycleStatus,
+    keyof ReturnType<typeof summarizeOutcomeGroups>
+  > = {
+    archived: "settled",
+    already_archived: "settled",
+    deleted_worktree: "settled",
+    already_transcript_only: "settled",
+    removed: "settled",
+    already_removed: "settled",
+    not_found: "settled",
+    requires_archive: "blocked",
+    requires_confirmation: "blocked",
+    active: "blocked",
+    invalid_scope: "failed",
+    error: "failed",
+  };
+
+  for (const [status, group] of Object.entries(EXPECTED)) {
+    test(`${status} → ${group}`, () => {
+      const counts = summarizeOutcomeGroups([row(status as TaskWorkspaceLifecycleStatus)]);
+      expect(counts[group]).toBe(1);
+      const others = (["settled", "blocked", "failed"] as const).filter((g) => g !== group);
+      for (const other of others) expect(counts[other]).toBe(0);
+    });
+  }
+
+  test("tallies a mixed batch across all three groups", () => {
+    expect(summarizeOutcomeGroups([row("archived"), row("active"), row("error")])).toEqual({
+      settled: 1,
+      blocked: 1,
+      failed: 1,
+    });
+  });
+});
+
+describe("WorkspaceLifecycleToolCall", () => {
+  beforeEach(() => {
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+  });
+
+  test("expanded card surfaces per-row blocked details (paths + active turns)", () => {
+    const view = renderWithProviders(
+      <WorkspaceLifecycleToolCall
+        args={{
+          action: "archive",
+          targets: [{ workspaceId: "ws-confirm" }, { workspaceId: "ws-active" }],
+        }}
+        status="completed"
+        defaultExpanded
+        result={{
+          results: [
+            {
+              status: "requires_confirmation",
+              action: "archive",
+              workspaceId: "ws-confirm",
+              paths: ["src/scratch.local.ts"],
+            },
+            {
+              status: "active",
+              action: "archive",
+              workspaceId: "ws-active",
+              activeTaskIds: ["wst_running01"],
+            },
+          ],
+        }}
+      />
+    );
+    // Conditional detail branches: the untracked path and the active turn id (both data,
+    // not copy) render only because the rows have those fields.
+    expect(view.queryByText("src/scratch.local.ts")).not.toBeNull();
+    expect(view.queryByText("wst_running01")).not.toBeNull();
+  });
+
+  test("self-heals a malformed result by falling back to the requested targets", () => {
+    const view = renderWithProviders(
+      <WorkspaceLifecycleToolCall
+        args={{ action: "remove", targets: [{ workspaceId: "arg-fallback-id" }] }}
+        status="completed"
+        defaultExpanded
+        // Not a valid { results: [...] } payload — must not throw, must surface the request.
+        result={{ unexpected: "shape" }}
+      />
+    );
+    expect(view.queryByText("arg-fallback-id")).not.toBeNull();
+  });
+
+  test("renders the shared error box for a thrown { success: false } result", () => {
+    const view = renderWithProviders(
+      <WorkspaceLifecycleToolCall
+        args={{ action: "remove", targets: [{ workspaceId: "ws-1" }] }}
+        status="failed"
+        defaultExpanded
+        result={{ success: false, error: "needs an orchestrator workspace context" }}
+      />
+    );
+    expect(view.queryByText("needs an orchestrator workspace context")).not.toBeNull();
+    // The requested-targets fallback is suppressed when there is a top-level error.
+    expect(view.queryByText("ws-1")).toBeNull();
+  });
+});

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx
@@ -172,4 +172,18 @@ describe("WorkspaceLifecycleToolCall", () => {
     // The requested-targets fallback is suppressed when there is a top-level error.
     expect(view.queryByText("ws-1")).toBeNull();
   });
+
+  test("surfaces a nested { error } failure (no success flag) instead of the fallback", () => {
+    const view = renderWithProviders(
+      <WorkspaceLifecycleToolCall
+        args={{ action: "archive", targets: [{ workspaceId: "ws-nested" }] }}
+        status="failed"
+        defaultExpanded
+        // code_execution/PTC reconstructs nested failures as { error } with no success flag.
+        result={{ error: "child workspace is not owned by this orchestrator" }}
+      />
+    );
+    expect(view.queryByText("child workspace is not owned by this orchestrator")).not.toBeNull();
+    expect(view.queryByText("ws-nested")).toBeNull();
+  });
 });

--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -30,6 +30,7 @@ import type {
   TaskApplyGitPatchToolResultSchema,
   TaskListToolResultSchema,
   TaskTerminateToolResultSchema,
+  TaskWorkspaceLifecycleToolResultSchema,
   TOOL_DEFINITIONS,
   WebFetchToolResultSchema,
   WorkflowRunToolResultSchema,
@@ -270,6 +271,27 @@ export type TaskListToolSuccessResult = z.infer<typeof TaskListToolResultSchema>
 export type TaskTerminateToolArgs = z.infer<typeof TOOL_DEFINITIONS.task_terminate.schema>;
 
 export type TaskTerminateToolSuccessResult = z.infer<typeof TaskTerminateToolResultSchema>;
+
+// Task Workspace Lifecycle Tool Types (parent-owned archive/delete_worktree/remove)
+export type TaskWorkspaceLifecycleToolArgs = z.infer<
+  typeof TOOL_DEFINITIONS.task_workspace_lifecycle.schema
+>;
+
+// Success shape is `{ results: [...] }` (no top-level `success`); a thrown execute()
+// surfaces as ToolErrorResult, so the renderable result is the union of both.
+export type TaskWorkspaceLifecycleToolSuccessResult = z.infer<
+  typeof TaskWorkspaceLifecycleToolResultSchema
+>;
+
+export type TaskWorkspaceLifecycleToolResult =
+  | TaskWorkspaceLifecycleToolSuccessResult
+  | ToolErrorResult;
+
+// One per-target outcome row, discriminated on `status` (12 lifecycle states).
+export type TaskWorkspaceLifecycleTargetResult =
+  TaskWorkspaceLifecycleToolSuccessResult["results"][number];
+
+export type TaskWorkspaceLifecycleStatus = TaskWorkspaceLifecycleTargetResult["status"];
 
 // Workflow Definition Tool Types
 // Workflow Run Tool Types


### PR DESCRIPTION
## Summary

Adds `WorkspaceLifecycleToolCall`, a dedicated transcript card for the parent-owned
`task_workspace_lifecycle` tool. Until now those calls fell through to the generic tool
renderer; this gives orchestrator workspace cleanup a first-class, glanceable card.

## Background

`task_workspace_lifecycle` (added in #3633) lets an orchestrator archive, delete the worktree
of, or remove the child workspaces it created via `task(kind="workspace")`. Its result is a
batch of per-target outcomes, which the generic renderer surfaced only as raw JSON. This card
ports the "Workspace Lifecycle Tool Call" design from the Mux Design System into a real
component.

The design mockup used a simplified *placeholder* schema (`archive | delete`, a top-level
`success`, a `name` field, four statuses). The real backend is different — actions are
`archive | delete_worktree | remove`, and the result is `{ results: [...] }` with **no**
top-level `success` and **twelve** discriminated `status` values. The card binds to the real
types and ports the mockup's *visual vocabulary*, not its data shape.

## Implementation

- **Collapsed** the card reads as a verb + target count + a summary pill: a single solid
  "N archived" pill when every target landed the same way, or severity-grouped dot-chips
  (settled / blocked / failed) for mixed batches.
- **Expanded** it lists each target with a status-specific icon and tone, the originating
  `wst_…` task id (when distinct), and the real `paths` (untracked files for
  `requires_confirmation`), `activeTaskIds` (for `active`), and `note` / `error` fields, plus
  a follow-up hint for blocked states (e.g. "pass `interrupt_active: true`").
- Results are validated with `safeParse` so a malformed/partial payload self-heals to a
  "requested targets" fallback instead of throwing; a thrown `{ success: false, error }`
  routes to the shared `ErrorBox`.
- The status → tone/group/icon map is an exhaustive `Record` over the backend status union, so
  a new backend status fails the typecheck until the card handles it.
- Registers the component + a `Layers` header icon, and exports the derived
  arg/result/status types from `common/types/tools.ts`.
- Long workspace ids truncate and path/id lists wrap (`break-all` + capped scroll), keeping the
  card within its container at mobile (~375px) widths.

## Validation

- `make typecheck`, eslint, and `bun test src/browser/features/Tools/` (268 tests) pass.
- New happy-dom test asserts the outcome-group classification, malformed-result self-healing,
  and the top-level error path — behavior, not card prose.
- Storybook states are added with snapshots disabled (the Chromatic budget is at its ceiling);
  Storybook compiles and serves all states. The 375px play test is included but could not be
  executed locally (no Playwright browser available in this environment).

## Risks

Low and isolated: a new, additive transcript renderer behind the tool registry. Worst case for
a rendering bug is a single tool card degrading — and an unparseable result already falls back
to the generic-style requested-targets view rather than breaking the workspace.
