### PR TITLE
chore(design-sync): sync WorkspaceLifecycleToolCall into the design system

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -162,13 +162,39 @@ needed; the cap is per-file 5 MB on both `_ds_bundle.js` and each `_preview/*.js
 - **Per-file 5 MB cap** applies to BOTH `_ds_bundle.js` and each `_preview/*.js`.
   Bundle ~4.7 MB and previews ~3.3 MB leave thin headroom — adding components or
   providers needs a fresh size measurement. (HeartbeatToolCall added: bundle 4.69 MB,
-  its preview 3.21 MB — still fits, headroom now ~0.3 MB.)
+  its preview 3.21 MB. WorkspaceLifecycleToolCall added: bundle **4.71 MB**, its preview
+  3.22 MB — both still fit, headroom now **~0.29 MB**. Tool cards share deps
+  (ToolPrimitives/toolUtils/lucide/the tool schema), so each new one adds only ~tens of KB
+  to the bundle; a NON-tool-card component would need a fresh union measurement first.)
 - **HeartbeatToolCall (tool card):** owned preview has one cell per story (10, named to
   match the story exports so `compare` pairs them — the stories import `meta.tsx` → the
   whole app, so the preview is hand-authored like the other cards). `cfg.overrides`
   uses `cardMode: "column"` because the `CustomMessageWrapping` story renders at a pinned
   375px (narrower than a grid cell → `[GRID_OVERFLOW] wide`); column keeps all stories
   full-width. All 10 stories grade `match`.
+- **WorkspaceLifecycleToolCall (tool card, `task_workspace_lifecycle`):** owned preview, one
+  cell per story (8, named to match exports so `compare` pairs them — stories import
+  `meta.tsx` → whole app, so hand-authored like the other cards). `cfg.overrides` uses
+  `cardMode: "column"` (the `BlockedNeedsAction` story renders at a pinned 375px →
+  `[GRID_OVERFLOW] wide`, same as Heartbeat). **Capture cap raised to 8** (`compare
+  --max-stories 8`) so the tail `ErrorResult` (ErrorBox layout) + `InvalidScope` (danger
+  row) variants grade too — the default cap is 6 and would skip them. All 8 grade `match`.
+  gen-barrel auto-resolves it (segment `WorkspaceLifecycle` → real name via story imports);
+  no EXCLUDE entry needed.
+- **Card viewport — KEEP THE DEFAULT 900x700; do NOT bump it for height.** Tall multi-story
+  column cards (HeartbeatToolCall, WorkspaceLifecycleToolCall) and tall sections
+  (KeybindsSection, GoalTab, GeneralSection) exceed 700px, but the gallery ALREADY handles this:
+  per `emit.mjs` (~L475) the product "fits the card to its ≤728px column / 500px fold by scaling;
+  content below the fold is **hover-scrollable**." So at the default viewport you scroll the card
+  to see everything at normal zoom. Setting a tall `cfg.overrides.<Name>.viewport` (e.g. 900x2600)
+  was tried and REVERTED — it makes the gallery scale the whole oversized card down to fit the
+  column, so it renders tiny/zoomed-out and is harder to read than the scroll. A `viewport`
+  override is for the capture/grading framing of overlays (`single` mode), not for showing tall
+  cards in full. (Reverting the bump re-grades the card — render unchanged, re-confirms `match`.)
+- **"Empty card on first appearance" is a stale gallery render, NOT a defect:** a brand-new
+  card can show empty cells (labels only) in the gallery until the app recompiles its
+  thumbnail — a hard-refresh / re-open of the project (which clears `_ds_needs_recompile` and
+  re-renders) fixes it. Don't chase it as a sync bug if the card renders correctly standalone.
 - **WorkflowRun/Timeouts exclusion:** `WorkflowRunToolCall` is EXCLUDE_HEAVY via its
   `WorkflowRun` segment, but `WorkflowRunToolCall.timeout.stories.tsx` titles to
   `…/WorkflowRun/Timeouts` (segment `Timeouts`), which slips that exclusion and would pull

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -75,7 +75,8 @@
     "HookOutput": "HookOutputDisplay",
     "Init": "InitMessage",
     "Streaming": "StreamingBarrierView",
-    "Todo": "TodoToolCall"
+    "Todo": "TodoToolCall",
+    "WorkspaceLifecycle": "WorkspaceLifecycleToolCall"
   },
   "overrides": {
     "StreamingBarrierView": {
@@ -166,6 +167,10 @@
       "skip": []
     },
     "HeartbeatToolCall": {
+      "skip": [],
+      "cardMode": "column"
+    },
+    "WorkspaceLifecycleToolCall": {
       "skip": [],
       "cardMode": "column"
     },

--- a/.design-sync/ds-barrel.ts
+++ b/.design-sync/ds-barrel.ts
@@ -39,6 +39,7 @@ export { TitleBar } from "@/browser/components/TitleBar/TitleBar";
 export { TodoToolCall } from "@/browser/features/Tools/TodoToolCall";
 export { Tooltip } from "@/browser/components/Tooltip/Tooltip";
 export { TranscriptHydrationSkeleton } from "@/browser/components/ChatPane/TranscriptHydrationSkeleton";
+export { WorkspaceLifecycleToolCall } from "@/browser/features/Tools/WorkspaceLifecycleToolCall";
 
 // ── Providers ──
 export { ThemeProvider } from "@/browser/contexts/ThemeContext";

--- a/.design-sync/previews/WorkspaceLifecycleToolCall.tsx
+++ b/.design-sync/previews/WorkspaceLifecycleToolCall.tsx
@@ -1,0 +1,188 @@
+import * as React from "react";
+import { MuxPreviewShell } from "../preview-harness";
+import { WorkspaceLifecycleToolCall } from "@/browser/features/Tools/WorkspaceLifecycleToolCall";
+
+// Isolated previews of the workspace-lifecycle tool-call card — one cell per story in
+// WorkspaceLifecycleToolCall.stories.tsx, named to match the story exports so compare pairs
+// them, rendered with the same inline args/result/status. Hand-authored (not generated)
+// because the stories import meta.tsx → the whole app graph, which is over the bundle cap
+// (see .design-sync/NOTES.md "UI primitives / previews").
+
+// Mirrors the stories' decorator chain (theme + tooltip provider, dark background, max-w-2xl).
+// `width` reproduces a story-level narrow wrapper (BlockedNeedsAction renders at 375px).
+const Shell = (props: { width?: string; children: React.ReactNode }) => (
+  <MuxPreviewShell>
+    <div className="bg-background p-6">
+      <div className="w-full max-w-2xl">
+        {props.width ? <div style={{ width: props.width }}>{props.children}</div> : props.children}
+      </div>
+    </div>
+  </MuxPreviewShell>
+);
+
+export const ArchiveMultiple = () => (
+  <Shell>
+    <WorkspaceLifecycleToolCall
+      args={{
+        action: "archive",
+        targets: [
+          { workspaceId: "24e33167af" },
+          { workspaceId: "4a92f76fbf" },
+          { workspaceId: "0b71c40e21" },
+        ],
+      }}
+      status="completed"
+      defaultExpanded
+      result={{
+        results: [
+          { status: "archived", action: "archive", workspaceId: "24e33167af" },
+          { status: "archived", action: "archive", workspaceId: "4a92f76fbf" },
+          { status: "archived", action: "archive", workspaceId: "0b71c40e21" },
+        ],
+      }}
+    />
+  </Shell>
+);
+
+export const RemoveSingle = () => (
+  <Shell>
+    <WorkspaceLifecycleToolCall
+      args={{ action: "remove", targets: [{ taskId: "wst_9f0c1d77aa" }] }}
+      status="completed"
+      defaultExpanded
+      result={{
+        results: [
+          {
+            status: "removed",
+            action: "remove",
+            taskId: "wst_9f0c1d77aa",
+            workspaceId: "9f0c1d77aa",
+          },
+        ],
+      }}
+    />
+  </Shell>
+);
+
+export const DeleteWorktreeBatch = () => (
+  <Shell>
+    <WorkspaceLifecycleToolCall
+      args={{
+        action: "delete_worktree",
+        targets: [{ workspaceId: "9f0c1d77aa" }, { workspaceId: "771be0c3d2" }],
+      }}
+      status="completed"
+      defaultExpanded
+      result={{
+        results: [
+          { status: "deleted_worktree", action: "delete_worktree", workspaceId: "9f0c1d77aa" },
+          { status: "deleted_worktree", action: "delete_worktree", workspaceId: "771be0c3d2" },
+        ],
+      }}
+    />
+  </Shell>
+);
+
+export const PartialNotFound = () => (
+  <Shell>
+    <WorkspaceLifecycleToolCall
+      args={{
+        action: "archive",
+        targets: [
+          { workspaceId: "9f0c1d77aa" },
+          { workspaceId: "771be0c3d2" },
+          { workspaceId: "deadbeef00" },
+        ],
+      }}
+      status="completed"
+      defaultExpanded
+      result={{
+        results: [
+          { status: "archived", action: "archive", workspaceId: "9f0c1d77aa" },
+          { status: "already_archived", action: "archive", workspaceId: "771be0c3d2" },
+          {
+            status: "not_found",
+            action: "archive",
+            workspaceId: "deadbeef00",
+            note: "Owned workspace metadata is already absent.",
+          },
+        ],
+      }}
+    />
+  </Shell>
+);
+
+export const BlockedNeedsAction = () => (
+  <Shell width="375px">
+    <WorkspaceLifecycleToolCall
+      args={{
+        action: "archive",
+        targets: [
+          { workspaceId: "feature-billing-webhooks-experiment-very-long-id-001" },
+          { workspaceId: "4a92f76fbf" },
+        ],
+      }}
+      status="completed"
+      defaultExpanded
+      result={{
+        results: [
+          {
+            status: "requires_confirmation",
+            action: "archive",
+            workspaceId: "feature-billing-webhooks-experiment-very-long-id-001",
+            paths: [
+              "packages/server/src/very/deeply/nested/path/to/an/untracked/file/that/is/quite/long/scratch.local.ts",
+              ".env.local",
+            ],
+          },
+          {
+            status: "active",
+            action: "archive",
+            workspaceId: "4a92f76fbf",
+            activeTaskIds: ["wst_4a92f76fbf01"],
+          },
+        ],
+      }}
+    />
+  </Shell>
+);
+
+export const Executing = () => (
+  <Shell>
+    <WorkspaceLifecycleToolCall
+      args={{
+        action: "remove",
+        targets: [{ workspaceId: "24e33167af" }, { workspaceId: "4a92f76fbf" }],
+      }}
+      status="executing"
+      defaultExpanded
+    />
+  </Shell>
+);
+
+export const ErrorResult = () => (
+  <Shell>
+    <WorkspaceLifecycleToolCall
+      args={{ action: "remove", targets: [{ workspaceId: "24e33167af" }] }}
+      status="failed"
+      defaultExpanded
+      result={{
+        success: false,
+        error: "task_workspace_lifecycle requires an orchestrator workspace context.",
+      }}
+    />
+  </Shell>
+);
+
+export const InvalidScope = () => (
+  <Shell>
+    <WorkspaceLifecycleToolCall
+      args={{ action: "remove", targets: [{ taskId: "wst_notmine00" }] }}
+      status="completed"
+      defaultExpanded
+      result={{
+        results: [{ status: "invalid_scope", action: "remove", taskId: "wst_notmine00" }],
+      }}
+    />
+  </Shell>
+);


### PR DESCRIPTION
## Summary

Adds the design-sync state that registers `WorkspaceLifecycleToolCall` as a curated component
in the **Mux Design System** (claude.ai/design), so future `/design-sync` runs reuse it
incrementally. The component itself shipped in #3638; this PR is the `.design-sync/` bookkeeping
(it has already been uploaded to the design system).

## Background

The Mux Design System mirrors `src/browser`'s storied components to claude.ai/design, where the
design agent builds with the real compiled components. When a new transcript card lands it has to
be added to the curated sync set — mirroring `chore(design-sync): sync HeartbeatToolCall` (#3636).

## Implementation

- **`config.json`** — `titleMap` entry (`WorkspaceLifecycle` → `WorkspaceLifecycleToolCall`) and an
  `overrides` entry with `cardMode: "column"` (the `BlockedNeedsAction` story renders at a pinned
  375px, narrower than a grid cell, so column keeps all stories full-width).
- **`ds-barrel.ts`** — the `WorkspaceLifecycleToolCall` export (what `gen-barrel.mjs` emits; the
  component lives on `window.Mux` for the isolated previews).
- **`previews/WorkspaceLifecycleToolCall.tsx`** — hand-authored isolated preview, one cell per story
  (all 8 states), `MuxPreviewShell` + inline props — the stories import the whole app graph, so the
  preview is authored like the other tool cards.
- **`NOTES.md`** — re-sync watch-items and the card-viewport learning (below).

## Validation

All 35 components verified through the `/design-sync` driver: `WorkspaceLifecycleToolCall` graded
`match` against its Storybook render for every captured story, the other 34 carried forward, the
bundle stayed under the 5 MB cap, and `package-validate` exited clean. The conventions header still
validates against the build.

## Notes

Recorded a deliberate decision in `NOTES.md`: tall cards keep the **default `900x700`** viewport —
the gallery already hover-scrolls content below the ~500px fold, so a tall card's full content is
reachable by scrolling. Bumping `cfg.overrides.<Name>.viewport` to fit the content was tried and
**reverted**, because the gallery scales the whole oversized card down to fit its column (tiny /
zoomed-out, worse than the scroll).

## Risks

None to the app — this PR only touches `.design-sync/` tooling state (no `src/` changes).
