### PR TITLE
🤖 feat: open workflow child workspaces

### DIFF
--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
@@ -100,6 +100,7 @@ function makeRunningStepView(taskId: string): WorkflowRunView {
           {
             stepId: "implement",
             taskId,
+            taskWorkspaceId: taskId,
             status: "running",
             title: "Implement #160",
             phaseName: "implementation",
@@ -137,6 +138,7 @@ function makeCompletedStepView(taskId: string): WorkflowRunView {
           {
             stepId: "review",
             taskId,
+            taskWorkspaceId: taskId,
             status: "completed",
             title: "Review implementation",
             phaseName: "review",
@@ -204,6 +206,21 @@ describe("WorkflowTimeline", () => {
 
   test("hides child task workspace action when workspace metadata is missing", () => {
     const view = render(<WorkflowTimeline view={makeRunningStepView("task_deleted")} />);
+
+    fireEvent.click(view.getByRole("button", { name: "Implementation 0/1" }));
+
+    expect(
+      view.queryByRole("button", { name: "Open workspace for workflow step Implement #160" })
+    ).toBeNull();
+  });
+
+  test("hides workspace action when a step only references another task id", () => {
+    syncWorkflowTaskWorkspaces(
+      new Map([["task_source", createWorkflowTaskWorkspaceMetadata("task_source")]])
+    );
+    const workflowView = makeRunningStepView("task_source");
+    delete workflowView.phases[0].steps[0].taskWorkspaceId;
+    const view = render(<WorkflowTimeline view={workflowView} />);
 
     fireEvent.click(view.getByRole("button", { name: "Implementation 0/1" }));
 

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 
 import { installDom } from "../../../../../tests/ui/dom";
 void mock.module("@/browser/features/Tools/WorkflowToolShared", () => ({
@@ -10,6 +13,19 @@ void mock.module("@/browser/features/Tools/WorkflowToolShared", () => ({
 
 import type { WorkflowRunView } from "./projectWorkflowRun";
 import { WorkflowTimeline } from "./WorkflowTimeline";
+
+function createWorkflowTaskWorkspaceMetadata(workspaceId: string): FrontendWorkspaceMetadata {
+  return {
+    id: workspaceId,
+    name: workspaceId,
+    title: workspaceId,
+    projectPath: "/repo",
+    projectName: "repo",
+    namedWorkspacePath: `/repo/${workspaceId}`,
+    createdAt: "2026-05-29T00:00:00.000Z",
+    runtimeConfig: { type: "local", srcBaseDir: "/tmp/mux-src" },
+  };
+}
 
 function normalizeText(element: Element): string {
   return element.textContent?.replace(/\s+/g, " ").trim() ?? "";
@@ -50,6 +66,86 @@ function makeCompletedView(): WorkflowRunView {
   };
 }
 
+function makeRunningStepView(taskId: string): WorkflowRunView {
+  const timestamp = "2026-06-25T12:00:00.000Z";
+  return {
+    ...makeCompletedView(),
+    status: "running",
+    phases: [
+      {
+        name: "implementation",
+        label: "Implementation",
+        steps: [
+          {
+            stepId: "implement",
+            taskId,
+            status: "running",
+            title: "Implement #160",
+            phaseName: "implementation",
+            startedAt: timestamp,
+          },
+        ],
+        done: 0,
+        total: 1,
+        running: true,
+        failed: false,
+      },
+    ],
+    steps: [],
+    result: null,
+    stats: {
+      total: 1,
+      done: 0,
+      running: 1,
+      failed: 0,
+      elapsedMs: 0,
+    },
+  };
+}
+
+function makeCompletedStepView(taskId: string): WorkflowRunView {
+  const startedAt = "2026-06-25T12:00:00.000Z";
+  const completedAt = "2026-06-25T12:00:02.000Z";
+  return {
+    ...makeCompletedView(),
+    phases: [
+      {
+        name: "review",
+        label: "Review",
+        steps: [
+          {
+            stepId: "review",
+            taskId,
+            status: "completed",
+            title: "Review implementation",
+            phaseName: "review",
+            startedAt,
+            completedAt,
+            durationMs: 2000,
+            result: {
+              title: "Review result",
+              reportMarkdown: "Completed step report body.",
+            },
+          },
+        ],
+        done: 1,
+        total: 1,
+        running: false,
+        failed: false,
+      },
+    ],
+    steps: [],
+    result: null,
+    stats: {
+      total: 1,
+      done: 1,
+      running: 0,
+      failed: 0,
+      elapsedMs: 2000,
+    },
+  };
+}
+
 describe("WorkflowTimeline", () => {
   let cleanupDom: (() => void) | null = null;
 
@@ -58,9 +154,65 @@ describe("WorkflowTimeline", () => {
   });
 
   afterEach(() => {
+    useWorkspaceStoreRaw().setNavigateToWorkspace(() => undefined);
+    useWorkspaceStoreRaw().syncWorkspaces(new Map());
     cleanup();
     cleanupDom?.();
     cleanupDom = null;
+  });
+
+  test("opens an available child task workspace from a workflow step", () => {
+    const navigatedTo: string[] = [];
+    useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
+      navigatedTo.push(workspaceId);
+    });
+    useWorkspaceStoreRaw().syncWorkspaces(
+      new Map([["task_live", createWorkflowTaskWorkspaceMetadata("task_live")]])
+    );
+
+    const view = render(<WorkflowTimeline view={makeRunningStepView("task_live")} />);
+
+    fireEvent.click(view.getByRole("button", { name: "Implementation 0/1" }));
+    fireEvent.click(
+      view.getByRole("button", { name: "Open workspace for workflow step Implement #160" })
+    );
+
+    expect(navigatedTo).toEqual(["task_live"]);
+  });
+
+  test("hides child task workspace action when workspace metadata is missing", () => {
+    const view = render(<WorkflowTimeline view={makeRunningStepView("task_deleted")} />);
+
+    fireEvent.click(view.getByRole("button", { name: "Implementation 0/1" }));
+
+    expect(
+      view.queryByRole("button", { name: "Open workspace for workflow step Implement #160" })
+    ).toBeNull();
+  });
+
+  test("opens completed step details independently from workspace navigation", () => {
+    const navigatedTo: string[] = [];
+    useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
+      navigatedTo.push(workspaceId);
+    });
+    useWorkspaceStoreRaw().syncWorkspaces(
+      new Map([["task_completed", createWorkflowTaskWorkspaceMetadata("task_completed")]])
+    );
+    const view = render(<WorkflowTimeline view={makeCompletedStepView("task_completed")} />);
+
+    fireEvent.click(view.getByRole("button", { name: "Review 1/1" }));
+    expect(view.queryByText("Completed step report body.")).toBeNull();
+
+    fireEvent.click(
+      view.getByRole("button", { name: "Open workspace for workflow step Review implementation" })
+    );
+
+    expect(navigatedTo).toEqual(["task_completed"]);
+    expect(view.queryByText("Completed step report body.")).toBeNull();
+
+    fireEvent.click(view.getByRole("button", { name: "Review implementation 2s" }));
+
+    expect(view.getByText("Completed step report body.")).toBeDefined();
   });
 
   test("renders final report stat chips as bold key before value", () => {

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 
 import { installDom } from "../../../../../tests/ui/dom";
@@ -9,6 +8,21 @@ void mock.module("@/browser/features/Tools/WorkflowToolShared", () => ({
   WorkflowJsonBlock: (props: { value: unknown; ariaLabel: string }) => (
     <pre aria-label={props.ariaLabel}>{JSON.stringify(props.value)}</pre>
   ),
+}));
+
+let workflowTaskWorkspaces = new Map<string, FrontendWorkspaceMetadata>();
+let navigateToWorkspace: (workspaceId: string) => void = () => undefined;
+const workspaceStoreSubscribers = new Set<() => void>();
+
+void mock.module("@/browser/stores/WorkspaceStore", () => ({
+  useWorkspaceStoreRaw: () => ({
+    subscribeDerived: (listener: () => void) => {
+      workspaceStoreSubscribers.add(listener);
+      return () => workspaceStoreSubscribers.delete(listener);
+    },
+    getWorkspaceMetadata: (workspaceId: string) => workflowTaskWorkspaces.get(workspaceId),
+    navigateToWorkspace: (workspaceId: string) => navigateToWorkspace(workspaceId),
+  }),
 }));
 
 import type { WorkflowRunView } from "./projectWorkflowRun";
@@ -25,6 +39,13 @@ function createWorkflowTaskWorkspaceMetadata(workspaceId: string): FrontendWorks
     createdAt: "2026-05-29T00:00:00.000Z",
     runtimeConfig: { type: "local", srcBaseDir: "/tmp/mux-src" },
   };
+}
+
+function syncWorkflowTaskWorkspaces(nextWorkspaces: Map<string, FrontendWorkspaceMetadata>): void {
+  workflowTaskWorkspaces = nextWorkspaces;
+  for (const subscriber of workspaceStoreSubscribers) {
+    subscriber();
+  }
 }
 
 function normalizeText(element: Element): string {
@@ -154,19 +175,20 @@ describe("WorkflowTimeline", () => {
   });
 
   afterEach(() => {
-    useWorkspaceStoreRaw().setNavigateToWorkspace(() => undefined);
-    useWorkspaceStoreRaw().syncWorkspaces(new Map());
     cleanup();
+    navigateToWorkspace = () => undefined;
+    syncWorkflowTaskWorkspaces(new Map());
+    workspaceStoreSubscribers.clear();
     cleanupDom?.();
     cleanupDom = null;
   });
 
   test("opens an available child task workspace from a workflow step", () => {
     const navigatedTo: string[] = [];
-    useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
+    navigateToWorkspace = (workspaceId) => {
       navigatedTo.push(workspaceId);
-    });
-    useWorkspaceStoreRaw().syncWorkspaces(
+    };
+    syncWorkflowTaskWorkspaces(
       new Map([["task_live", createWorkflowTaskWorkspaceMetadata("task_live")]])
     );
 
@@ -192,10 +214,10 @@ describe("WorkflowTimeline", () => {
 
   test("opens completed step details independently from workspace navigation", () => {
     const navigatedTo: string[] = [];
-    useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {
+    navigateToWorkspace = (workspaceId) => {
       navigatedTo.push(workspaceId);
-    });
-    useWorkspaceStoreRaw().syncWorkspaces(
+    };
+    syncWorkflowTaskWorkspaces(
       new Map([["task_completed", createWorkflowTaskWorkspaceMetadata("task_completed")]])
     );
     const view = render(<WorkflowTimeline view={makeCompletedStepView("task_completed")} />);

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
@@ -88,14 +88,14 @@ const WorkflowStepRow: React.FC<{ step: WorkflowStepView; isLast: boolean }> = (
     step.result?.structuredOutput !== undefined
   );
   const workspaceStore = useWorkspaceStoreRaw();
-  const taskWorkspaceAvailable = useWorkflowTaskWorkspaceAvailable(step.taskId);
-  const canOpenWorkspace = step.taskId != null && taskWorkspaceAvailable;
+  const taskWorkspaceAvailable = useWorkflowTaskWorkspaceAvailable(step.taskWorkspaceId);
+  const canOpenWorkspace = step.taskWorkspaceId != null && taskWorkspaceAvailable;
   const openTaskWorkspace = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    if (step.taskId == null) {
+    if (step.taskWorkspaceId == null) {
       return;
     }
-    workspaceStore.navigateToWorkspace(step.taskId);
+    workspaceStore.navigateToWorkspace(step.taskWorkspaceId);
   };
   const headerContent = (
     <>

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
@@ -16,6 +16,7 @@ import {
 
 import { MarkdownRenderer } from "@/browser/features/Messages/MarkdownRenderer";
 import { WorkflowJsonBlock } from "@/browser/features/Tools/WorkflowToolShared";
+import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
 
 import { WorkflowLiveDot } from "./WorkflowBadges";
 import type { WorkflowPhaseView, WorkflowRunView, WorkflowStepView } from "./projectWorkflowRun";
@@ -66,6 +67,15 @@ function useDisclosureOpenOnFailure(
   return [open, setOpen] as const;
 }
 
+function useWorkflowTaskWorkspaceAvailable(taskId: string | undefined): boolean {
+  const workspaceStore = useWorkspaceStoreRaw();
+  return React.useSyncExternalStore(
+    workspaceStore.subscribeDerived,
+    () => taskId != null && workspaceStore.getWorkspaceMetadata(taskId) != null,
+    () => false
+  );
+}
+
 const WorkflowStepRow: React.FC<{ step: WorkflowStepView; isLast: boolean }> = (props) => {
   const step = props.step;
   const expandable = step.status === "completed" || step.status === "failed";
@@ -76,6 +86,40 @@ const WorkflowStepRow: React.FC<{ step: WorkflowStepView; isLast: boolean }> = (
   const showReport = hasDisplayableWorkflowReport(
     step.result?.reportMarkdown,
     step.result?.structuredOutput !== undefined
+  );
+  const workspaceStore = useWorkspaceStoreRaw();
+  const taskWorkspaceAvailable = useWorkflowTaskWorkspaceAvailable(step.taskId);
+  const canOpenWorkspace = step.taskId != null && taskWorkspaceAvailable;
+  const openTaskWorkspace = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (step.taskId == null) {
+      return;
+    }
+    workspaceStore.navigateToWorkspace(step.taskId);
+  };
+  const headerContent = (
+    <>
+      <span className="text-foreground min-w-0 flex-1 truncate text-[13px]">{step.title}</span>
+      {step.status === "completed" && step.durationMs != null && (
+        <span className="text-muted shrink-0 text-[11px] tabular-nums">
+          {formatWorkflowDuration(step.durationMs)}
+        </span>
+      )}
+      {step.status === "running" && (
+        <span className="text-accent shrink-0 text-[11px]">running…</span>
+      )}
+      {step.status === "failed" && (
+        <span className="shrink-0 text-[11px]" style={{ color }}>
+          failed
+        </span>
+      )}
+      {expandable &&
+        (open ? (
+          <ChevronDown className="text-muted h-3 w-3 shrink-0" />
+        ) : (
+          <ChevronRight className="text-muted h-3 w-3 shrink-0" />
+        ))}
+    </>
   );
 
   return (
@@ -90,34 +134,32 @@ const WorkflowStepRow: React.FC<{ step: WorkflowStepView; isLast: boolean }> = (
         {!props.isLast && <span className="bg-border w-px flex-1" />}
       </div>
       <div className="min-w-0 flex-1 pt-0.5 pb-2">
-        <button
-          type="button"
-          disabled={!expandable}
-          onClick={() => setOpen((value) => !value)}
-          className="enabled:hover:bg-surface-secondary flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left disabled:cursor-default"
-          aria-expanded={expandable ? open : undefined}
-        >
-          <span className="text-foreground min-w-0 flex-1 truncate text-[13px]">{step.title}</span>
-          {step.status === "completed" && step.durationMs != null && (
-            <span className="text-muted shrink-0 text-[11px] tabular-nums">
-              {formatWorkflowDuration(step.durationMs)}
-            </span>
+        <div className="flex min-w-0 items-center gap-1">
+          {expandable ? (
+            <button
+              type="button"
+              onClick={() => setOpen((value) => !value)}
+              className="hover:bg-surface-secondary flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left"
+              aria-expanded={open}
+            >
+              {headerContent}
+            </button>
+          ) : (
+            <div className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left">
+              {headerContent}
+            </div>
           )}
-          {step.status === "running" && (
-            <span className="text-accent shrink-0 text-[11px]">running…</span>
+          {canOpenWorkspace && (
+            <button
+              type="button"
+              aria-label={`Open workspace for workflow step ${step.title}`}
+              onClick={openTaskWorkspace}
+              className="border-border bg-surface-primary text-content-secondary hover:bg-surface-secondary shrink-0 rounded-md border px-2 py-1 text-[11px] font-medium"
+            >
+              Open
+            </button>
           )}
-          {step.status === "failed" && (
-            <span className="shrink-0 text-[11px]" style={{ color }}>
-              failed
-            </span>
-          )}
-          {expandable &&
-            (open ? (
-              <ChevronDown className="text-muted h-3 w-3 shrink-0" />
-            ) : (
-              <ChevronRight className="text-muted h-3 w-3 shrink-0" />
-            ))}
-        </button>
+        </div>
 
         {open && expandable && (
           <div className="border-border bg-surface-primary mx-2 mb-1.5 rounded-lg border p-3">

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
@@ -237,6 +237,13 @@ describe("projectWorkflowRun — phase grouping & step folding", () => {
     expect(view.steps.find((step) => step.stepId === "fetch-1a")?.title).toBe("Fetch: arxiv.org");
   });
 
+  test("exposes direct task event workspaces for row navigation", () => {
+    const verify2 = view.steps.find((step) => step.stepId === "verify-2");
+
+    expect(verify2?.taskId).toBe("ws-verify-2");
+    expect(verify2?.taskWorkspaceId).toBe("ws-verify-2");
+  });
+
   test("aggregates run stats and arg entries", () => {
     expect(view.stats).toMatchObject({ total: 5, done: 4, running: 1, failed: 0 });
     expect(view.stats.elapsedMs).toBe(74_000);
@@ -315,6 +322,7 @@ describe("projectWorkflowRun — non-task step events", () => {
         stepId: "patch-1",
         inputHash: "h",
         status: "completed",
+        taskId: "ws-src",
         startedAt: at(1),
         completedAt: at(4),
       },
@@ -328,6 +336,11 @@ describe("projectWorkflowRun — non-task step events", () => {
     expect(view.steps.find((step) => step.stepId === "wf-1")?.phaseName).toBe("delegate");
     // Nested-workflow steps take their title from the child workflow name.
     expect(view.steps.find((step) => step.stepId === "wf-1")?.title).toBe("deep-research");
+    // Patch steps may store the source task id for persistence/usage, but only direct task
+    // events represent a child workspace created by that row.
+    const patchStep = view.steps.find((step) => step.stepId === "patch-1");
+    expect(patchStep?.taskId).toBe("ws-src");
+    expect(patchStep?.taskWorkspaceId).toBeUndefined();
     // Nothing falls into the implicit ungrouped bucket.
     expect(view.phases.some((phase) => phase.name === "")).toBe(false);
   });

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
@@ -244,6 +244,54 @@ describe("projectWorkflowRun — phase grouping & step folding", () => {
     expect(verify2?.taskWorkspaceId).toBe("ws-verify-2");
   });
 
+  test("uses the current retried task id for row navigation", () => {
+    const events: WorkflowRunEvent[] = [
+      { sequence: 1, type: "phase", at: at(1), name: "Verify" },
+      {
+        sequence: 2,
+        type: "task",
+        at: at(1),
+        stepId: "verify",
+        taskId: "ws-verify-old",
+        status: "started",
+        title: "Verify claim",
+      },
+      {
+        sequence: 3,
+        type: "task",
+        at: at(5),
+        stepId: "verify",
+        taskId: "ws-verify-old",
+        status: "failed",
+        title: "Verify claim",
+      },
+      {
+        sequence: 4,
+        type: "task",
+        at: at(8),
+        stepId: "verify",
+        taskId: "ws-verify-new",
+        status: "started",
+        title: "Verify claim",
+      },
+    ];
+    const steps: WorkflowStepRecord[] = [
+      {
+        stepId: "verify",
+        inputHash: "h-new",
+        status: "started",
+        taskId: "ws-verify-new",
+        startedAt: at(8),
+      },
+    ];
+
+    const view = projectWorkflowRun(makeRun({ events, steps }));
+
+    const verify = view.steps.find((step) => step.stepId === "verify");
+    expect(verify?.taskId).toBe("ws-verify-new");
+    expect(verify?.taskWorkspaceId).toBe("ws-verify-new");
+  });
+
   test("aggregates run stats and arg entries", () => {
     expect(view.stats).toMatchObject({ total: 5, done: 4, running: 1, failed: 0 });
     expect(view.stats.elapsedMs).toBe(74_000);

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
@@ -11,8 +11,9 @@
  *   - the step title comes from its `task` event (falling back to the step's
  *     result title, then the stepId);
  *   - duration is derived from the step timestamps;
- *   - per-step token/cost usage is an optional overlay (a step's `taskId` is
- *     the child task workspace id, so the caller can resolve usage by task id).
+ *   - per-step token/cost usage is an optional overlay keyed by the persisted
+ *     step `taskId`. UI navigation uses `taskWorkspaceId`, which is present only
+ *     for direct agent-task events so patch rows do not link to their source task.
  *
  * Keeping this pure (no React, no IPC) makes the non-trivial folding logic unit
  * testable and keeps the components dumb.
@@ -37,8 +38,10 @@ export interface WorkflowStepUsage {
 
 export interface WorkflowStepView {
   stepId: string;
-  /** Child task workspace id, when the step spawned a sub-agent. */
+  /** Persisted task id associated with the step; patch steps may reference their source task. */
   taskId?: string;
+  /** Child workspace id created by this step's direct agent task event. */
+  taskWorkspaceId?: string;
   status: WorkflowStepDisplayStatus;
   /** Human title (task title or nested-workflow name → step result title → stepId). */
   title: string;
@@ -108,7 +111,7 @@ export interface WorkflowRunView {
 }
 
 export interface ProjectWorkflowRunOptions {
-  /** Per-task usage keyed by the step's `taskId` (child task workspace id). */
+  /** Per-task usage keyed by the persisted step `taskId`. */
   usageByTaskId?: ReadonlyMap<string, WorkflowStepUsage>;
 }
 
@@ -238,6 +241,7 @@ export function projectWorkflowRun(
   // the ungrouped bucket even when a phase was active.
   const stepFirstEventSeq = new Map<string, number>();
   const stepTitle = new Map<string, string>();
+  const stepTaskWorkspaceId = new Map<string, string>();
   for (const event of events) {
     const stepId = stepBearingEventStepId(event);
     if (stepId == null) {
@@ -245,6 +249,9 @@ export function projectWorkflowRun(
     }
     if (!stepFirstEventSeq.has(stepId)) {
       stepFirstEventSeq.set(stepId, event.sequence);
+    }
+    if (event.type === "task" && !stepTaskWorkspaceId.has(stepId)) {
+      stepTaskWorkspaceId.set(stepId, event.taskId);
     }
     if (!stepTitle.has(stepId)) {
       if (event.type === "task" && event.title != null && event.title.length > 0) {
@@ -282,6 +289,7 @@ export function projectWorkflowRun(
     return {
       stepId: step.stepId,
       taskId: step.taskId,
+      taskWorkspaceId: stepTaskWorkspaceId.get(step.stepId),
       status: STEP_STATUS_TO_DISPLAY[step.status],
       title: stepTitle.get(step.stepId) ?? step.result?.title ?? step.stepId,
       phaseName,

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
@@ -241,7 +241,7 @@ export function projectWorkflowRun(
   // the ungrouped bucket even when a phase was active.
   const stepFirstEventSeq = new Map<string, number>();
   const stepTitle = new Map<string, string>();
-  const stepTaskWorkspaceId = new Map<string, string>();
+  const stepTaskEventIds = new Map<string, Set<string>>();
   for (const event of events) {
     const stepId = stepBearingEventStepId(event);
     if (stepId == null) {
@@ -250,8 +250,13 @@ export function projectWorkflowRun(
     if (!stepFirstEventSeq.has(stepId)) {
       stepFirstEventSeq.set(stepId, event.sequence);
     }
-    if (event.type === "task" && !stepTaskWorkspaceId.has(stepId)) {
-      stepTaskWorkspaceId.set(stepId, event.taskId);
+    if (event.type === "task") {
+      const taskEventIds = stepTaskEventIds.get(stepId);
+      if (taskEventIds != null) {
+        taskEventIds.add(event.taskId);
+      } else {
+        stepTaskEventIds.set(stepId, new Set([event.taskId]));
+      }
     }
     if (!stepTitle.has(stepId)) {
       if (event.type === "task" && event.title != null && event.title.length > 0) {
@@ -286,10 +291,14 @@ export function projectWorkflowRun(
         ? Math.max(0, parseTime(step.completedAt) - parseTime(step.startedAt))
         : undefined;
     const usage = step.taskId != null ? usageByTaskId?.get(step.taskId) : undefined;
+    const taskWorkspaceId =
+      step.taskId != null && stepTaskEventIds.get(step.stepId)?.has(step.taskId) === true
+        ? step.taskId
+        : undefined;
     return {
       stepId: step.stepId,
       taskId: step.taskId,
-      taskWorkspaceId: stepTaskWorkspaceId.get(step.stepId),
+      taskWorkspaceId,
       status: STEP_STATUS_TO_DISPLAY[step.status],
       title: stepTitle.get(step.stepId) ?? step.result?.title ?? step.stepId,
       phaseName,


### PR DESCRIPTION
## Summary

Adds a row-level **Open** action to workflow steps in the right-sidebar Workflows tab when the step has an available child task workspace. The action uses the existing workspace navigation path so users can jump directly from the workflow timeline to the child/sub-agent workspace.

## Background

Workflow steps already carry `taskId` values for child task workspaces, but the Workflows tab only displayed those IDs in details. Users had to find the corresponding workspace manually in the left sidebar.

## Implementation

- Subscribes to workspace metadata from the Workflows timeline so stale/deleted child workspace links are hidden.
- Splits step-row chrome into a disclosure/title area plus a sibling **Open** button, avoiding nested interactive elements.
- Keeps completed/failed step disclosure behavior independent from child-workspace navigation.

## Validation

- `bun test src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx`
- `bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`

## Dogfooding

Dogfooded in an isolated dev-server sandbox with a seeded workflow run and child workspace. Captured evidence locally under `dogfood-output/workflow-open-link/`:

- `screenshots/initial-workflows-tab.png`
- `screenshots/before-open-click.png`
- `screenshots/after-open-click.png`
- `screenshots/narrow-sidebar.png`
- `videos/open-child-workspace.webm`

## Risks

Low. This is UI-only, gates the new action on existing workspace metadata, and keeps disclosure/navigation controls as separate buttons to avoid invalid nested markup.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan: Open workflow child workspaces from the right sidebar

## Goal

Add a direct navigation affordance in the **right sidebar → Workflows** tab so a user can click a running workflow step and jump straight to the corresponding child/sub-agent workspace, instead of locating that workspace manually in the left sidebar.

The desired behavior is intentionally narrow: when a workflow step has a live child task workspace, the Workflows tab should expose an accessible click target that calls the existing workspace navigation mechanism.

## Current evidence

Verified repository facts:

- `src/browser/features/RightSidebar/Workflows/WorkflowsTab.tsx` renders the focused workflow run and passes its projected view model to `WorkflowTimeline`.
- `src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx` renders the phase/step stream. `WorkflowStepRow` is the correct UI seam for per-step actions.
- `src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts` already exposes `WorkflowStepView.taskId?: string`; comments identify this as the child task workspace id.
- `src/common/orpc/schemas/workflow.ts` already persists `WorkflowStepRecordSchema.taskId?: string`; no schema or backend persistence change is needed.
- `src/node/services/workflows/WorkflowTaskServiceAdapter.ts` records created child task ids into workflow lifecycle callbacks; those task ids are already available in workflow step records.
- `src/browser/App.tsx` wires `workspaceStore.setNavigateToWorkspace(...)` to `setSelectedWorkspace(...)`, so `workspaceStore.navigateToWorkspace(taskId)` is the existing app-wide navigation path.
- `src/browser/features/Tools/WorkflowRunToolCall.tsx` already implements a similar chat-card affordance using:
  - `useWorkspaceStoreRaw()`
  - `useSyncExternalStore(workspaceStore.subscribeDerived, ...)`
  - `workspaceStore.getWorkspaceMetadata(taskId) != null` for availability
  - `workspaceStore.navigateToWorkspace(taskId)` for navigation
- Existing tests in `src/browser/features/Tools/WorkflowRunToolCall.test.tsx` cover that pattern and can guide the Workflows-tab tests.

<details>
<summary>Explore sub-agent confirmation</summary>

A read-only Explore sub-agent confirmed the same implementation seam:

- Target `WorkflowStepRow` in `src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx`.
- No backend/schema changes are required because `WorkflowStepRecordSchema.taskId` and `WorkflowStepView.taskId` already exist.
- Match the existing tool-card availability/navigation pattern from `WorkflowRunToolCall.tsx`.
- Main pitfalls are valid HTML/accessibility around nested buttons and preserving narrow-sidebar layout behavior.

</details>

## Recommended approach — UI-only Workflows-tab action

**Difficulty:** Low.

**Estimated effort:** 1–2 hours implementation + targeted tests; add time for manual dogfooding evidence.

**Net product LoC estimate:** approximately **+35 to +70 product LoC**.

**Files likely touched:**

- `src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx`
- `src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx`

Optional but likely useful:

- `src/browser/features/Tools/WorkflowRunToolCall.tsx` only if extracting/reusing its availability helper.
- A small shared helper file only if duplication would otherwise become meaningful; avoid this unless it keeps the change simpler.

### Why this approach

This is the smallest change that satisfies the user request:

- It uses data already present in the workflow run view model.
- It uses an existing, proven navigation path.
- It avoids backend migrations, ORPC schema updates, workflow runtime changes, or persistent data changes.
- It can be tested in happy-dom with the existing store and testing-library setup.

## Alternative approaches considered

### Alternative A: Add navigation only for currently running steps

**Net product LoC estimate:** approximately **+25 to +50 product LoC**.

This is slightly smaller, because running steps are the primary user need and do not need completed-step detail-card handling.

Tradeoff: users often inspect completed/failed child workspaces after a workflow step finishes. Hiding the action after completion would make the affordance feel inconsistent, especially if the child workspace still exists.

**Recommendation:** Do not choose this unless we want the narrowest possible first iteration.

### Alternative B: Add backend-derived workspace metadata to workflow records

**Net product LoC estimate:** approximately **+120 to +250 product LoC**.

This would enrich workflow run records or API responses with child workspace metadata/availability.

Tradeoff: unnecessary complexity. The frontend already has the workspace registry and can cheaply check availability by task id. Backend enrichment risks duplicating workspace state and complicating replay/history behavior.

**Recommendation:** Do not choose this.

## Detailed implementation steps

### Phase 1 — Add a workspace availability/navigation helper

1. In `WorkflowTimeline.tsx`, import:
   - `useSyncExternalStore` from React, or continue using `React.useSyncExternalStore` if keeping the current import style.
   - `useWorkspaceStoreRaw` from `@/browser/stores/WorkspaceStore`.
   - Optionally `WORKFLOW_ACTION_BUTTON_CLASS` from `@/browser/features/Tools/WorkflowToolShared` if its style is acceptable outside tool cards.

2. Add a small local helper near `WorkflowStepRow`:

   ```ts
   function useWorkflowTaskWorkspaceAvailable(taskId: string | undefined): boolean {
     const workspaceStore = useWorkspaceStoreRaw();
     return React.useSyncExternalStore(
       workspaceStore.subscribeDerived,
       () => taskId != null && workspaceStore.getWorkspaceMetadata(taskId) != null,
       () => false
     );
   }
   ```

   Notes:
   - Accepting `string | undefined` keeps callsites simple and avoids conditional hooks.
   - This should remain a local helper unless another Workflows component needs it. The chat-card implementation can remain unchanged to avoid broadening the diff.
   - The `getWorkspaceMetadata` check intentionally hides stale links when workflow history outlives deleted or archived child workspaces.

3. In `WorkflowStepRow`, retrieve:

   ```ts
   const workspaceStore = useWorkspaceStoreRaw();
   const taskWorkspaceAvailable = useWorkflowTaskWorkspaceAvailable(step.taskId);
   const canOpenWorkspace = step.taskId != null && taskWorkspaceAvailable;
   ```

4. Add a tiny navigation handler:

   ```ts
   const openTaskWorkspace = () => {
     if (step.taskId == null) {
       return;
     }
     workspaceStore.navigateToWorkspace(step.taskId);
   };
   ```

   Defensive note: the guard avoids relying on a stale closure if the row rerenders between availability and click.

### Phase 2 — Add the UI affordance without nesting buttons

`WorkflowStepRow` currently renders the step title row as a `<button>` even when disabled. Adding another button inside that button would be invalid HTML.

Implement one of these two valid layouts. Prefer Option 2 if it stays clean.

#### Option 1: Workspace action in the expanded detail card

- For completed/failed expandable rows, keep the current disclosure button untouched.
- In the detail-card metadata row where `task {step.taskId}` currently renders, replace it with:
  - a compact `Workspace` button if the task workspace exists;
  - the existing inert `task {step.taskId}` text if it does not.
- For running rows, add a compact `Open` button beside the `running…` status because running rows usually have no expanded detail card.

Pros:
- Smallest disruption to current layout.
- Avoids changing most disclosure markup.

Cons:
- Completed/failed workspace action is only visible after expansion.

#### Option 2: Split row chrome into disclosure area + action button

- Replace the current single header button with a grid/flex container:
  - disclosure/title/status button area for expandable rows;
  - non-button title/status area for non-expandable rows;
  - separate `Open`/`Workspace` button when `canOpenWorkspace` is true.
- Preserve the existing title truncation and status indicators.

Pros:
- Workspace action is consistently visible for running, completed, failed, and interrupted steps.
- Best matches the user's request to click directly from the sidebar.

Cons:
- Slightly larger JSX refactor.

**Recommended UI choice:** Option 2, unless the refactor becomes noisy. It gives the clearest UX: every live child workspace has one visible action in the step row.

### Phase 3 — Accessibility and interaction details

The new affordance should:

- Render as a real `<button type="button">`.
- Use an accessible label such as:
  - `Open workspace for workflow step ${step.title}`
  - Include `step.taskId` in the label if useful for disambiguation.
- Call `event.stopPropagation()` if placed near any disclosure click target.
- Not use native `title` attributes; if a tooltip is necessary, use the shared tooltip component. Prefer no tooltip for this minimal change.
- Preserve keyboard access:
  - Tab reaches the workspace button.
  - Enter/Space activates it through native button behavior.
  - Existing disclosure Enter/Space behavior still works.
- Avoid emoji. Use text-only (`Open` or `Workspace`) or an existing lucide icon if needed; text-only is preferable for clarity.
- Preserve narrow width behavior:
  - Keep step title in a `minmax(0, 1fr)`/`min-w-0` area with `truncate`.
  - Keep the action button `shrink-0` and short (`Open` likely better than `Workspace` for row-level UI).
  - Avoid `whitespace-nowrap` on long labels inside flexible cells.

Recommended visual copy:

- Row action: `Open`
- Accessible label: `Open workspace for workflow step ${step.title}`

### Phase 4 — Tests

Update `src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx`.

1. Add test setup utilities similar to `WorkflowRunToolCall.test.tsx`:
   - create fake `FrontendWorkspaceMetadata` for a child task workspace.
   - use `useWorkspaceStoreRaw().setNavigateToWorkspace(...)` to capture navigations.
   - use `useWorkspaceStoreRaw().syncWorkspaces(...)` to seed available workspaces.
   - reset navigation callback and workspace store in `afterEach` to avoid cross-test leakage.
   - if importing `WORKFLOW_ACTION_BUTTON_CLASS` from `WorkflowToolShared`, update the existing `WorkflowTimeline.test.tsx` mock for that module to export the constant; otherwise keep local classes to avoid test mock churn.

2. Add a test: **shows and activates workspace action for an available child task workspace**.
   - Render a `WorkflowRunView` with a phase containing a running step:
     - `stepId: "implement"`
     - `taskId: "task_live"`
     - `status: "running"`
     - `title: "Implement #160"`
   - Seed workspace metadata for `task_live`.
   - Find the action by role/name.
   - Click it.
   - Assert `navigatedTo` equals `["task_live"]`.

3. Add a test: **hides workspace action for missing/deleted child workspaces**.
   - Render a similar step with `taskId: "task_deleted"`.
   - Do not seed workspace metadata.
   - Assert no `Open workspace...` button is present.

4. Add a test or assertions to ensure disclosure still works for completed steps.
   - Render a completed step with result/report.
   - Verify the disclosure button still toggles expanded content.
   - If the completed step has an available workspace, verify clicking `Open` does not toggle disclosure.

5. Keep tests behavioral, not tautological.
   - Avoid asserting exact CSS class strings unless layout behavior depends on them.
   - Assert navigation behavior, availability gating, and disclosure separation.

Targeted test command:

```bash
bun test src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
```

### Phase 5 — Validation

Run, at minimum:

```bash
bun test src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
make typecheck
make lint
```

If the change imports from a shared tool component or affects test setup in a way that might impact workflow tool cards, also run:

```bash
bun test src/browser/features/Tools/WorkflowRunToolCall.test.tsx
```

If lint is memory-constrained in this workspace, use the known repo-safe variant:

```bash
MUX_ESLINT_CONCURRENCY=1 make lint
```

Do not claim completion until targeted tests and static checks pass, or report exact blockers.

## Dogfooding plan

Because this is frontend/workflow UX, manual dogfooding must include screenshots and a short screen recording. This plan incorporates the repo `dogfood`, `agent-browser`, and `dev-server-sandbox` skill guidance.

### Skill-derived dogfood constraints

- Use the direct `agent-browser` binary; do **not** use `npx agent-browser`.
- Before running browser automation commands, load the installed CLI’s current workflow guide:

  ```bash
  agent-browser skills get core
  ```

- Use an isolated dev-server sandbox for this repo when possible:

  ```bash
  make dev-server-sandbox
  ```

  The sandbox creates a temporary `MUX_ROOT`, seeds provider/project config when available, strips provider env vars that could shadow seeded config, picks free backend/Vite ports, disables tutorials by default, and sets `VITE_ALLOWED_HOSTS=all` for forwarded/proxied access.

- Keep dogfood artifacts under a dedicated directory, for example:

  ```bash
  mkdir -p dogfood-output/workflow-open-link/screenshots dogfood-output/workflow-open-link/videos
  ```

- Work forward: do not delete screenshots/videos/report artifacts mid-session.
- For interactive behavior, capture a video plus step screenshots. For static visible states, an annotated screenshot is enough.
- Use `snapshot -i` to find clickable elements, `screenshot --annotate` for visual evidence, and check `errors`/`console` during the session.

### Setup

1. Start an isolated Mux dev server in the background and capture the printed app URL/ports:

   ```bash
   make dev-server-sandbox
   ```

   If a clean sandbox is needed to avoid local provider/project state, use:

   ```bash
   make dev-server-sandbox DEV_SERVER_SANDBOX_ARGS="--clean-providers --clean-projects"
   ```

2. Open the app URL with a named browser session:

   ```bash
   agent-browser --session workflow-open-link open <APP_URL>
   agent-browser --session workflow-open-link wait --load networkidle
   agent-browser --session workflow-open-link snapshot -i
   ```

3. Launch or resume a workflow that spawns a child workspace. Good candidates:
   - `issue-implementation-loop`
   - a small local test workflow that calls `agent(...)`
   - any built-in/project workflow that produces a visible task step

4. Open the parent workspace while that workflow is running or while its child task workspace still exists.

### Manual checks with evidence

1. Capture the initial state:

   ```bash
   agent-browser --session workflow-open-link screenshot --annotate dogfood-output/workflow-open-link/screenshots/initial-workflows-tab.png
   agent-browser --session workflow-open-link errors
   agent-browser --session workflow-open-link console
   ```

2. Open **right sidebar → Workflows** and locate a child step in **Step stream**.
3. Verify an `Open` action appears on the step row when the child workspace exists.
4. Capture the pre-click state:

   ```bash
   agent-browser --session workflow-open-link screenshot --annotate dogfood-output/workflow-open-link/screenshots/before-open-click.png
   ```

5. Record the click-to-navigation flow at human-reviewable speed:

   ```bash
   agent-browser --session workflow-open-link record start dogfood-output/workflow-open-link/videos/open-child-workspace.webm
   # Use snapshot -i to identify the Open button ref, then click it.
   agent-browser --session workflow-open-link snapshot -i
   agent-browser --session workflow-open-link click <OPEN_BUTTON_REF>
   sleep 2
   agent-browser --session workflow-open-link screenshot --annotate dogfood-output/workflow-open-link/screenshots/after-open-click.png
   agent-browser --session workflow-open-link record stop
   ```

6. Verify the selected workspace changed to the child/sub-agent workspace without using the left sidebar.
7. Narrow the window/right sidebar enough to approximate a narrow container and verify:
   - step title truncates instead of overflowing;
   - `Open` remains reachable;
   - no right-edge overflow.
8. Capture narrow-layout evidence:

   ```bash
   agent-browser --session workflow-open-link screenshot --annotate dogfood-output/workflow-open-link/screenshots/narrow-sidebar.png
   ```

9. If feasible, archive/delete a child workspace or use a run whose child workspace no longer exists, then verify no stale `Open` action appears for that step.
10. Check browser errors/console again:

   ```bash
   agent-browser --session workflow-open-link errors
   agent-browser --session workflow-open-link console
   ```

11. Close the browser session when done:

   ```bash
   agent-browser --session workflow-open-link close
   ```

### Evidence to attach/report

- Targeted test output.
- Typecheck/lint output.
- `dogfood-output/workflow-open-link/screenshots/initial-workflows-tab.png`.
- `dogfood-output/workflow-open-link/screenshots/before-open-click.png`.
- `dogfood-output/workflow-open-link/screenshots/after-open-click.png`.
- `dogfood-output/workflow-open-link/screenshots/narrow-sidebar.png`.
- `dogfood-output/workflow-open-link/videos/open-child-workspace.webm`.
- Browser errors/console output summary.
- Note the workflow/run and child workspace used for manual verification.

## Risks and mitigations

### Risk: invalid nested interactive elements

Mitigation:
- Do not place a button inside the existing disclosure button.
- Use a row layout with separate sibling controls, or keep completed/failed actions inside expanded detail content.
- Add a test that clicking the workspace action does not toggle disclosure.

### Risk: stale workflow history links to deleted child workspaces

Mitigation:
- Gate the action on `workspaceStore.getWorkspaceMetadata(taskId) != null`, subscribed with `useSyncExternalStore`.
- Render no action when metadata is absent.

### Risk: right sidebar overflow at narrow widths

Mitigation:
- Preserve `min-w-0`, `flex-1`, and `truncate` around step titles.
- Keep the action text short (`Open`) and `shrink-0`.
- Dogfood with a narrow sidebar/window and capture evidence.

### Risk: duplicated helper logic with workflow tool cards

Mitigation:
- Start with a local helper in `WorkflowTimeline.tsx` to keep the diff small.
- Extract a shared helper only if the duplication becomes non-trivial or lint/type constraints make local implementation awkward.

### Risk: interrupted/failed/completed states differ in usefulness

Mitigation:
- Show the action for any step with an existing child workspace, regardless of step status.
- This is more consistent and helps inspect completed or failed sub-agent workspaces.

## Acceptance criteria

- A workflow step with an available `taskId` child workspace shows a visible row-level action in the Workflows tab.
- Clicking the action navigates to that child workspace using existing workspace navigation.
- Steps without `taskId` or without available workspace metadata do not show a stale action.
- Existing expand/collapse behavior for completed/failed steps still works.
- The new action is keyboard accessible and has a useful accessible name.
- No invalid nested button/interactive markup is introduced.
- Narrow-sidebar layout remains usable without right-edge overflow.
- Targeted workflow timeline tests pass.
- Typecheck and lint pass.
- Manual dogfooding produces before/after screenshots and a short recording.

## Advisor review

Advisor review status: **APPROVED**.

Advisor confidence notes incorporated into this plan:

- Treat the split row layout (Option 2) as the primary handoff so the action is visible and no nested buttons are introduced.
- For non-expandable rows, use a non-button wrapper rather than a disabled button when adjacent controls are present.
- If sharing/importing `WORKFLOW_ACTION_BUTTON_CLASS`, update the `WorkflowTimeline.test.tsx` module mock accordingly; otherwise use local classes for the smallest diff.
- Reset `workspaceStore.setNavigateToWorkspace` and `syncWorkspaces(new Map())` in test cleanup.
- Include a behavioral assertion that clicking `Open` on an expandable/completed row does not toggle disclosure.

### Skill-informed advisor follow-up

Advisor review status after reading `dogfood`, `agent-browser`, and `dev-server-sandbox`: **APPROVED**.

Advisor notes incorporated/confirmed:

- Run `make dev-server-sandbox` as a long-lived/background server and capture the printed app URL.
- Prefer seeded providers/projects by default; use `--clean-providers --clean-projects` only when a clean sandbox is more important than launching a real provider-backed workflow.
- A full dogfood report template is optional for this focused validation; screenshots, video, console/errors summary, and final evidence summary are sufficient unless explicitly requested.

## Rollback plan

If the UI causes layout or interaction regressions, revert only the `WorkflowTimeline.tsx` row-action changes and associated tests. Because no backend/schema/persistence changes are planned, rollback is low risk.

## Implementation order for an Exec agent

1. Add local workspace availability/navigation helper in `WorkflowTimeline.tsx`.
2. Refactor `WorkflowStepRow` row header just enough to add a sibling `Open` button without nesting buttons.
3. Preserve existing disclosure behavior and detail-card rendering.
4. Add/adjust `WorkflowTimeline.test.tsx` tests for availability, navigation, and disclosure separation.
5. Run targeted tests.
6. Run typecheck/lint.
7. Dogfood with a real workflow and collect screenshots/video evidence.
8. Report validation and evidence; do not open a PR unless explicitly asked.

</details>

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$48.62`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=48.62 -->
