### PR TITLE
🤖 fix: allow patch apply with unrelated dirty files

### DIFF
--- a/docs/hooks/tools.mdx
+++ b/docs/hooks/tools.mdx
@@ -674,7 +674,7 @@ If a value is too large for the environment, it may be omitted (not set). Mux al
 | ---------------------------------- | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `MUX_TOOL_INPUT_DRY_RUN`           | `dry_run`           | boolean | When true, attempt to apply the patch in a temporary git worktree and then discard it (does not modify the current workspace). |
 | `MUX_TOOL_INPUT_EXPECTED_HEAD_SHA` | `expected_head_sha` | string  | When provided, refuse to apply unless the target repository HEAD matches this SHA.                                             |
-| `MUX_TOOL_INPUT_FORCE`             | `force`             | boolean | When true, allow apply even if the patch was previously applied (and skip clean-tree checks).                                  |
+| `MUX_TOOL_INPUT_FORCE`             | `force`             | boolean | When true, allow apply even if the patch was previously applied.                                                               |
 | `MUX_TOOL_INPUT_PROJECT_PATH`      | `project_path`      | string  | When provided, apply only the patch artifact for this project path.                                                            |
 | `MUX_TOOL_INPUT_TASK_ID`           | `task_id`           | string  | Child task ID whose patch artifact should be applied                                                                           |
 | `MUX_TOOL_INPUT_THREE_WAY`         | `three_way`         | boolean | When true, run git am with --3way                                                                                              |

--- a/src/browser/features/Tools/TaskToolCall.stories.tsx
+++ b/src/browser/features/Tools/TaskToolCall.stories.tsx
@@ -184,8 +184,8 @@ export const TaskApplyGitPatchStates: Story = {
         result={{
           success: false,
           taskId: "task-fe-001",
-          error: "Working tree is not clean.",
-          note: "Commit/stash your changes (or pass force=true) before applying patches.",
+          error: "fatal: Dirty index: cannot apply patches (dirty: src/App.tsx)",
+          note: "git am failed before entering conflict-recovery state. Review the error output above and fix the patch/input before retrying.",
         }}
         status="completed"
       />

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -890,9 +890,7 @@ export const TaskApplyGitPatchToolArgsSchema = z
     force: z
       .boolean()
       .nullish()
-      .describe(
-        "When true, allow apply even if the patch was previously applied (and skip clean-tree checks)."
-      ),
+      .describe("When true, allow apply even if the patch was previously applied."),
   })
   .strict();
 

--- a/src/node/services/agentSkills/builtInSkillContent.generated.ts
+++ b/src/node/services/agentSkills/builtInSkillContent.generated.ts
@@ -5386,7 +5386,7 @@ export const BUILTIN_SKILL_FILES: Record<string, Record<string, string>> = {
       "| ---------------------------------- | ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |",
       "| `MUX_TOOL_INPUT_DRY_RUN`           | `dry_run`           | boolean | When true, attempt to apply the patch in a temporary git worktree and then discard it (does not modify the current workspace). |",
       "| `MUX_TOOL_INPUT_EXPECTED_HEAD_SHA` | `expected_head_sha` | string  | When provided, refuse to apply unless the target repository HEAD matches this SHA.                                             |",
-      "| `MUX_TOOL_INPUT_FORCE`             | `force`             | boolean | When true, allow apply even if the patch was previously applied (and skip clean-tree checks).                                  |",
+      "| `MUX_TOOL_INPUT_FORCE`             | `force`             | boolean | When true, allow apply even if the patch was previously applied.                                                               |",
       "| `MUX_TOOL_INPUT_PROJECT_PATH`      | `project_path`      | string  | When provided, apply only the patch artifact for this project path.                                                            |",
       "| `MUX_TOOL_INPUT_TASK_ID`           | `task_id`           | string  | Child task ID whose patch artifact should be applied                                                                           |",
       "| `MUX_TOOL_INPUT_THREE_WAY`         | `three_way`         | boolean | When true, run git am with --3way                                                                                              |",

--- a/src/node/services/tools/task_apply_git_patch.test.ts
+++ b/src/node/services/tools/task_apply_git_patch.test.ts
@@ -51,6 +51,7 @@ async function buildReadyProjectArtifact(params: {
   childRepo: string;
   baseSha: string;
   headSha: string;
+  formatPatchArgs?: string;
 }) {
   const patchPath = getSubagentGitPatchMboxPath(
     params.sessionDir,
@@ -58,7 +59,9 @@ async function buildReadyProjectArtifact(params: {
     params.storageKey
   );
   const patch = execSync(
-    `git format-patch --stdout --binary ${params.baseSha}..${params.headSha}`,
+    `git format-patch --stdout --binary ${params.formatPatchArgs ?? ""} ${params.baseSha}..${
+      params.headSha
+    }`,
     {
       cwd: params.childRepo,
       encoding: "buffer",
@@ -358,6 +361,522 @@ describe("task_apply_git_patch tool", () => {
     expect(execSync("git status --porcelain", { cwd: targetRepo, encoding: "utf-8" }).trim()).toBe(
       ""
     );
+  }, 20_000);
+
+  it("lets git am apply when dirty files are unrelated to the patch", async () => {
+    const childRepo = path.join(rootDir, "child-unrelated-dirty");
+    const targetRepo = path.join(rootDir, "target-unrelated-dirty");
+    for (const repo of [childRepo, targetRepo]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+      initGitRepo(repo);
+    }
+
+    await commitFile(childRepo, "README.md", "hello", "base");
+    await commitFile(targetRepo, "README.md", "hello", "base");
+    await commitFile(targetRepo, "notes.txt", "local base", "local notes");
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await fsPromises.writeFile(path.join(childRepo, "README.md"), "hello\nchild", "utf-8");
+    execSync("git add README.md", { cwd: childRepo, stdio: "ignore" });
+    execSync(
+      'git -c core.hooksPath=/dev/null commit --cleanup=verbatim -m "child change" -m "rename from notes.txt"',
+      {
+        cwd: childRepo,
+        stdio: "ignore",
+      }
+    );
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const sessionDir = path.join(rootDir, "session-unrelated-dirty");
+    await fsPromises.mkdir(sessionDir, { recursive: true });
+    const childTaskId = "child-task-unrelated-dirty";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target",
+          projectPath: targetRepo,
+          projectName: "target",
+          childRepo,
+          baseSha,
+          headSha,
+        }),
+      ],
+    });
+
+    await fsPromises.writeFile(
+      path.join(targetRepo, "notes.txt"),
+      "local base\nworktree edit",
+      "utf-8"
+    );
+    await fsPromises.writeFile(path.join(targetRepo, "temp.log"), "scratch", "utf-8");
+    const headBeforeDryRun = execSync("git rev-parse HEAD", {
+      cwd: targetRepo,
+      encoding: "utf-8",
+    }).trim();
+
+    const config = {
+      ...getTestDeps(),
+      cwd: targetRepo,
+      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtimeTempDir: path.join(rootDir, "runtime-tmp-unrelated-dirty"),
+      workspaceSessionDir: sessionDir,
+    };
+
+    const dryRun = await applyTaskGitPatchArtifact(
+      config,
+      { task_id: childTaskId, dry_run: true, three_way: true },
+      {}
+    );
+    expect(dryRun.success).toBe(true);
+    expect(execSync("git rev-parse HEAD", { cwd: targetRepo, encoding: "utf-8" }).trim()).toBe(
+      headBeforeDryRun
+    );
+
+    const realApply = await applyTaskGitPatchArtifact(
+      config,
+      { task_id: childTaskId, three_way: true },
+      {}
+    );
+
+    expect(realApply.success).toBe(true);
+    expect(execSync("git log -1 --pretty=%s", { cwd: targetRepo, encoding: "utf-8" }).trim()).toBe(
+      "child change"
+    );
+    expect(await fsPromises.readFile(path.join(targetRepo, "README.md"), "utf-8")).toBe(
+      "hello\nchild"
+    );
+    expect(await fsPromises.readFile(path.join(targetRepo, "notes.txt"), "utf-8")).toBe(
+      "local base\nworktree edit"
+    );
+    expect(await fsPromises.readFile(path.join(targetRepo, "temp.log"), "utf-8")).toBe("scratch");
+    const status = execSync("git status --porcelain", { cwd: targetRepo, encoding: "utf-8" });
+    expect(status).toContain(" M notes.txt");
+    expect(status).toContain("?? temp.log");
+  }, 20_000);
+
+  it("rejects staged unrelated changes before git am", async () => {
+    const childRepo = path.join(rootDir, "child-staged-unrelated");
+    const targetRepo = path.join(rootDir, "target-staged-unrelated");
+    for (const repo of [childRepo, targetRepo]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+      initGitRepo(repo);
+    }
+
+    await commitFile(childRepo, "README.md", "hello", "base");
+    await commitFile(targetRepo, "README.md", "hello", "base");
+    await commitFile(targetRepo, "notes.txt", "local base", "local notes");
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await commitFile(childRepo, "README.md", "hello\nchild", "child change");
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const sessionDir = path.join(rootDir, "session-staged-unrelated");
+    await fsPromises.mkdir(sessionDir, { recursive: true });
+    const childTaskId = "child-task-staged-unrelated";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target",
+          projectPath: targetRepo,
+          projectName: "target",
+          childRepo,
+          baseSha,
+          headSha,
+        }),
+      ],
+    });
+
+    await fsPromises.writeFile(path.join(targetRepo, "notes.txt"), "local base\nstaged", "utf-8");
+    execSync("git add notes.txt", { cwd: targetRepo, stdio: "ignore" });
+    const headBeforeApply = execSync("git rev-parse HEAD", {
+      cwd: targetRepo,
+      encoding: "utf-8",
+    }).trim();
+
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        cwd: targetRepo,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: path.join(rootDir, "runtime-tmp-staged-unrelated"),
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, dry_run: true, three_way: true },
+      {}
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected staged change failure");
+    }
+    expect(result.error).toContain("staged changes");
+    expect(result.conflictPaths).toEqual(["notes.txt"]);
+    expect(execSync("git rev-parse HEAD", { cwd: targetRepo, encoding: "utf-8" }).trim()).toBe(
+      headBeforeApply
+    );
+  }, 20_000);
+
+  it("rejects intent-to-add entries before git am", async () => {
+    const childRepo = path.join(rootDir, "child-intent-to-add");
+    const targetRepo = path.join(rootDir, "target-intent-to-add");
+    for (const repo of [childRepo, targetRepo]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+      initGitRepo(repo);
+    }
+
+    await commitFile(childRepo, "README.md", "hello", "base");
+    await commitFile(targetRepo, "README.md", "hello", "base");
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await commitFile(childRepo, "README.md", "hello\nchild", "child change");
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const sessionDir = path.join(rootDir, "session-intent-to-add");
+    await fsPromises.mkdir(sessionDir, { recursive: true });
+    const childTaskId = "child-task-intent-to-add";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target",
+          projectPath: targetRepo,
+          projectName: "target",
+          childRepo,
+          baseSha,
+          headSha,
+        }),
+      ],
+    });
+
+    await fsPromises.writeFile(path.join(targetRepo, "notes.txt"), "intent", "utf-8");
+    execSync("git add -N notes.txt", { cwd: targetRepo, stdio: "ignore" });
+
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        cwd: targetRepo,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: path.join(rootDir, "runtime-tmp-intent-to-add"),
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, dry_run: true, three_way: true },
+      {}
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected intent-to-add failure");
+    }
+    expect(result.error).toContain("staged changes");
+    expect(result.conflictPaths).toEqual(["notes.txt"]);
+  }, 20_000);
+
+  it("rejects overlapping dirty paths before a multi-commit patch can partially apply", async () => {
+    const childRepo = path.join(rootDir, "child-overlapping-dirty");
+    const targetRepo = path.join(rootDir, "target-overlapping-dirty");
+    for (const repo of [childRepo, targetRepo]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+      initGitRepo(repo);
+      await fsPromises.writeFile(path.join(repo, "README.md"), "hello", "utf-8");
+      await fsPromises.writeFile(path.join(repo, "f.txt"), "base", "utf-8");
+      execSync("git add README.md f.txt", { cwd: repo, stdio: "ignore" });
+      execSync('git commit -m "base"', { cwd: repo, stdio: "ignore" });
+    }
+
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await commitFile(childRepo, "README.md", "hello\nchild", "child readme change");
+    await commitFile(childRepo, "f.txt", "base\nchild", "child f change");
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const sessionDir = path.join(rootDir, "session-overlapping-dirty");
+    await fsPromises.mkdir(sessionDir, { recursive: true });
+    const childTaskId = "child-task-overlapping-dirty";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target",
+          projectPath: targetRepo,
+          projectName: "target",
+          childRepo,
+          baseSha,
+          headSha,
+        }),
+      ],
+    });
+
+    await fsPromises.writeFile(path.join(targetRepo, "f.txt"), "base\nlocal", "utf-8");
+    const headBeforeApply = execSync("git rev-parse HEAD", {
+      cwd: targetRepo,
+      encoding: "utf-8",
+    }).trim();
+
+    const config = {
+      ...getTestDeps(),
+      cwd: targetRepo,
+      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtimeTempDir: path.join(rootDir, "runtime-tmp-overlapping-dirty"),
+      workspaceSessionDir: sessionDir,
+    };
+
+    const dryRun = await applyTaskGitPatchArtifact(
+      config,
+      { task_id: childTaskId, dry_run: true, three_way: true },
+      {}
+    );
+    expect(dryRun.success).toBe(false);
+    if (dryRun.success) {
+      throw new Error("expected overlapping dirty path dry-run failure");
+    }
+    expect(dryRun.error).toContain("overlap patch paths");
+    expect(dryRun.conflictPaths).toEqual(["f.txt"]);
+    expect(execSync("git rev-parse HEAD", { cwd: targetRepo, encoding: "utf-8" }).trim()).toBe(
+      headBeforeApply
+    );
+
+    const result = await applyTaskGitPatchArtifact(
+      config,
+      { task_id: childTaskId, three_way: true },
+      {}
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected overlapping dirty path failure");
+    }
+    expect(result.error).toContain("overlap patch paths");
+    expect(result.conflictPaths).toEqual(["f.txt"]);
+    expect(execSync("git rev-parse HEAD", { cwd: targetRepo, encoding: "utf-8" }).trim()).toBe(
+      headBeforeApply
+    );
+    expect(await fsPromises.readFile(path.join(targetRepo, "README.md"), "utf-8")).toBe("hello");
+    expect(await fsPromises.readFile(path.join(targetRepo, "f.txt"), "utf-8")).toBe("base\nlocal");
+  }, 20_000);
+
+  it("treats dirty rename sources as overlapping patch paths", async () => {
+    const childRepo = path.join(rootDir, "child-rename-source-dirty");
+    const targetRepo = path.join(rootDir, "target-rename-source-dirty");
+    for (const repo of [childRepo, targetRepo]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+      initGitRepo(repo);
+      await fsPromises.writeFile(path.join(repo, "README.md"), "hello", "utf-8");
+      await fsPromises.mkdir(path.join(repo, "é b"), { recursive: true });
+      await fsPromises.writeFile(path.join(repo, "é b", "old.txt"), "base", "utf-8");
+      execSync("git add README.md 'é b/old.txt'", { cwd: repo, stdio: "ignore" });
+      execSync('git commit -m "base"', { cwd: repo, stdio: "ignore" });
+    }
+
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await commitFile(childRepo, "README.md", "hello\nchild", "child readme change");
+    execSync("git mv 'é b/old.txt' 'é b/new.txt'", { cwd: childRepo, stdio: "ignore" });
+    execSync('git commit -m "rename old"', { cwd: childRepo, stdio: "ignore" });
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const sessionDir = path.join(rootDir, "session-rename-source-dirty");
+    await fsPromises.mkdir(sessionDir, { recursive: true });
+    const childTaskId = "child-task-rename-source-dirty";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target",
+          projectPath: targetRepo,
+          projectName: "target",
+          childRepo,
+          baseSha,
+          headSha,
+        }),
+      ],
+    });
+
+    await fsPromises.writeFile(path.join(targetRepo, "é b", "old.txt"), "base\nlocal", "utf-8");
+    const headBeforeApply = execSync("git rev-parse HEAD", {
+      cwd: targetRepo,
+      encoding: "utf-8",
+    }).trim();
+
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        cwd: targetRepo,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: path.join(rootDir, "runtime-tmp-rename-source-dirty"),
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, dry_run: true, three_way: true },
+      {}
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected rename source overlap failure");
+    }
+    expect(result.conflictPaths).toEqual(["é b/old.txt"]);
+    expect(execSync("git rev-parse HEAD", { cwd: targetRepo, encoding: "utf-8" }).trim()).toBe(
+      headBeforeApply
+    );
+  }, 20_000);
+
+  it("treats dirty ancestor paths as overlapping patch paths", async () => {
+    const childRepo = path.join(rootDir, "child-ancestor-dirty");
+    const targetRepo = path.join(rootDir, "target-ancestor-dirty");
+    for (const repo of [childRepo, targetRepo]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+      initGitRepo(repo);
+      await commitFile(repo, "README.md", "hello", "base");
+    }
+
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await commitFile(childRepo, "README.md", "hello\nchild", "child readme change");
+    await fsPromises.mkdir(path.join(childRepo, "dir"), { recursive: true });
+    await fsPromises.writeFile(path.join(childRepo, "dir", "file.txt"), "child", "utf-8");
+    execSync("git add dir/file.txt", { cwd: childRepo, stdio: "ignore" });
+    execSync('git commit -m "add nested file"', { cwd: childRepo, stdio: "ignore" });
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const sessionDir = path.join(rootDir, "session-ancestor-dirty");
+    await fsPromises.mkdir(sessionDir, { recursive: true });
+    const childTaskId = "child-task-ancestor-dirty";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target",
+          projectPath: targetRepo,
+          projectName: "target",
+          childRepo,
+          baseSha,
+          headSha,
+        }),
+      ],
+    });
+
+    await fsPromises.writeFile(
+      path.join(targetRepo, "dir"),
+      "local file blocks directory",
+      "utf-8"
+    );
+    const headBeforeApply = execSync("git rev-parse HEAD", {
+      cwd: targetRepo,
+      encoding: "utf-8",
+    }).trim();
+
+    const result = await applyTaskGitPatchArtifact(
+      {
+        ...getTestDeps(),
+        cwd: targetRepo,
+        runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+        runtimeTempDir: path.join(rootDir, "runtime-tmp-ancestor-dirty"),
+        workspaceSessionDir: sessionDir,
+      },
+      { task_id: childTaskId, dry_run: true, three_way: true },
+      {}
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected ancestor path overlap failure");
+    }
+    expect(result.conflictPaths).toEqual(["dir"]);
+    expect(execSync("git rev-parse HEAD", { cwd: targetRepo, encoding: "utf-8" }).trim()).toBe(
+      headBeforeApply
+    );
+  }, 20_000);
+
+  it("treats dirty deleted copy sources as overlapping patch paths", async () => {
+    const childRepo = path.join(rootDir, "child-copy-source-dirty");
+    const targetRepo = path.join(rootDir, "target-copy-source-dirty");
+    for (const repo of [childRepo, targetRepo]) {
+      await fsPromises.mkdir(repo, { recursive: true });
+      initGitRepo(repo);
+      await commitFile(repo, "src.txt", "source", "base");
+    }
+
+    const baseSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+    await fsPromises.copyFile(path.join(childRepo, "src.txt"), path.join(childRepo, "dst.txt"));
+    execSync("git add dst.txt", { cwd: childRepo, stdio: "ignore" });
+    execSync('git commit -m "copy source"', { cwd: childRepo, stdio: "ignore" });
+    const headSha = execSync("git rev-parse HEAD", { cwd: childRepo, encoding: "utf-8" }).trim();
+
+    const sessionDir = path.join(rootDir, "session-copy-source-dirty");
+    await fsPromises.mkdir(sessionDir, { recursive: true });
+    const childTaskId = "child-task-copy-source-dirty";
+    await writePatchArtifact({
+      sessionDir,
+      workspaceId: getTestDeps().workspaceId,
+      childTaskId,
+      projectArtifacts: [
+        await buildReadyProjectArtifact({
+          sessionDir,
+          childTaskId,
+          storageKey: "target",
+          projectPath: targetRepo,
+          projectName: "target",
+          childRepo,
+          baseSha,
+          headSha,
+          formatPatchArgs: "-C --find-copies-harder",
+        }),
+      ],
+    });
+
+    const config = {
+      ...getTestDeps(),
+      cwd: targetRepo,
+      runtime: createRuntime({ type: "local", srcBaseDir: "/tmp" }),
+      runtimeTempDir: path.join(rootDir, "runtime-tmp-copy-source-dirty"),
+      workspaceSessionDir: sessionDir,
+    };
+
+    await fsPromises.rm(path.join(targetRepo, "src.txt"));
+
+    const result = await applyTaskGitPatchArtifact(
+      config,
+      { task_id: childTaskId, dry_run: true, three_way: true },
+      {}
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected dirty copy source failure");
+    }
+    expect(result.conflictPaths).toEqual(["src.txt"]);
+
+    execSync("git checkout -- src.txt", { cwd: targetRepo, stdio: "ignore" });
+    await fsPromises.writeFile(path.join(targetRepo, "src.txt"), "source\nlocal", "utf-8");
+    const withoutThreeWay = await applyTaskGitPatchArtifact(
+      config,
+      { task_id: childTaskId, dry_run: true, three_way: false },
+      {}
+    );
+    expect(withoutThreeWay.success).toBe(false);
+    if (withoutThreeWay.success) {
+      throw new Error("expected dirty copy source failure without three-way");
+    }
+    expect(withoutThreeWay.conflictPaths).toEqual(["src.txt"]);
   }, 20_000);
 
   it("cleans repo-local patch files when the runtime copy fails", async () => {

--- a/src/node/services/tools/task_apply_git_patch.ts
+++ b/src/node/services/tools/task_apply_git_patch.ts
@@ -688,6 +688,345 @@ function buildRuntimeTempPath(params: {
   return runtimePath;
 }
 
+interface GitStatusPorcelainEntry {
+  path: string;
+  status: string;
+}
+
+function parseGitStatusPorcelainZ(stdout: string): GitStatusPorcelainEntry[] {
+  const entriesByPath: GitStatusPorcelainEntry[] = [];
+  const entries = stdout.split("\0");
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    if (entry.length < 4) continue;
+
+    const status = entry.slice(0, 2);
+    const filePath = entry.slice(3);
+    if (filePath.length > 0) {
+      entriesByPath.push({ path: filePath, status });
+    }
+
+    if (status.includes("R") || status.includes("C")) {
+      i += 1;
+      const sourcePath = entries[i];
+      if (sourcePath != null && sourcePath.length > 0) {
+        entriesByPath.push({ path: sourcePath, status });
+      }
+    }
+  }
+  return entriesByPath;
+}
+
+function parseGitApplyNumstatZ(stdout: string): string[] {
+  return stdout
+    .split("\0")
+    .map((entry) => {
+      const firstTabIndex = entry.indexOf("\t");
+      const secondTabIndex = entry.indexOf("\t", firstTabIndex + 1);
+      return secondTabIndex === -1 ? "" : entry.slice(secondTabIndex + 1);
+    })
+    .filter((filePath) => filePath.length > 0);
+}
+
+interface PatchMetadataPaths {
+  renamePaths: string[];
+  copySourcePaths: string[];
+}
+
+function parsePatchMetadataPaths(stdout: string): PatchMetadataPaths {
+  const renamePaths: string[] = [];
+  const copySourcePaths: string[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const renamePrefix = line.startsWith("rename from ")
+      ? "rename from "
+      : line.startsWith("rename to ")
+        ? "rename to "
+        : undefined;
+    if (renamePrefix != null) {
+      const filePath = parsePatchMetadataPath(line.slice(renamePrefix.length));
+      if (filePath.length > 0) {
+        renamePaths.push(filePath);
+      }
+      continue;
+    }
+
+    if (line.startsWith("copy from ")) {
+      const filePath = parsePatchMetadataPath(line.slice("copy from ".length));
+      if (filePath.length > 0) {
+        copySourcePaths.push(filePath);
+      }
+    }
+  }
+  return { renamePaths, copySourcePaths };
+}
+
+function parseDiffGitHeaderPaths(stdout: string): string[] {
+  const paths = new Set<string>();
+  for (const line of stdout.split(/\r?\n/)) {
+    if (!line.startsWith("diff --git ")) continue;
+    for (const filePath of parseDiffGitHeaderLine(line.slice("diff --git ".length))) {
+      paths.add(filePath);
+    }
+  }
+  return [...paths].filter((filePath) => filePath.length > 0);
+}
+
+function parseDiffGitHeaderLine(line: string): string[] {
+  if (line.startsWith('"')) {
+    const first = parseGitQuotedPath(line, 0);
+    if (first == null) return [];
+    let secondStartOffset = first.nextOffset;
+    while (line[secondStartOffset] === " ") {
+      secondStartOffset += 1;
+    }
+    const second = parseGitQuotedPath(line, secondStartOffset);
+    return [stripDiffPathPrefix(first.path), stripDiffPathPrefix(second?.path)].filter(
+      (filePath): filePath is string => filePath != null && filePath.length > 0
+    );
+  }
+
+  if (!line.startsWith("a/")) {
+    return [];
+  }
+
+  const paths = new Set<string>();
+  let separatorIndex = line.indexOf(" b/", "a/".length);
+  while (separatorIndex !== -1) {
+    paths.add(line.slice("a/".length, separatorIndex));
+    paths.add(line.slice(separatorIndex + " b/".length));
+    separatorIndex = line.indexOf(" b/", separatorIndex + 1);
+  }
+  return [...paths];
+}
+
+function stripDiffPathPrefix(filePath: string | undefined): string | undefined {
+  if (filePath == null) return undefined;
+  return filePath.startsWith("a/") || filePath.startsWith("b/") ? filePath.slice(2) : filePath;
+}
+
+function parsePatchMetadataPath(value: string): string {
+  if (!value.startsWith('"')) {
+    return value;
+  }
+  return parseGitQuotedPath(value, 0)?.path ?? "";
+}
+
+function parseGitQuotedPath(
+  value: string,
+  startOffset: number
+): { path: string; nextOffset: number } | undefined {
+  if (value[startOffset] !== '"') {
+    return undefined;
+  }
+
+  const bytes: number[] = [];
+  const encoder = new TextEncoder();
+  let offset = startOffset + 1;
+  while (offset < value.length) {
+    const char = value[offset];
+    if (char === '"') {
+      return { path: new TextDecoder().decode(Uint8Array.from(bytes)), nextOffset: offset + 1 };
+    }
+
+    if (char !== "\\") {
+      const codePoint = value.codePointAt(offset);
+      if (codePoint == null) {
+        return undefined;
+      }
+      const codePointString = String.fromCodePoint(codePoint);
+      bytes.push(...encoder.encode(codePointString));
+      offset += codePointString.length;
+      continue;
+    }
+
+    offset += 1;
+    if (offset >= value.length) {
+      return undefined;
+    }
+
+    const escaped = value[offset];
+    if (/[0-7]/.test(escaped)) {
+      let octal = escaped;
+      offset += 1;
+      while (offset < value.length && octal.length < 3 && /[0-7]/.test(value[offset])) {
+        octal += value[offset];
+        offset += 1;
+      }
+      bytes.push(Number.parseInt(octal, 8));
+      continue;
+    }
+
+    const escapedByte = decodeGitQuotedEscapedByte(escaped);
+    if (escapedByte == null) {
+      bytes.push(...encoder.encode(escaped));
+    } else {
+      bytes.push(escapedByte);
+    }
+    offset += 1;
+  }
+
+  return undefined;
+}
+
+function decodeGitQuotedEscapedByte(char: string): number | undefined {
+  switch (char) {
+    case "a":
+      return 0x07;
+    case "b":
+      return 0x08;
+    case "t":
+      return 0x09;
+    case "n":
+      return 0x0a;
+    case "v":
+      return 0x0b;
+    case "f":
+      return 0x0c;
+    case "r":
+      return 0x0d;
+    case '"':
+      return 0x22;
+    case "\\":
+      return 0x5c;
+    default:
+      return undefined;
+  }
+}
+
+function patchPathOverlapsDirtyPath(patchPath: string, dirtyPath: string): boolean {
+  const normalizedPatchPath = patchPath.replace(/\/+$/, "");
+  const normalizedDirtyPath = dirtyPath.replace(/\/+$/, "");
+  return (
+    normalizedPatchPath === normalizedDirtyPath ||
+    normalizedPatchPath.startsWith(`${normalizedDirtyPath}/`) ||
+    normalizedDirtyPath.startsWith(`${normalizedPatchPath}/`)
+  );
+}
+
+async function checkDirtyPatchPathOverlap(params: {
+  runtime: ToolConfiguration["runtime"];
+  cwd: string;
+  remotePatchPath: string;
+  threeWay: boolean;
+}): Promise<{ error: string; conflictPaths?: string[] } | undefined> {
+  const statusResult = await execBuffered(
+    params.runtime,
+    "git status --porcelain -z --untracked-files=all",
+    {
+      cwd: params.cwd,
+      timeout: 10,
+    }
+  );
+  if (statusResult.exitCode !== 0) {
+    return { error: statusResult.stderr.trim() || "git status failed" };
+  }
+
+  const dirtyEntries = parseGitStatusPorcelainZ(statusResult.stdout);
+  if (dirtyEntries.length === 0) {
+    return undefined;
+  }
+
+  const cachedResult = await execBuffered(
+    params.runtime,
+    "git diff-index --cached --name-only -z HEAD --",
+    {
+      cwd: params.cwd,
+      timeout: 10,
+    }
+  );
+  if (cachedResult.exitCode !== 0) {
+    return { error: cachedResult.stderr.trim() || "git diff-index failed" };
+  }
+  const stagedPaths = cachedResult.stdout
+    .split("\0")
+    .filter((filePath) => filePath.length > 0)
+    .sort();
+  if (stagedPaths.length > 0) {
+    return {
+      error: "Index has staged changes; git am requires a clean index.",
+      conflictPaths: stagedPaths,
+    };
+  }
+
+  const dirtyPaths = new Set(dirtyEntries.map((entry) => entry.path));
+
+  const patchBodyCommand = `awk '/^From / { in_patch=0 } /^---$/ { in_patch=1; next } in_patch { print }' ${shellQuote(
+    params.remotePatchPath
+  )}`;
+  const numstatResult = await execBuffered(
+    params.runtime,
+    `${patchBodyCommand} | git apply --numstat -z`,
+    {
+      cwd: params.cwd,
+      timeout: 30,
+    }
+  );
+  const numstatPaths = parseGitApplyNumstatZ(numstatResult.stdout);
+
+  const diffHeaderResult = await execBuffered(
+    params.runtime,
+    `awk '/^From / { in_patch=0 } /^---$/ { in_patch=1; next } in_patch && /^diff --git / { print }' ${shellQuote(
+      params.remotePatchPath
+    )}`,
+    {
+      cwd: params.cwd,
+      timeout: 30,
+    }
+  );
+
+  if (numstatResult.exitCode !== 0 && !numstatResult.stderr.includes("No valid patches")) {
+    return {
+      error:
+        numstatResult.stderr.trim() ||
+        numstatResult.stdout.trim() ||
+        "Could not determine patch paths before applying in dirty worktree.",
+    };
+  }
+
+  const metadataResult = await execBuffered(
+    params.runtime,
+    `awk '/^From / { in_patch=0; in_diff=0 } /^---$/ { in_patch=1; next } in_patch && /^diff --git / { in_diff=1; next } in_patch && in_diff && (/^rename from / || /^rename to / || /^copy from /) { print }' ${shellQuote(
+      params.remotePatchPath
+    )}`,
+    {
+      cwd: params.cwd,
+      timeout: 30,
+    }
+  );
+  const metadataPaths = parsePatchMetadataPaths(metadataResult.stdout);
+  const patchPaths = new Set([
+    ...(numstatResult.exitCode === 0
+      ? numstatPaths
+      : parseDiffGitHeaderPaths(diffHeaderResult.stdout)),
+    ...metadataPaths.renamePaths,
+  ]);
+  const conflictPaths = [
+    ...new Set([
+      ...[...dirtyPaths].filter((dirtyPath) =>
+        [...patchPaths].some((patchPath) => patchPathOverlapsDirtyPath(patchPath, dirtyPath))
+      ),
+      ...dirtyEntries
+        .filter(
+          (entry) => !params.threeWay || entry.status.includes("D") || entry.status.includes("T")
+        )
+        .filter((entry) =>
+          metadataPaths.copySourcePaths.some((copySourcePath) =>
+            patchPathOverlapsDirtyPath(copySourcePath, entry.path)
+          )
+        )
+        .map((entry) => entry.path),
+    ]),
+  ].sort();
+  if (conflictPaths.length === 0) {
+    return undefined;
+  }
+
+  return {
+    error: "Working tree has local changes that overlap patch paths.",
+    conflictPaths,
+  };
+}
+
 async function checkExpectedHead(params: {
   runtime: ToolConfiguration["runtime"];
   cwd: string;
@@ -774,41 +1113,6 @@ async function applyProjectPatch(params: {
     };
   }
 
-  if (!params.force) {
-    const statusResult = await execBuffered(params.runtime, "git status --porcelain", {
-      cwd: params.repoCwd,
-      timeout: 10,
-    });
-    if (statusResult.exitCode !== 0) {
-      return {
-        success: false,
-        projectResult: {
-          projectPath: params.projectArtifact.projectPath,
-          projectName: params.projectArtifact.projectName,
-          status: "failed",
-          error: statusResult.stderr.trim() || "git status failed",
-          note: patchResolution.note,
-        },
-      };
-    }
-
-    if (statusResult.stdout.trim().length > 0) {
-      return {
-        success: false,
-        projectResult: {
-          projectPath: params.projectArtifact.projectPath,
-          projectName: params.projectArtifact.projectName,
-          status: "failed",
-          error: "Working tree is not clean.",
-          note: mergeNotes(
-            patchResolution.note,
-            "Commit/stash your changes (or pass force=true) before applying patches."
-          ),
-        },
-      };
-    }
-  }
-
   const expectedHeadError = await checkExpectedHead({
     runtime: params.runtime,
     cwd: params.repoCwd,
@@ -841,6 +1145,29 @@ async function applyProjectPatch(params: {
     const nhp = gitNoHooksPrefix(params.trusted);
 
     if (params.dryRun) {
+      const dryRunDirtyOverlap = await checkDirtyPatchPathOverlap({
+        runtime: params.runtime,
+        cwd: params.repoCwd,
+        remotePatchPath,
+        threeWay: params.threeWay,
+      });
+      if (dryRunDirtyOverlap != null) {
+        return {
+          success: false,
+          projectResult: {
+            projectPath: params.projectArtifact.projectPath,
+            projectName: params.projectArtifact.projectName,
+            status: "failed",
+            error: dryRunDirtyOverlap.error,
+            conflictPaths: dryRunDirtyOverlap.conflictPaths,
+            note: mergeNotes(
+              patchResolution.note,
+              "Commit or stash local changes on overlapping patch paths before applying. Unrelated dirty files can remain in place."
+            ),
+          },
+        };
+      }
+
       const dryRunHeadError = await checkExpectedHead({
         runtime: params.runtime,
         cwd: params.repoCwd,
@@ -1024,6 +1351,32 @@ async function applyProjectPatch(params: {
           });
         }
       }
+    }
+
+    // Let `git am --3way` handle unrelated dirty files, but reject dirty paths
+    // that overlap the patch series before a multi-commit `git am` can partially
+    // advance HEAD and then fail on a later commit.
+    const dirtyOverlap = await checkDirtyPatchPathOverlap({
+      runtime: params.runtime,
+      cwd: params.repoCwd,
+      remotePatchPath,
+      threeWay: params.threeWay,
+    });
+    if (dirtyOverlap != null) {
+      return {
+        success: false,
+        projectResult: {
+          projectPath: params.projectArtifact.projectPath,
+          projectName: params.projectArtifact.projectName,
+          status: "failed",
+          error: dirtyOverlap.error,
+          conflictPaths: dirtyOverlap.conflictPaths,
+          note: mergeNotes(
+            patchResolution.note,
+            "Commit or stash local changes on overlapping patch paths before applying. Unrelated dirty files can remain in place."
+          ),
+        },
+      };
     }
 
     const applyHeadError = await checkExpectedHead({


### PR DESCRIPTION
## Summary

Allow `task_apply_git_patch` and workflow `applyPatch` to integrate patches in workspaces that have unrelated dirty files, while still rejecting local dirty changes that overlap the patch series before `git am` can partially apply it.

## Background

Workflow patch application could fail before invoking Git when unrelated temp files or local edits were present in the parent workspace. Git can safely apply format patches when those dirty files are unrelated, so Mux should preserve that behavior without risking partial multi-commit application when local edits overlap later patch commits.

## Implementation

- Removed the blanket `git status --porcelain` clean-tree rejection from the shared patch-apply implementation.
- Added a dirty-path overlap preflight that compares dirty paths with patch-touched paths from `git apply --numstat -z` over real patch bodies plus rename/copy metadata extracted only from real patch sections.
- Falls back to patch `diff --git` headers when `--numstat` cannot report hunk paths for patch-body-only inputs such as gitlink-only changes, including Git-quoted fallback headers.
- Decodes Git C-quoted metadata paths, including octal escapes and raw astral Unicode, so rename/copy paths with escaped bytes are included.
- Treats rename sources, dirty deleted/typechanged copy sources, all dirty copy sources when `three_way` is false, and file/directory ancestor pairs as overlapping patch paths.
- Uses `git diff-index --cached --name-only -z HEAD --` to reject staged index changes and intent-to-add entries up front because `git am` requires a clean index even when those paths are unrelated.
- Runs the overlap preflight for dry-run and again immediately before real apply.
- Kept `expected_head_sha`, dry-run, and `git am --3way` conflict handling intact.
- Updated the `force` description now that it no longer skips a clean-tree preflight.
- Added regression coverage for unrelated dirty tracked/untracked files, staged unrelated changes, intent-to-add entries, commit-message metadata false positives, overlapping dirty multi-commit patches, dirty rename sources with Git-quoted paths containing ` b/`, dirty copy-source hazards, and dirty ancestor path conflicts.

## Validation

- `bun test src/node/services/tools/task_apply_git_patch.test.ts`
- `make fmt`
- `make fmt-check`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `make static-check`

## Risks

Low-to-medium risk in patch integration flows: this intentionally allows more real `git am` attempts in dirty workspaces, but overlapping dirty paths and any staged/intent-to-add index changes are rejected before apply and Git still blocks other unsafe states.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$6.20`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=6.20 -->
