### PR TITLE
🤖 feat: show nested workflow progress inline

### DIFF
--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
@@ -389,6 +389,27 @@ describe("WorkflowTimeline", () => {
     expect(view.getByText("running · 0/1 steps · child-phase")).toBeDefined();
   });
 
+  test("uses active child run progress when the parent nested event is terminal", async () => {
+    const client = {
+      workflows: {
+        getRun: () => Promise.resolve(makeChildWorkflowRun()),
+      },
+    };
+    const staleParentView = makeNestedWorkflowParentView();
+    staleParentView.phases[0].failed = true;
+    staleParentView.phases[0].steps[0].status = "failed";
+    staleParentView.phases[0].steps[0].nestedWorkflowStatus = "failed";
+
+    const view = renderWithWorkflowApi(
+      <WorkflowTimeline view={staleParentView} workspaceId="workspace-main" />,
+      client
+    );
+
+    await waitFor(() => {
+      expect(view.getByText("running · 0/1 steps · child-phase")).toBeDefined();
+    });
+  });
+
   test("auto-opens an active nested workflow when the child event arrives after mount", async () => {
     const client = {
       workflows: {

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
@@ -389,6 +389,41 @@ describe("WorkflowTimeline", () => {
     expect(view.getByText("running · 0/1 steps · child-phase")).toBeDefined();
   });
 
+  test("auto-opens an active nested workflow when the child event arrives after mount", async () => {
+    const client = {
+      workflows: {
+        getRun: () => Promise.resolve(makeChildWorkflowRun()),
+      },
+    };
+    const initialView = makeNestedWorkflowParentView();
+    delete initialView.phases[0].steps[0].nestedWorkflowRunId;
+    delete initialView.phases[0].steps[0].nestedWorkflowName;
+    delete initialView.phases[0].steps[0].nestedWorkflowStatus;
+    const withApi = (timelineView: WorkflowRunView) => (
+      <APIContext.Provider
+        value={{
+          status: "connected",
+          api: client as never,
+          error: null,
+          authenticate: () => undefined,
+          retry: () => undefined,
+        }}
+      >
+        <WorkflowTimeline view={timelineView} workspaceId="workspace-main" />
+      </APIContext.Provider>
+    );
+
+    const view = render(withApi(initialView));
+    fireEvent.click(view.getByRole("button", { name: "delegate 0/1" }));
+    expect(view.queryByText("Nested workflow implementation-loop")).toBeNull();
+
+    view.rerender(withApi(makeNestedWorkflowParentView()));
+
+    await waitFor(() => {
+      expect(view.getByText("Nested workflow implementation-loop")).toBeDefined();
+    });
+  });
+
   test("renders final report stat chips as bold key before value", () => {
     const { container } = render(<WorkflowTimeline view={makeCompletedView()} />);
 

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx
@@ -1,6 +1,9 @@
+import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
+import { APIContext } from "@/browser/contexts/API";
+import type { WorkflowRunRecord } from "@/common/types/workflow";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 
 import { installDom } from "../../../../../tests/ui/dom";
@@ -169,6 +172,113 @@ function makeCompletedStepView(taskId: string): WorkflowRunView {
   };
 }
 
+function makeNestedWorkflowParentView(): WorkflowRunView {
+  const timestamp = "2026-06-25T12:00:00.000Z";
+  return {
+    ...makeCompletedView(),
+    status: "running",
+    phases: [
+      {
+        name: "delegate",
+        label: "delegate",
+        steps: [
+          {
+            stepId: "implementation-loop",
+            status: "running",
+            title: "implementation-loop",
+            phaseName: "delegate",
+            startedAt: timestamp,
+            nestedWorkflowRunId: "wfr_child01",
+            nestedWorkflowName: "implementation-loop",
+            nestedWorkflowStatus: "started",
+          },
+        ],
+        done: 0,
+        total: 1,
+        running: true,
+        failed: false,
+      },
+    ],
+    steps: [],
+    result: null,
+    stats: {
+      total: 1,
+      done: 0,
+      running: 1,
+      failed: 0,
+      elapsedMs: 0,
+    },
+  };
+}
+
+function makeChildWorkflowRun(): WorkflowRunRecord {
+  const timestamp = "2026-06-25T12:00:00.000Z";
+  return {
+    id: "wfr_child01",
+    workspaceId: "workspace-main",
+    workflow: {
+      name: "implementation-loop",
+      description: "Implement a nested slice",
+      scope: "global",
+      requestedScriptPath: "skill://implementation-loop/workflow.js",
+      canonicalScriptPath: "skill://implementation-loop/workflow.js",
+      sourceKind: "skill",
+      sourceHash: "sha256:child",
+      executable: true,
+    },
+    source: "export default function workflow() { return null; }",
+    sourceHash: "sha256:child",
+    args: { target: "coder/mux#3546" },
+    parentWorkflow: {
+      runId: "wfr_parent01",
+      stepId: "implementation-loop",
+      inputHash: "hash-child",
+      depth: 0,
+    },
+    status: "running",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    events: [
+      { sequence: 1, type: "status", at: timestamp, status: "running" },
+      { sequence: 2, type: "phase", at: timestamp, name: "child-phase" },
+      {
+        sequence: 3,
+        type: "task",
+        at: timestamp,
+        stepId: "child-task",
+        taskId: "task_child",
+        status: "started",
+        title: "Child task",
+      },
+    ],
+    steps: [
+      {
+        stepId: "child-task",
+        inputHash: "child-task-hash",
+        status: "started",
+        taskId: "task_child",
+        startedAt: timestamp,
+      },
+    ],
+  };
+}
+
+function renderWithWorkflowApi(ui: ReactElement, client: unknown) {
+  return render(
+    <APIContext.Provider
+      value={{
+        status: "connected",
+        api: client as never,
+        error: null,
+        authenticate: () => undefined,
+        retry: () => undefined,
+      }}
+    >
+      {ui}
+    </APIContext.Provider>
+  );
+}
+
 describe("WorkflowTimeline", () => {
   let cleanupDom: (() => void) | null = null;
 
@@ -252,6 +362,31 @@ describe("WorkflowTimeline", () => {
     fireEvent.click(view.getByRole("button", { name: "Review implementation 2s" }));
 
     expect(view.getByText("Completed step report body.")).toBeDefined();
+  });
+
+  test("inlines a nested workflow run under its parent step", async () => {
+    const requestedRunIds: string[] = [];
+    const client = {
+      workflows: {
+        getRun: (input: { runId: string }) => {
+          requestedRunIds.push(input.runId);
+          return Promise.resolve(makeChildWorkflowRun());
+        },
+      },
+    };
+
+    const view = renderWithWorkflowApi(
+      <WorkflowTimeline view={makeNestedWorkflowParentView()} workspaceId="workspace-main" />,
+      client
+    );
+
+    fireEvent.click(view.getByRole("button", { name: "delegate 0/1" }));
+
+    await waitFor(() => {
+      expect(view.getByText("child-phase")).toBeDefined();
+    });
+    expect(requestedRunIds).toContain("wfr_child01");
+    expect(view.getByText("running · 0/1 steps · child-phase")).toBeDefined();
   });
 
   test("renders final report stat chips as bold key before value", () => {

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
@@ -16,10 +16,17 @@ import {
 
 import { MarkdownRenderer } from "@/browser/features/Messages/MarkdownRenderer";
 import { WorkflowJsonBlock } from "@/browser/features/Tools/WorkflowToolShared";
+import { useWorkflowRunById } from "@/browser/hooks/useWorkflowRunById";
 import { useWorkspaceStoreRaw } from "@/browser/stores/WorkspaceStore";
+import { isActiveWorkflowRunStatus } from "@/common/types/workflow";
 
 import { WorkflowLiveDot } from "./WorkflowBadges";
-import type { WorkflowPhaseView, WorkflowRunView, WorkflowStepView } from "./projectWorkflowRun";
+import {
+  projectWorkflowRun,
+  type WorkflowPhaseView,
+  type WorkflowRunView,
+  type WorkflowStepView,
+} from "./projectWorkflowRun";
 import {
   WORKFLOW_TONE_VAR,
   formatWorkflowCost,
@@ -31,6 +38,46 @@ import {
 } from "./workflowDisplay";
 
 const ASK_MODE_BORDER = "color-mix(in srgb, var(--color-ask-mode) 35%, transparent)";
+const MAX_INLINE_NESTED_WORKFLOW_DEPTH = 3;
+
+interface WorkflowTimelineProps {
+  view: WorkflowRunView;
+  workspaceId?: string;
+  nestedDepth?: number;
+}
+
+interface WorkflowPhaseSectionProps {
+  phase: WorkflowPhaseView;
+  workspaceId?: string;
+  nestedDepth: number;
+}
+
+interface WorkflowStepRowProps {
+  step: WorkflowStepView;
+  isLast: boolean;
+  workspaceId?: string;
+  nestedDepth: number;
+}
+
+function isWorkflowStepNestedStatusActive(
+  status: WorkflowStepView["nestedWorkflowStatus"]
+): boolean {
+  return status === "started" || status === "running" || status === "backgrounded";
+}
+
+function getNestedWorkflowSummary(input: {
+  childView: WorkflowRunView | null;
+  fallbackStatus?: WorkflowStepView["nestedWorkflowStatus"];
+}): string {
+  if (input.childView == null) {
+    return input.fallbackStatus ?? "loading";
+  }
+  const activePhase =
+    input.childView.phases.find((phase) => phase.running) ?? input.childView.phases.at(-1);
+  const phaseLabel =
+    activePhase != null && activePhase.label.length > 0 ? ` · ${activePhase.label}` : "";
+  return `${input.childView.status} · ${input.childView.stats.done}/${input.childView.stats.total} steps${phaseLabel}`;
+}
 
 const WorkflowStepNode: React.FC<{ step: WorkflowStepView; color: string }> = (props) => {
   if (props.step.status === "running") {
@@ -54,9 +101,10 @@ const WorkflowStepNode: React.FC<{ step: WorkflowStepView; color: string }> = (p
  * only a fresh false→true transition forces it open.
  */
 function useDisclosureOpenOnFailure(
-  failed: boolean
+  failed: boolean,
+  defaultOpen = false
 ): readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>] {
-  const [open, setOpen] = React.useState(failed);
+  const [open, setOpen] = React.useState(failed || defaultOpen);
   const [prevFailed, setPrevFailed] = React.useState(failed);
   if (failed !== prevFailed) {
     setPrevFailed(failed);
@@ -67,12 +115,84 @@ function useDisclosureOpenOnFailure(
   return [open, setOpen] as const;
 }
 
-const WorkflowStepRow: React.FC<{ step: WorkflowStepView; isLast: boolean }> = (props) => {
+const NestedWorkflowStepPanel: React.FC<{
+  step: WorkflowStepView;
+  workspaceId?: string;
+  nestedDepth: number;
+  parentOpen: boolean;
+}> = (props) => {
+  const nestedRunId = props.step.nestedWorkflowRunId;
+  const withinDepthLimit = props.nestedDepth < MAX_INLINE_NESTED_WORKFLOW_DEPTH;
+  const fallbackActive = isWorkflowStepNestedStatusActive(props.step.nestedWorkflowStatus);
+  const childRunState = useWorkflowRunById({
+    workspaceId: props.workspaceId,
+    runId: nestedRunId,
+    enabled:
+      nestedRunId != null &&
+      props.workspaceId != null &&
+      withinDepthLimit &&
+      (props.parentOpen || fallbackActive),
+    pollWhileActive: fallbackActive,
+  });
+  const childRun = childRunState.run;
+  const childView = childRun != null ? projectWorkflowRun(childRun) : null;
+  const childActive = childRun != null && isActiveWorkflowRunStatus(childRun.status);
+  const childSummary = getNestedWorkflowSummary({
+    childView,
+    fallbackStatus: props.step.nestedWorkflowStatus,
+  });
+
+  if (nestedRunId == null) {
+    return null;
+  }
+
+  return (
+    <div className="border-border bg-surface-secondary/40 mt-2.5 rounded-lg border p-2.5">
+      <div className="flex min-w-0 items-center gap-2">
+        {childActive || (childRun == null && fallbackActive) ? <WorkflowLiveDot /> : null}
+        <span className="text-content-primary min-w-0 truncate text-xs font-semibold">
+          Nested workflow {props.step.nestedWorkflowName ?? props.step.title}
+        </span>
+        <span className="text-muted counter-nums-mono min-w-0 truncate text-[10px]">
+          {nestedRunId}
+        </span>
+      </div>
+      <div className="text-muted mt-1 text-[11px]">{childSummary}</div>
+
+      {!withinDepthLimit ? (
+        <div className="text-muted mt-2 text-[11px]">
+          Nested workflow depth limit reached; showing summary only.
+        </div>
+      ) : childRunState.error != null ? (
+        <div className="text-danger mt-2 text-[11px]">{childRunState.error}</div>
+      ) : childRunState.loading && childRun == null ? (
+        <div className="text-muted mt-2 text-[11px]">Loading nested workflow…</div>
+      ) : childRun != null && childView != null ? (
+        <div className="border-border/70 mt-2 border-l pl-3">
+          <WorkflowTimeline
+            view={childView}
+            workspaceId={childRun.workspaceId}
+            nestedDepth={props.nestedDepth + 1}
+          />
+        </div>
+      ) : (
+        <div className="text-muted mt-2 text-[11px]">Nested workflow run is not available.</div>
+      )}
+    </div>
+  );
+};
+
+const WorkflowStepRow: React.FC<WorkflowStepRowProps> = (props) => {
   const step = props.step;
-  const expandable = step.status === "completed" || step.status === "failed";
+  const hasNestedWorkflow = step.nestedWorkflowRunId != null;
+  const expandable = step.status === "completed" || step.status === "failed" || hasNestedWorkflow;
   // Surface failures by default (including live failures that arrive after the row mounted while
-  // running); otherwise stay collapsed for scanability.
-  const [open, setOpen] = useDisclosureOpenOnFailure(step.status === "failed");
+  // running); active nested workflows also start open so their child progress is visible.
+  const [open, setOpen] = useDisclosureOpenOnFailure(
+    step.status === "failed",
+    hasNestedWorkflow &&
+      (step.status === "running" || isWorkflowStepNestedStatusActive(step.nestedWorkflowStatus))
+  );
   const color = WORKFLOW_TONE_VAR[getWorkflowStepTone(step.status)];
   const showReport = hasDisplayableWorkflowReport(
     step.result?.reportMarkdown,
@@ -109,6 +229,11 @@ const WorkflowStepRow: React.FC<{ step: WorkflowStepView; isLast: boolean }> = (
       {step.status === "failed" && (
         <span className="shrink-0 text-[11px]" style={{ color }}>
           failed
+        </span>
+      )}
+      {hasNestedWorkflow && (
+        <span className="border-border text-plan-mode shrink-0 rounded border px-1.5 py-px text-[10px]">
+          nested
         </span>
       )}
       {expandable &&
@@ -210,6 +335,14 @@ const WorkflowStepRow: React.FC<{ step: WorkflowStepView; isLast: boolean }> = (
                 </div>
               </>
             )}
+            {hasNestedWorkflow && (
+              <NestedWorkflowStepPanel
+                step={step}
+                workspaceId={props.workspaceId}
+                nestedDepth={props.nestedDepth}
+                parentOpen={open}
+              />
+            )}
           </div>
         )}
       </div>
@@ -217,7 +350,7 @@ const WorkflowStepRow: React.FC<{ step: WorkflowStepView; isLast: boolean }> = (
   );
 };
 
-const WorkflowPhaseSection: React.FC<{ phase: WorkflowPhaseView }> = (props) => {
+const WorkflowPhaseSection: React.FC<WorkflowPhaseSectionProps> = (props) => {
   const phase = props.phase;
   const allDone = phase.total > 0 && phase.done === phase.total;
   // Phase events can carry a structured `details` info object (e.g. {angleCount, maxSources}).
@@ -304,6 +437,8 @@ const WorkflowPhaseSection: React.FC<{ phase: WorkflowPhaseView }> = (props) => 
               key={step.stepId}
               step={step}
               isLast={index === phase.steps.length - 1}
+              workspaceId={props.workspaceId}
+              nestedDepth={props.nestedDepth}
             />
           ))}
         </div>
@@ -383,8 +518,9 @@ const WorkflowFinalReport: React.FC<{ view: WorkflowRunView }> = (props) => {
 };
 
 /** "Timeline" run body: a vertical stream of phases and their agent steps. */
-export const WorkflowTimeline: React.FC<{ view: WorkflowRunView }> = (props) => {
+export const WorkflowTimeline: React.FC<WorkflowTimelineProps> = (props) => {
   const view = props.view;
+  const nestedDepth = props.nestedDepth ?? 0;
   return (
     <div className="flex flex-col gap-4">
       {/* Surface a run-level failure (e.g. setup/compile/eval errors that occur before any step)
@@ -411,7 +547,12 @@ export const WorkflowTimeline: React.FC<{ view: WorkflowRunView }> = (props) => 
           <div className="text-muted px-2 py-3 text-xs">No steps yet.</div>
         ) : (
           view.phases.map((phase) => (
-            <WorkflowPhaseSection key={phase.name || "__ungrouped"} phase={phase} />
+            <WorkflowPhaseSection
+              key={phase.name || "__ungrouped"}
+              phase={phase}
+              workspaceId={props.workspaceId}
+              nestedDepth={nestedDepth}
+            />
           ))
         )}
       </div>

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
@@ -141,6 +141,7 @@ const NestedWorkflowStepPanel: React.FC<{
       props.workspaceId != null &&
       withinDepthLimit &&
       (props.parentOpen || fallbackActive),
+    pollAfterTerminal: true,
     pollWhileActive: true,
   });
   const childRun = childRunState.run;

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
@@ -94,21 +94,28 @@ const WorkflowStepNode: React.FC<{ step: WorkflowStepView; color: string }> = (p
 };
 
 /**
- * Disclosure state that opens when `failed` is initially true AND auto-opens if the value
- * transitions to true later — e.g. a live run whose phase/step fails after it first mounted while
- * running, where a plain `useState(failed)` would keep the stale collapsed state. Uses React's
- * "adjust state during render" pattern (no effect). The user can still collapse it afterward;
- * only a fresh false→true transition forces it open.
+ * Disclosure state that opens when a signal is initially true AND auto-opens if the value
+ * transitions to true later — e.g. a live run whose phase/step fails, or a nested workflow event
+ * arriving after the parent row has already mounted. Uses React's "adjust state during render"
+ * pattern (no effect). The user can still collapse it afterward; only a fresh false→true
+ * transition forces it open.
  */
-function useDisclosureOpenOnFailure(
+function useDisclosureOpenOnSignal(
   failed: boolean,
   defaultOpen = false
 ): readonly [boolean, React.Dispatch<React.SetStateAction<boolean>>] {
   const [open, setOpen] = React.useState(failed || defaultOpen);
   const [prevFailed, setPrevFailed] = React.useState(failed);
+  const [prevDefaultOpen, setPrevDefaultOpen] = React.useState(defaultOpen);
   if (failed !== prevFailed) {
     setPrevFailed(failed);
     if (failed) {
+      setOpen(true);
+    }
+  }
+  if (defaultOpen !== prevDefaultOpen) {
+    setPrevDefaultOpen(defaultOpen);
+    if (defaultOpen) {
       setOpen(true);
     }
   }
@@ -188,7 +195,7 @@ const WorkflowStepRow: React.FC<WorkflowStepRowProps> = (props) => {
   const expandable = step.status === "completed" || step.status === "failed" || hasNestedWorkflow;
   // Surface failures by default (including live failures that arrive after the row mounted while
   // running); active nested workflows also start open so their child progress is visible.
-  const [open, setOpen] = useDisclosureOpenOnFailure(
+  const [open, setOpen] = useDisclosureOpenOnSignal(
     step.status === "failed",
     hasNestedWorkflow &&
       (step.status === "running" || isWorkflowStepNestedStatusActive(step.nestedWorkflowStatus))
@@ -361,7 +368,7 @@ const WorkflowPhaseSection: React.FC<WorkflowPhaseSectionProps> = (props) => {
   // default to keep a fanned-out run (20+ steps) scannable — except failed phases, which start
   // open so the failure (and the failed step's error) is visible without a manual expand.
   const hasBody = phase.steps.length > 0 || hasInfo;
-  const [open, setOpen] = useDisclosureOpenOnFailure(phase.failed);
+  const [open, setOpen] = useDisclosureOpenOnSignal(phase.failed);
 
   const headerContent = (
     <>

--- a/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowTimeline.tsx
@@ -131,6 +131,8 @@ const NestedWorkflowStepPanel: React.FC<{
   const nestedRunId = props.step.nestedWorkflowRunId;
   const withinDepthLimit = props.nestedDepth < MAX_INLINE_NESTED_WORKFLOW_DEPTH;
   const fallbackActive = isWorkflowStepNestedStatusActive(props.step.nestedWorkflowStatus);
+  // Poll while the panel is mounted: checkpoint retries can reuse the child run id without a new
+  // parent started event, so the durable child record is the source of truth for live progress.
   const childRunState = useWorkflowRunById({
     workspaceId: props.workspaceId,
     runId: nestedRunId,
@@ -139,7 +141,7 @@ const NestedWorkflowStepPanel: React.FC<{
       props.workspaceId != null &&
       withinDepthLimit &&
       (props.parentOpen || fallbackActive),
-    pollWhileActive: fallbackActive,
+    pollWhileActive: true,
   });
   const childRun = childRunState.run;
   const childView = childRun != null ? projectWorkflowRun(childRun) : null;

--- a/src/browser/features/RightSidebar/Workflows/WorkflowsTab.stories.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowsTab.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { APIContext } from "@/browser/contexts/API";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import type { WorkflowRunRecord, WorkflowRunStreamEvent } from "@/common/types/workflow";
+
+import { WorkflowsTab } from "./WorkflowsTab";
+
+const meta = {
+  title: "Features/RightSidebar/Workflows",
+  component: WorkflowsTab,
+  parameters: {
+    layout: "centered",
+    backgrounds: { default: "dark" },
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider forcedTheme="dark">
+        <div className="bg-background text-foreground border-border h-[760px] w-[430px] overflow-auto rounded-xl border p-4">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof WorkflowsTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const NOW = "2026-05-29T00:00:00.000Z";
+
+const nestedChildRun: WorkflowRunRecord = {
+  id: "wfr_child_story",
+  workspaceId: "workspace-1",
+  workflow: {
+    name: "implementation-loop",
+    description: "Implementation loop",
+    scope: "global",
+    requestedScriptPath: "skill://implementation-loop/workflow.js",
+    canonicalScriptPath: "skill://implementation-loop/workflow.js",
+    sourceKind: "skill",
+    sourceHash: "sha256:nested-child",
+    executable: true,
+  },
+  source: "export default function workflow() { return null; }",
+  sourceHash: "sha256:nested-child",
+  args: { target: "coder/mux#3546" },
+  parentWorkflow: {
+    runId: "wfr_nested_parent_story",
+    stepId: "implementation-loop",
+    inputHash: "sha256:nested-child-input",
+    depth: 0,
+  },
+  status: "running",
+  createdAt: NOW,
+  updatedAt: "2026-05-29T00:00:04.000Z",
+  events: [
+    { sequence: 1, type: "status", at: NOW, status: "running" },
+    { sequence: 2, type: "phase", at: "2026-05-29T00:00:01.000Z", name: "fetch-context" },
+    {
+      sequence: 3,
+      type: "task",
+      at: "2026-05-29T00:00:01.500Z",
+      stepId: "fetch-issue-context",
+      taskId: "task_context",
+      status: "completed",
+      title: "Fetch issue context",
+    },
+    { sequence: 4, type: "phase", at: "2026-05-29T00:00:03.000Z", name: "implementation" },
+    {
+      sequence: 5,
+      type: "task",
+      at: "2026-05-29T00:00:03.500Z",
+      stepId: "implement",
+      taskId: "task_implement",
+      status: "started",
+      title: "Implement nested slice",
+    },
+  ],
+  steps: [
+    {
+      stepId: "fetch-issue-context",
+      inputHash: "sha256:context",
+      status: "completed",
+      taskId: "task_context",
+      startedAt: "2026-05-29T00:00:01.500Z",
+      completedAt: "2026-05-29T00:00:02.500Z",
+      result: { reportMarkdown: "Fetched issue context." },
+    },
+    {
+      stepId: "implement",
+      inputHash: "sha256:implement",
+      status: "started",
+      taskId: "task_implement",
+      startedAt: "2026-05-29T00:00:03.500Z",
+    },
+  ],
+};
+
+const nestedParentRun: WorkflowRunRecord = {
+  id: "wfr_nested_parent_story",
+  workspaceId: "workspace-1",
+  workflow: {
+    name: "issue-implementation-loop",
+    description: "Issue implementation loop",
+    scope: "global",
+    requestedScriptPath: "skill://issue-implementation-loop/workflow.js",
+    canonicalScriptPath: "skill://issue-implementation-loop/workflow.js",
+    sourceKind: "skill",
+    sourceHash: "sha256:nested-parent",
+    executable: true,
+  },
+  source: "export default function workflow() { return null; }",
+  sourceHash: "sha256:nested-parent",
+  args: { repo: "coder/mux", issue: 3546, maxVerifierRuns: 1 },
+  status: "running",
+  createdAt: NOW,
+  updatedAt: "2026-05-29T00:00:04.000Z",
+  events: [
+    { sequence: 1, type: "status", at: NOW, status: "running" },
+    { sequence: 2, type: "phase", at: "2026-05-29T00:00:01.000Z", name: "implementation-loop" },
+    {
+      sequence: 3,
+      type: "workflow",
+      at: "2026-05-29T00:00:02.000Z",
+      stepId: "implementation-loop",
+      runId: nestedChildRun.id,
+      name: "implementation-loop",
+      status: "started",
+      details: { target: "coder/mux#3546" },
+    },
+  ],
+  steps: [
+    {
+      stepId: "implementation-loop",
+      inputHash: "sha256:nested-child-input",
+      status: "started",
+      startedAt: "2026-05-29T00:00:02.000Z",
+    },
+  ],
+};
+
+async function* subscribeWorkflowRuns(): AsyncGenerator<WorkflowRunStreamEvent> {
+  await Promise.resolve();
+  yield { type: "snapshot", runs: [nestedParentRun] };
+}
+
+const workflowApi = {
+  workflows: {
+    subscribe: () => subscribeWorkflowRuns(),
+    listScripts: () => Promise.resolve([]),
+    getRun: (input: { runId: string }) =>
+      Promise.resolve(input.runId === nestedChildRun.id ? nestedChildRun : nestedParentRun),
+    interrupt: () => Promise.resolve(nestedParentRun),
+    resume: () => Promise.resolve(nestedParentRun),
+    retryFromCheckpoint: () => Promise.resolve(nestedParentRun),
+    start: () => Promise.resolve({ runId: nestedParentRun.id, status: "running", result: null }),
+  },
+};
+
+export const NestedWorkflow: Story = {
+  args: { workspaceId: "workspace-1" },
+  render: (args) => (
+    <APIContext.Provider
+      value={{
+        status: "connected",
+        api: workflowApi as never,
+        error: null,
+        authenticate: () => undefined,
+        retry: () => undefined,
+      }}
+    >
+      <WorkflowsTab {...args} />
+    </APIContext.Provider>
+  ),
+};

--- a/src/browser/features/RightSidebar/Workflows/WorkflowsTab.tsx
+++ b/src/browser/features/RightSidebar/Workflows/WorkflowsTab.tsx
@@ -123,7 +123,7 @@ export const WorkflowsTab: React.FC<{ workspaceId: string }> = (props) => {
             view={view}
             onAfterAction={() => setOverrideRunId(null)}
           />
-          <WorkflowTimeline view={view} />
+          <WorkflowTimeline view={view} workspaceId={props.workspaceId} />
         </React.Fragment>
       )}
 

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
@@ -384,6 +384,11 @@ describe("projectWorkflowRun — non-task step events", () => {
     expect(view.steps.find((step) => step.stepId === "wf-1")?.phaseName).toBe("delegate");
     // Nested-workflow steps take their title from the child workflow name.
     expect(view.steps.find((step) => step.stepId === "wf-1")?.title).toBe("deep-research");
+    expect(view.steps.find((step) => step.stepId === "wf-1")).toMatchObject({
+      nestedWorkflowRunId: "wfr_child01",
+      nestedWorkflowName: "deep-research",
+      nestedWorkflowStatus: "started",
+    });
     // Patch steps may store the source task id for persistence/usage, but only direct task
     // events represent a child workspace created by that row.
     const patchStep = view.steps.find((step) => step.stepId === "patch-1");

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
@@ -422,7 +422,7 @@ describe("projectWorkflowRun — non-task step events", () => {
       {
         sequence: 4,
         type: "workflow",
-        at: at(11),
+        at: at(4),
         stepId: "wf-repeat",
         runId: "wfr_child_second",
         name: "implementation-loop",
@@ -441,10 +441,12 @@ describe("projectWorkflowRun — non-task step events", () => {
         stepId: "wf-repeat",
         inputHash: "h-second",
         status: "started",
-        startedAt: at(10),
+        startedAt: at(4),
       },
     ];
 
+    // The second child starts at the exact timestamp the first attempt completed; the end of
+    // a completed attempt must be exclusive so the older row does not steal the newer child.
     const view = projectWorkflowRun(makeRun({ events, steps }));
 
     expect(view.steps.map((step) => step.nestedWorkflowRunId)).toEqual([

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts
@@ -397,6 +397,62 @@ describe("projectWorkflowRun — non-task step events", () => {
     // Nothing falls into the implicit ungrouped bucket.
     expect(view.phases.some((phase) => phase.name === "")).toBe(false);
   });
+
+  test("assigns repeated nested workflow ids to their matching step attempts", () => {
+    const events: WorkflowRunEvent[] = [
+      { sequence: 1, type: "phase", at: at(1), name: "delegate" },
+      {
+        sequence: 2,
+        type: "workflow",
+        at: at(2),
+        stepId: "wf-repeat",
+        runId: "wfr_child_first",
+        name: "implementation-loop",
+        status: "started",
+      },
+      {
+        sequence: 3,
+        type: "workflow",
+        at: at(3),
+        stepId: "wf-repeat",
+        runId: "wfr_child_first",
+        name: "implementation-loop",
+        status: "completed",
+      },
+      {
+        sequence: 4,
+        type: "workflow",
+        at: at(11),
+        stepId: "wf-repeat",
+        runId: "wfr_child_second",
+        name: "implementation-loop",
+        status: "started",
+      },
+    ];
+    const steps: WorkflowStepRecord[] = [
+      {
+        stepId: "wf-repeat",
+        inputHash: "h-first",
+        status: "completed",
+        startedAt: at(1),
+        completedAt: at(4),
+      },
+      {
+        stepId: "wf-repeat",
+        inputHash: "h-second",
+        status: "started",
+        startedAt: at(10),
+      },
+    ];
+
+    const view = projectWorkflowRun(makeRun({ events, steps }));
+
+    expect(view.steps.map((step) => step.nestedWorkflowRunId)).toEqual([
+      "wfr_child_first",
+      "wfr_child_second",
+    ]);
+    expect(view.steps.map((step) => step.nestedWorkflowStatus)).toEqual(["completed", "started"]);
+  });
 });
 
 describe("projectWorkflowRun — title & result fallbacks", () => {

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
@@ -55,6 +55,10 @@ export interface WorkflowStepView {
   error?: string;
   /** Optional usage overlay resolved from the step's task workspace. */
   usage?: WorkflowStepUsage;
+  /** Nested workflow run spawned by this step, when the step delegates to another workflow. */
+  nestedWorkflowRunId?: string;
+  nestedWorkflowName?: string;
+  nestedWorkflowStatus?: Extract<WorkflowRunEvent, { type: "workflow" }>["status"];
 }
 
 export interface WorkflowPhaseView {
@@ -242,6 +246,10 @@ export function projectWorkflowRun(
   const stepFirstEventSeq = new Map<string, number>();
   const stepTitle = new Map<string, string>();
   const stepTaskEventIds = new Map<string, Set<string>>();
+  const stepNestedWorkflowEvents = new Map<
+    string,
+    Extract<WorkflowRunEvent, { type: "workflow" }>
+  >();
   for (const event of events) {
     const stepId = stepBearingEventStepId(event);
     if (stepId == null) {
@@ -257,6 +265,11 @@ export function projectWorkflowRun(
       } else {
         stepTaskEventIds.set(stepId, new Set([event.taskId]));
       }
+    }
+    if (event.type === "workflow") {
+      // Keep the latest event for the row so the sidebar can show the current nested-run status
+      // and fetch the child run at the exact point where the parent delegated to it.
+      stepNestedWorkflowEvents.set(stepId, event);
     }
     if (!stepTitle.has(stepId)) {
       if (event.type === "task" && event.title != null && event.title.length > 0) {
@@ -295,6 +308,7 @@ export function projectWorkflowRun(
       step.taskId != null && stepTaskEventIds.get(step.stepId)?.has(step.taskId) === true
         ? step.taskId
         : undefined;
+    const nestedWorkflowEvent = stepNestedWorkflowEvents.get(step.stepId);
     return {
       stepId: step.stepId,
       taskId: step.taskId,
@@ -308,6 +322,9 @@ export function projectWorkflowRun(
       result: step.result,
       error: step.error,
       usage,
+      nestedWorkflowRunId: nestedWorkflowEvent?.runId,
+      nestedWorkflowName: nestedWorkflowEvent?.name,
+      nestedWorkflowStatus: nestedWorkflowEvent?.status,
     };
   });
 

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
@@ -214,6 +214,63 @@ function stepBearingEventStepId(event: WorkflowRunEvent): string | null {
   }
 }
 
+type WorkflowChildEvent = Extract<WorkflowRunEvent, { type: "workflow" }>;
+
+interface WorkflowChildAttempt {
+  firstEvent: WorkflowChildEvent;
+  latestEvent: WorkflowChildEvent;
+}
+
+function getWorkflowChildAttempts(events: readonly WorkflowRunEvent[]): WorkflowChildAttempt[] {
+  const attempts: WorkflowChildAttempt[] = [];
+  const attemptsByKey = new Map<string, WorkflowChildAttempt>();
+  for (const event of events) {
+    if (event.type !== "workflow") {
+      continue;
+    }
+    const key = `${event.stepId}:${event.runId}`;
+    const existing = attemptsByKey.get(key);
+    if (existing != null) {
+      existing.latestEvent = event;
+      continue;
+    }
+    const attempt = { firstEvent: event, latestEvent: event };
+    attemptsByKey.set(key, attempt);
+    attempts.push(attempt);
+  }
+  return attempts;
+}
+
+function workflowChildAttemptOverlapsStep(
+  attempt: WorkflowChildAttempt,
+  step: WorkflowRunRecord["steps"][number]
+): boolean {
+  const childStartedAt = parseTime(attempt.firstEvent.at);
+  const stepStartedAt = parseTime(step.startedAt);
+  const stepCompletedAt =
+    step.completedAt != null ? parseTime(step.completedAt) : Number.POSITIVE_INFINITY;
+  return childStartedAt >= stepStartedAt && childStartedAt <= stepCompletedAt;
+}
+
+function findNestedWorkflowAttemptForStep(
+  step: WorkflowRunRecord["steps"][number],
+  attempts: readonly WorkflowChildAttempt[]
+): WorkflowChildAttempt | null {
+  const matchingAttempts = attempts.filter(
+    (attempt) =>
+      attempt.firstEvent.stepId === step.stepId && workflowChildAttemptOverlapsStep(attempt, step)
+  );
+  if (matchingAttempts.length > 0) {
+    return (
+      [...matchingAttempts].sort((a, b) => b.latestEvent.sequence - a.latestEvent.sequence)[0] ??
+      null
+    );
+  }
+
+  const sameStepAttempts = attempts.filter((attempt) => attempt.firstEvent.stepId === step.stepId);
+  return sameStepAttempts.length === 1 ? (sameStepAttempts[0] ?? null) : null;
+}
+
 export function projectWorkflowRun(
   run: WorkflowRunRecord,
   options: ProjectWorkflowRunOptions = {}
@@ -246,10 +303,7 @@ export function projectWorkflowRun(
   const stepFirstEventSeq = new Map<string, number>();
   const stepTitle = new Map<string, string>();
   const stepTaskEventIds = new Map<string, Set<string>>();
-  const stepNestedWorkflowEvents = new Map<
-    string,
-    Extract<WorkflowRunEvent, { type: "workflow" }>
-  >();
+  const nestedWorkflowAttempts = getWorkflowChildAttempts(events);
   for (const event of events) {
     const stepId = stepBearingEventStepId(event);
     if (stepId == null) {
@@ -265,11 +319,6 @@ export function projectWorkflowRun(
       } else {
         stepTaskEventIds.set(stepId, new Set([event.taskId]));
       }
-    }
-    if (event.type === "workflow") {
-      // Keep the latest event for the row so the sidebar can show the current nested-run status
-      // and fetch the child run at the exact point where the parent delegated to it.
-      stepNestedWorkflowEvents.set(stepId, event);
     }
     if (!stepTitle.has(stepId)) {
       if (event.type === "task" && event.title != null && event.title.length > 0) {
@@ -308,7 +357,10 @@ export function projectWorkflowRun(
       step.taskId != null && stepTaskEventIds.get(step.stepId)?.has(step.taskId) === true
         ? step.taskId
         : undefined;
-    const nestedWorkflowEvent = stepNestedWorkflowEvents.get(step.stepId);
+    const nestedWorkflowEvent = findNestedWorkflowAttemptForStep(
+      step,
+      nestedWorkflowAttempts
+    )?.latestEvent;
     return {
       stepId: step.stepId,
       taskId: step.taskId,

--- a/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
+++ b/src/browser/features/RightSidebar/Workflows/projectWorkflowRun.ts
@@ -249,7 +249,7 @@ function workflowChildAttemptOverlapsStep(
   const stepStartedAt = parseTime(step.startedAt);
   const stepCompletedAt =
     step.completedAt != null ? parseTime(step.completedAt) : Number.POSITIVE_INFINITY;
-  return childStartedAt >= stepStartedAt && childStartedAt <= stepCompletedAt;
+  return childStartedAt >= stepStartedAt && childStartedAt < stepCompletedAt;
 }
 
 function findNestedWorkflowAttemptForStep(

--- a/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.stories.tsx
@@ -447,6 +447,178 @@ export const RunningBackgroundWithRun: Story = {
   },
 };
 
+const nestedChildRun: WorkflowRunRecord = {
+  id: "wfr_child_story",
+  workspaceId: "workspace-1",
+  workflow: {
+    name: "implementation-loop",
+    description: "Implementation loop",
+    scope: "global" as const,
+    requestedScriptPath: "skill://implementation-loop/workflow.js",
+    canonicalScriptPath: "skill://implementation-loop/workflow.js",
+    sourceKind: "skill" as const,
+    sourceHash: "sha256:nested-child",
+    executable: true,
+  },
+  source: "export default function workflow() { return null; }",
+  sourceHash: "sha256:nested-child",
+  args: { target: "coder/mux#3546" },
+  parentWorkflow: {
+    runId: "wfr_nested_parent_story",
+    stepId: "implementation-loop",
+    inputHash: "sha256:nested-child-input",
+    depth: 0,
+  },
+  status: "running" as const,
+  createdAt: "2026-05-29T00:00:00.000Z",
+  updatedAt: "2026-05-29T00:00:04.000Z",
+  events: [
+    {
+      sequence: 1,
+      type: "status" as const,
+      at: "2026-05-29T00:00:00.000Z",
+      status: "running" as const,
+    },
+    { sequence: 2, type: "phase" as const, at: "2026-05-29T00:00:01.000Z", name: "fetch-context" },
+    {
+      sequence: 3,
+      type: "task" as const,
+      at: "2026-05-29T00:00:01.500Z",
+      stepId: "fetch-issue-context",
+      taskId: "task_context",
+      status: "completed",
+      title: "Fetch issue context",
+    },
+    { sequence: 4, type: "phase" as const, at: "2026-05-29T00:00:03.000Z", name: "implementation" },
+    {
+      sequence: 5,
+      type: "task" as const,
+      at: "2026-05-29T00:00:03.500Z",
+      stepId: "implement",
+      taskId: "task_implement",
+      status: "started",
+      title: "Implement nested slice",
+    },
+  ],
+  steps: [
+    {
+      stepId: "fetch-issue-context",
+      inputHash: "sha256:context",
+      status: "completed" as const,
+      taskId: "task_context",
+      startedAt: "2026-05-29T00:00:01.500Z",
+      completedAt: "2026-05-29T00:00:02.500Z",
+      result: { reportMarkdown: "Fetched issue context." },
+    },
+    {
+      stepId: "implement",
+      inputHash: "sha256:implement",
+      status: "started" as const,
+      taskId: "task_implement",
+      startedAt: "2026-05-29T00:00:03.500Z",
+    },
+  ],
+};
+
+const nestedParentRun: WorkflowRunRecord = {
+  id: "wfr_nested_parent_story",
+  workspaceId: "workspace-1",
+  workflow: {
+    name: "issue-implementation-loop",
+    description: "Issue implementation loop",
+    scope: "global" as const,
+    requestedScriptPath: "skill://issue-implementation-loop/workflow.js",
+    canonicalScriptPath: "skill://issue-implementation-loop/workflow.js",
+    sourceKind: "skill" as const,
+    sourceHash: "sha256:nested-parent",
+    executable: true,
+  },
+  source: "export default function workflow() { return null; }",
+  sourceHash: "sha256:nested-parent",
+  args: { issue: 3546 },
+  status: "running" as const,
+  createdAt: "2026-05-29T00:00:00.000Z",
+  updatedAt: "2026-05-29T00:00:04.000Z",
+  events: [
+    {
+      sequence: 1,
+      type: "status" as const,
+      at: "2026-05-29T00:00:00.000Z",
+      status: "running" as const,
+    },
+    {
+      sequence: 2,
+      type: "phase" as const,
+      at: "2026-05-29T00:00:01.000Z",
+      name: "implementation-loop",
+    },
+    {
+      sequence: 3,
+      type: "workflow" as const,
+      at: "2026-05-29T00:00:02.000Z",
+      stepId: "implementation-loop",
+      runId: "wfr_child_story",
+      name: "implementation-loop",
+      status: "started",
+      details: { target: "coder/mux#3546" },
+    },
+  ],
+  steps: [
+    {
+      stepId: "implementation-loop",
+      inputHash: "sha256:nested-child-input",
+      status: "started" as const,
+      startedAt: "2026-05-29T00:00:02.000Z",
+    },
+  ],
+};
+
+const nestedWorkflowProps = {
+  args: {
+    script_path: "skill://issue-implementation-loop/workflow.js",
+    args: { issue: 3546 },
+    run_in_background: false,
+  },
+  status: "executing" as const,
+  result: {
+    status: "running" as const,
+    runId: nestedParentRun.id,
+    result: null,
+    run: nestedParentRun,
+  },
+} satisfies Parameters<typeof WorkflowRunToolCall>[0];
+
+function NestedWorkflowAPIProvider(props: { children: ReactNode }) {
+  const api = {
+    workflows: {
+      getRun: (input: { runId: string }) =>
+        Promise.resolve(input.runId === nestedChildRun.id ? nestedChildRun : nestedParentRun),
+    },
+  };
+  return (
+    <APIContext.Provider
+      value={{
+        status: "connected",
+        api: api as never,
+        error: null,
+        authenticate: () => undefined,
+        retry: () => undefined,
+      }}
+    >
+      {props.children}
+    </APIContext.Provider>
+  );
+}
+
+export const NestedWorkflow: Story = {
+  render: (args) => (
+    <NestedWorkflowAPIProvider>
+      <WorkflowRunToolCall {...nestedWorkflowProps} {...args} />
+    </NestedWorkflowAPIProvider>
+  ),
+  args: nestedWorkflowProps,
+};
+
 export const WorkspaceFileCompleted: Story = {
   args: {
     args: {

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "react";
 
 import { APIContext } from "@/browser/contexts/API";
+import type { WorkflowRunRecord } from "@/common/types/workflow";
 import type { FrontendWorkspaceMetadata } from "@/common/types/workspace";
 import {
   CommandRegistryProvider,
@@ -496,6 +497,114 @@ describe("WorkflowRunToolCall", () => {
       renderedText.indexOf("Workflow result body")
     );
     expect(renderedText).toContain("confidence");
+  });
+
+  test("inlines nested workflow progress in workflow event rows", async () => {
+    const timestamp = "2026-05-29T00:00:00.000Z";
+    const childRun: WorkflowRunRecord = {
+      id: "wfr_child01",
+      workspaceId: "workspace-1",
+      workflow: {
+        name: "implementation-loop",
+        description: "Implementation loop",
+        scope: "global",
+        requestedScriptPath: "skill://implementation-loop/workflow.js",
+        canonicalScriptPath: "skill://implementation-loop/workflow.js",
+        sourceKind: "skill",
+        sourceHash: "sha256:child",
+        executable: true,
+      },
+      source: "export default function workflow() { return null; }",
+      sourceHash: "sha256:child",
+      args: { target: "coder/mux#3546" },
+      parentWorkflow: {
+        runId: "wfr_parent01",
+        stepId: "implementation-loop",
+        inputHash: "hash-child",
+        depth: 0,
+      },
+      status: "running",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      events: [
+        { sequence: 1, type: "status", at: timestamp, status: "running" },
+        { sequence: 2, type: "phase", at: timestamp, name: "child-phase" },
+      ],
+      steps: [],
+    };
+    const requestedRunIds: string[] = [];
+    const client = {
+      workflows: {
+        getRun: async (input: { runId: string }) => {
+          requestedRunIds.push(input.runId);
+          return childRun;
+        },
+      },
+    };
+
+    const view = renderWithStickyToolProviders(
+      <APIHarness client={client}>
+        <WorkflowRunToolCall
+          args={{
+            name: "issue-implementation-loop",
+            args: { issue: 3546 },
+            run_in_background: false,
+          }}
+          status="executing"
+          result={{
+            status: "running",
+            runId: "wfr_parent01",
+            result: null,
+            run: {
+              id: "wfr_parent01",
+              workspaceId: "workspace-1",
+              workflow: {
+                name: "issue-implementation-loop",
+                description: "Issue loop",
+                scope: "global",
+                requestedScriptPath: "skill://issue-implementation-loop/workflow.js",
+                canonicalScriptPath: "skill://issue-implementation-loop/workflow.js",
+                sourceKind: "skill",
+                sourceHash: "sha256:parent",
+                executable: true,
+              },
+              source: "export default function workflow() { return null; }",
+              sourceHash: "sha256:parent",
+              args: { issue: 3546 },
+              status: "running",
+              createdAt: timestamp,
+              updatedAt: timestamp,
+              events: [
+                { sequence: 1, type: "phase", at: timestamp, name: "delegate" },
+                {
+                  sequence: 2,
+                  type: "workflow",
+                  at: timestamp,
+                  stepId: "implementation-loop",
+                  runId: "wfr_child01",
+                  name: "implementation-loop",
+                  status: "started",
+                },
+              ],
+              steps: [
+                {
+                  stepId: "implementation-loop",
+                  inputHash: "hash-child",
+                  status: "started",
+                  startedAt: timestamp,
+                },
+              ],
+            },
+          }}
+        />
+      </APIHarness>
+    );
+
+    await waitFor(() => {
+      expect(view.getByText("child-phase")).toBeTruthy();
+    });
+    expect(requestedRunIds).toContain("wfr_child01");
+    expect(view.container.textContent).toContain("running · 0/0 steps · child-phase");
   });
 
   test("coalesces task attempts, navigates active rows, expands completed outputs, opens workspaces, and opens reports", async () => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -607,6 +607,89 @@ describe("WorkflowRunToolCall", () => {
     expect(view.container.textContent).toContain("running · 0/0 steps · child-phase");
   });
 
+  test("refreshes a collapsed terminal workflow row when the child run is active again", async () => {
+    const timestamp = "2026-05-29T00:00:00.000Z";
+    const retriedChildRun: WorkflowRunRecord = {
+      id: "wfr_retried_child",
+      workspaceId: "workspace-1",
+      workflow: {
+        name: "implementation-loop",
+        description: "Implementation loop",
+        scope: "global",
+        requestedScriptPath: "skill://implementation-loop/workflow.js",
+        canonicalScriptPath: "skill://implementation-loop/workflow.js",
+        sourceKind: "skill",
+        sourceHash: "sha256:child",
+        executable: true,
+      },
+      source: "export default function workflow() { return null; }",
+      sourceHash: "sha256:child",
+      args: {},
+      status: "running",
+      createdAt: timestamp,
+      updatedAt: "2026-05-29T00:00:01.000Z",
+      events: [{ sequence: 1, type: "status", at: timestamp, status: "running" }],
+      steps: [],
+    };
+    const client = {
+      workflows: {
+        getRun: () => Promise.resolve(retriedChildRun),
+      },
+    };
+
+    const view = renderWithStickyToolProviders(
+      <APIHarness client={client}>
+        <WorkflowRunToolCall
+          args={{ name: "issue-implementation-loop", args: {}, run_in_background: false }}
+          status="completed"
+          result={{
+            status: "running",
+            runId: "wfr_parent_retried_child",
+            result: null,
+            run: {
+              id: "wfr_parent_retried_child",
+              workspaceId: "workspace-1",
+              workflow: {
+                name: "issue-implementation-loop",
+                description: "Issue loop",
+                scope: "global",
+                requestedScriptPath: "skill://issue-implementation-loop/workflow.js",
+                canonicalScriptPath: "skill://issue-implementation-loop/workflow.js",
+                sourceKind: "skill",
+                sourceHash: "sha256:parent",
+                executable: true,
+              },
+              source: "export default function workflow() { return null; }",
+              sourceHash: "sha256:parent",
+              args: {},
+              status: "running",
+              createdAt: timestamp,
+              updatedAt: timestamp,
+              events: [
+                {
+                  sequence: 1,
+                  type: "workflow",
+                  at: timestamp,
+                  stepId: "implementation-loop",
+                  runId: "wfr_retried_child",
+                  name: "implementation-loop",
+                  status: "failed",
+                },
+              ],
+              steps: [],
+            },
+          }}
+        />
+      </APIHarness>
+    );
+
+    await waitFor(() => {
+      expect(
+        view.getByText("implementation-loop / implementation-loop / wfr_retried_child / running")
+      ).toBeTruthy();
+    });
+  });
+
   test("keeps workflow event details visible when a nested run is unavailable", async () => {
     const timestamp = "2026-05-29T00:00:00.000Z";
     const client = {

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -607,6 +607,69 @@ describe("WorkflowRunToolCall", () => {
     expect(view.container.textContent).toContain("running · 0/0 steps · child-phase");
   });
 
+  test("does not fetch collapsed terminal child rows after the parent run is terminal", async () => {
+    const timestamp = "2026-05-29T00:00:00.000Z";
+    let getRunCount = 0;
+    const client = {
+      workflows: {
+        getRun: () => {
+          getRunCount += 1;
+          return Promise.resolve(null);
+        },
+      },
+    };
+
+    renderWithStickyToolProviders(
+      <APIHarness client={client}>
+        <WorkflowRunToolCall
+          args={{ name: "issue-implementation-loop", args: {}, run_in_background: false }}
+          status="interrupted"
+          result={{
+            status: "interrupted",
+            runId: "wfr_parent_terminal_child",
+            result: null,
+            run: {
+              id: "wfr_parent_terminal_child",
+              workspaceId: "workspace-1",
+              workflow: {
+                name: "issue-implementation-loop",
+                description: "Issue loop",
+                scope: "global",
+                requestedScriptPath: "skill://issue-implementation-loop/workflow.js",
+                canonicalScriptPath: "skill://issue-implementation-loop/workflow.js",
+                sourceKind: "skill",
+                sourceHash: "sha256:parent",
+                executable: true,
+              },
+              source: "export default function workflow() { return null; }",
+              sourceHash: "sha256:parent",
+              args: {},
+              status: "interrupted",
+              createdAt: timestamp,
+              updatedAt: timestamp,
+              events: [
+                {
+                  sequence: 1,
+                  type: "workflow",
+                  at: timestamp,
+                  stepId: "implementation-loop",
+                  runId: "wfr_terminal_child",
+                  name: "implementation-loop",
+                  status: "failed",
+                },
+              ],
+              steps: [],
+            },
+          }}
+        />
+      </APIHarness>
+    );
+
+    await Promise.resolve();
+
+    expect(getRunCount).toBe(0);
+  });
+
   test("refreshes a collapsed terminal workflow row when the child run is active again", async () => {
     const timestamp = "2026-05-29T00:00:00.000Z";
     const retriedChildRun: WorkflowRunRecord = {

--- a/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.test.tsx
@@ -607,6 +607,80 @@ describe("WorkflowRunToolCall", () => {
     expect(view.container.textContent).toContain("running · 0/0 steps · child-phase");
   });
 
+  test("keeps workflow event details visible when a nested run is unavailable", async () => {
+    const timestamp = "2026-05-29T00:00:00.000Z";
+    const client = {
+      workflows: {
+        getRun: () => Promise.resolve(null),
+      },
+    };
+
+    const view = renderWithStickyToolProviders(
+      <APIHarness client={client}>
+        <WorkflowRunToolCall
+          args={{
+            name: "issue-implementation-loop",
+            args: { issue: 3546 },
+            run_in_background: false,
+          }}
+          status="executing"
+          result={{
+            status: "running",
+            runId: "wfr_parent_missing_child",
+            result: null,
+            run: {
+              id: "wfr_parent_missing_child",
+              workspaceId: "workspace-1",
+              workflow: {
+                name: "issue-implementation-loop",
+                description: "Issue loop",
+                scope: "global",
+                requestedScriptPath: "skill://issue-implementation-loop/workflow.js",
+                canonicalScriptPath: "skill://issue-implementation-loop/workflow.js",
+                sourceKind: "skill",
+                sourceHash: "sha256:parent",
+                executable: true,
+              },
+              source: "export default function workflow() { return null; }",
+              sourceHash: "sha256:parent",
+              args: { issue: 3546 },
+              status: "running",
+              createdAt: timestamp,
+              updatedAt: timestamp,
+              events: [
+                { sequence: 1, type: "phase", at: timestamp, name: "delegate" },
+                {
+                  sequence: 2,
+                  type: "workflow",
+                  at: timestamp,
+                  stepId: "implementation-loop",
+                  runId: "wfr_missing_child",
+                  name: "implementation-loop",
+                  status: "started",
+                  details: { error: "child run metadata missing" },
+                },
+              ],
+              steps: [
+                {
+                  stepId: "implementation-loop",
+                  inputHash: "hash-child",
+                  status: "started",
+                  startedAt: timestamp,
+                },
+              ],
+            },
+          }}
+        />
+      </APIHarness>
+    );
+
+    await waitFor(() => {
+      expect(view.getByText("Nested workflow run is not available.")).toBeTruthy();
+    });
+    expect(view.container.textContent).toContain("Workflow event details");
+    expect(view.container.textContent).toContain("child run metadata missing");
+  });
+
   test("coalesces task attempts, navigates active rows, expands completed outputs, opens workspaces, and opens reports", async () => {
     const navigatedTo: string[] = [];
     useWorkspaceStoreRaw().setNavigateToWorkspace((workspaceId) => {

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -643,6 +643,18 @@ function WorkflowEventRow(props: {
   );
 }
 
+function WorkflowChildEventDetailBlock(props: { detail: unknown }) {
+  if (props.detail === undefined) {
+    return null;
+  }
+  return (
+    <div className="mt-2 space-y-1">
+      <div className="text-muted text-[10px] tracking-wide uppercase">Workflow event details</div>
+      <WorkflowJsonBlock value={props.detail} className="max-h-[180px]" />
+    </div>
+  );
+}
+
 function WorkflowChildRunRow(props: {
   row: WorkflowChildDisplayRow;
   displayIndex: number;
@@ -669,6 +681,7 @@ function WorkflowChildRunRow(props: {
   const childActive =
     childRun != null ? isActiveWorkflowRunStatus(childRun.status) : fallbackActive;
   const progressSummary = getWorkflowChildProgressSummary(childRun);
+  const fallbackDetail = getWorkflowMergedRowDetail(props.row);
   const label = `${event.stepId} / ${event.name} / ${event.runId} / ${childStatus}`;
 
   return (
@@ -721,7 +734,10 @@ function WorkflowChildRunRow(props: {
               Nested workflow depth limit reached; showing summary only.
             </div>
           ) : childRunState.error != null ? (
-            <ErrorBox className="mt-2">{childRunState.error}</ErrorBox>
+            <>
+              <ErrorBox className="mt-2">{childRunState.error}</ErrorBox>
+              <WorkflowChildEventDetailBlock detail={fallbackDetail} />
+            </>
           ) : childRunState.loading && childRun == null ? (
             <div className="text-muted mt-2 text-[11px]">Loading nested workflow…</div>
           ) : childRun != null && childView != null ? (
@@ -733,7 +749,12 @@ function WorkflowChildRunRow(props: {
               />
             </div>
           ) : (
-            <div className="text-muted mt-2 text-[11px]">Nested workflow run is not available.</div>
+            <>
+              <div className="text-muted mt-2 text-[11px]">
+                Nested workflow run is not available.
+              </div>
+              <WorkflowChildEventDetailBlock detail={fallbackDetail} />
+            </>
           )}
         </div>
       </details>

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -675,6 +675,7 @@ function WorkflowChildRunRow(props: {
     workspaceId: props.workspaceId,
     runId: event.runId,
     enabled: props.workspaceId != null && withinDepthLimit,
+    pollAfterTerminal: true,
     pollWhileActive: true,
   });
   const childRun = childRunState.run;

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -669,11 +669,13 @@ function WorkflowChildRunRow(props: {
   );
   const withinDepthLimit = props.depth < MAX_TOOL_INLINE_NESTED_WORKFLOW_DEPTH;
   const fallbackActive = isWorkflowChildEventActive(event.status);
+  // Fetch even for collapsed terminal-looking rows: checkpoint retries reuse the child run id and
+  // may not emit another parent started event, so the durable child record is the source of truth.
   const childRunState = useWorkflowRunById({
     workspaceId: props.workspaceId,
     runId: event.runId,
-    enabled: props.workspaceId != null && withinDepthLimit && (open || fallbackActive),
-    pollWhileActive: fallbackActive,
+    enabled: props.workspaceId != null && withinDepthLimit,
+    pollWhileActive: true,
   });
   const childRun = childRunState.run;
   const childView = childRun != null ? projectWorkflowRun(childRun) : null;

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -660,6 +660,7 @@ function WorkflowChildRunRow(props: {
   displayIndex: number;
   workspaceId?: string;
   depth: number;
+  parentRunActive: boolean;
 }) {
   const event = props.row.latestEvent;
   const [open, setOpen] = useState(
@@ -669,13 +670,15 @@ function WorkflowChildRunRow(props: {
   );
   const withinDepthLimit = props.depth < MAX_TOOL_INLINE_NESTED_WORKFLOW_DEPTH;
   const fallbackActive = isWorkflowChildEventActive(event.status);
-  // Fetch even for collapsed terminal-looking rows: checkpoint retries reuse the child run id and
-  // may not emit another parent started event, so the durable child record is the source of truth.
+  const shouldPollChildRun = open || fallbackActive || props.parentRunActive;
+  // Fetch collapsed terminal-looking rows while the parent run is active: checkpoint retries reuse
+  // the child run id and may not emit another parent started event. Once the parent is terminal,
+  // collapsed terminal rows stop polling unless the user expands them.
   const childRunState = useWorkflowRunById({
     workspaceId: props.workspaceId,
     runId: event.runId,
-    enabled: props.workspaceId != null && withinDepthLimit,
-    pollAfterTerminal: true,
+    enabled: props.workspaceId != null && withinDepthLimit && shouldPollChildRun,
+    pollAfterTerminal: shouldPollChildRun,
     pollWhileActive: true,
   });
   const childRun = childRunState.run;
@@ -1099,6 +1102,10 @@ function getLatestResultEvent(run: WorkflowRunRecord | null | undefined): unknow
   return run?.events.findLast((event) => event.type === "result")?.result;
 }
 
+function isWorkflowDisplayStatusActive(status: string): boolean {
+  return status === "pending" || status === "running" || status === "backgrounded";
+}
+
 function shouldRefreshWorkflow(status: string): boolean {
   return REFRESHING_WORKFLOW_STATUSES.has(status);
 }
@@ -1168,6 +1175,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
     successResult?.run == null && successResult?.status != null && !hasRefreshedRunSnapshot
       ? successResult.status
       : (run?.status ?? successResult?.status ?? status);
+  const parentRunActive = isWorkflowDisplayStatusActive(displayStatus);
   const displayEventSequence = getLatestWorkflowEventSequence(run);
   const resultValue = successResult?.result ?? getLatestResultEvent(run);
   const reportMarkdown = getReportMarkdown(resultValue);
@@ -1576,6 +1584,7 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                           row={row}
                           displayIndex={index + 1}
                           workspaceId={run?.workspaceId ?? workspaceId}
+                          parentRunActive={parentRunActive}
                           depth={0}
                         />
                       );

--- a/src/browser/features/Tools/WorkflowRunToolCall.tsx
+++ b/src/browser/features/Tools/WorkflowRunToolCall.tsx
@@ -16,10 +16,14 @@ import {
 } from "@/browser/contexts/CommandRegistryContext";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
 import { STRUCTURED_WORKFLOW_REPORT_PLACEHOLDER_MARKDOWN } from "@/common/constants/workflowReports";
-import type {
-  WorkflowRunEvent,
-  WorkflowRunRecord,
-  WorkflowStepRecord,
+import { WorkflowTimeline } from "@/browser/features/RightSidebar/Workflows/WorkflowTimeline";
+import { projectWorkflowRun } from "@/browser/features/RightSidebar/Workflows/projectWorkflowRun";
+import { useWorkflowRunById } from "@/browser/hooks/useWorkflowRunById";
+import {
+  isActiveWorkflowRunStatus,
+  type WorkflowRunEvent,
+  type WorkflowRunRecord,
+  type WorkflowStepRecord,
 } from "@/common/types/workflow";
 import type {
   WorkflowResumeToolArgs,
@@ -242,8 +246,25 @@ type WorkflowDisplayRow =
   | { kind: "patch"; firstEvent: WorkflowPatchEvent; latestEvent: WorkflowPatchEvent };
 
 type WorkflowTaskRow = Extract<WorkflowDisplayRow, { kind: "task" }>;
-type WorkflowChildRow = Extract<WorkflowDisplayRow, { kind: "workflow" }>;
+type WorkflowChildDisplayRow = Extract<WorkflowDisplayRow, { kind: "workflow" }>;
 type WorkflowPatchRow = Extract<WorkflowDisplayRow, { kind: "patch" }>;
+
+const MAX_TOOL_INLINE_NESTED_WORKFLOW_DEPTH = 3;
+
+function isWorkflowChildEventActive(status: WorkflowChildEvent["status"]): boolean {
+  return status === "started" || status === "running" || status === "backgrounded";
+}
+
+function getWorkflowChildProgressSummary(run: WorkflowRunRecord | null): string | null {
+  if (run == null) {
+    return null;
+  }
+  const view = projectWorkflowRun(run);
+  const activePhase = view.phases.find((phase) => phase.running) ?? view.phases.at(-1);
+  const phaseLabel =
+    activePhase != null && activePhase.label.length > 0 ? ` · ${activePhase.label}` : "";
+  return `${view.status} · ${view.stats.done}/${view.stats.total} steps${phaseLabel}`;
+}
 
 function getTaskEventKey(event: WorkflowTaskEvent): string {
   return `task:${event.stepId}:${event.taskId}`;
@@ -259,7 +280,7 @@ function getPatchEventKey(event: WorkflowPatchEvent): string {
 function getWorkflowDisplayRows(events: readonly WorkflowRunEvent[]): WorkflowDisplayRow[] {
   const rows: WorkflowDisplayRow[] = [];
   const taskRows = new Map<string, WorkflowTaskRow>();
-  const workflowRows = new Map<string, WorkflowChildRow>();
+  const workflowRows = new Map<string, WorkflowChildDisplayRow>();
   const patchRows = new Map<string, WorkflowPatchRow>();
 
   for (const event of events) {
@@ -292,7 +313,7 @@ function getWorkflowDisplayRows(events: readonly WorkflowRunEvent[]): WorkflowDi
         continue;
       }
 
-      const row: WorkflowChildRow = {
+      const row: WorkflowChildDisplayRow = {
         kind: "workflow",
         firstEvent: event,
         latestEvent: event,
@@ -538,7 +559,7 @@ function WorkflowEventTooltip(props: {
   );
 }
 
-function getWorkflowMergedRowDetail(row: WorkflowChildRow | WorkflowPatchRow): unknown {
+function getWorkflowMergedRowDetail(row: WorkflowChildDisplayRow | WorkflowPatchRow): unknown {
   const firstDetail = getWorkflowEventDetail(row.firstEvent);
   const latestDetail = getWorkflowEventDetail(row.latestEvent);
   if (row.firstEvent === row.latestEvent || row.latestEvent.status === "started") {
@@ -617,6 +638,104 @@ function WorkflowEventRow(props: {
         ) : (
           <WorkflowJsonBlock value={detail} className="mx-2 mb-2 max-h-[140px]" />
         )}
+      </details>
+    </li>
+  );
+}
+
+function WorkflowChildRunRow(props: {
+  row: WorkflowChildDisplayRow;
+  displayIndex: number;
+  workspaceId?: string;
+  depth: number;
+}) {
+  const event = props.row.latestEvent;
+  const [open, setOpen] = useState(
+    () =>
+      props.depth < MAX_TOOL_INLINE_NESTED_WORKFLOW_DEPTH &&
+      isWorkflowChildEventActive(event.status)
+  );
+  const withinDepthLimit = props.depth < MAX_TOOL_INLINE_NESTED_WORKFLOW_DEPTH;
+  const fallbackActive = isWorkflowChildEventActive(event.status);
+  const childRunState = useWorkflowRunById({
+    workspaceId: props.workspaceId,
+    runId: event.runId,
+    enabled: props.workspaceId != null && withinDepthLimit && (open || fallbackActive),
+    pollWhileActive: fallbackActive,
+  });
+  const childRun = childRunState.run;
+  const childView = childRun != null ? projectWorkflowRun(childRun) : null;
+  const childStatus = childRun?.status ?? event.status;
+  const childActive =
+    childRun != null ? isActiveWorkflowRunStatus(childRun.status) : fallbackActive;
+  const progressSummary = getWorkflowChildProgressSummary(childRun);
+  const label = `${event.stepId} / ${event.name} / ${event.runId} / ${childStatus}`;
+
+  return (
+    <li className="hover:bg-background/50">
+      <details
+        className="group"
+        open={open}
+        onToggle={(toggleEvent) => setOpen(toggleEvent.currentTarget.open)}
+      >
+        <summary className="cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+          <div className="border-plan-mode/70 bg-plan-mode-alpha grid grid-cols-[3rem_4.75rem_minmax(0,1fr)] items-center gap-2 border-l-2 px-2 py-1 text-[10px]">
+            <TooltipIfPresent
+              tooltip={
+                <WorkflowEventTooltip
+                  event={props.row.firstEvent}
+                  displayIndex={props.displayIndex}
+                  label={label}
+                />
+              }
+              side="top"
+              align="start"
+            >
+              <span
+                className="text-muted counter-nums-mono w-fit cursor-help"
+                aria-label={`Raw event #${props.row.firstEvent.sequence}`}
+              >
+                #{props.displayIndex}
+              </span>
+            </TooltipIfPresent>
+            <span className={`w-fit font-mono uppercase ${getEventTypeClass(event)}`}>
+              workflow
+            </span>
+            <span className="text-foreground flex min-w-0 items-center gap-1.5 truncate">
+              {childActive && <span className="bg-plan-mode h-1.5 w-1.5 shrink-0 rounded-full" />}
+              <span className="min-w-0 truncate">{label}</span>
+            </span>
+          </div>
+        </summary>
+        <div className="border-border bg-background/40 mx-2 mb-2 rounded border p-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 text-[10px]">
+            <span className="text-plan-mode font-medium">Nested workflow</span>
+            <span className="text-foreground font-medium">{event.name}</span>
+            <span className="text-muted counter-nums-mono min-w-0 truncate">{event.runId}</span>
+          </div>
+          {progressSummary != null && (
+            <div className="text-muted mt-1 text-[11px]">{progressSummary}</div>
+          )}
+          {!withinDepthLimit ? (
+            <div className="text-muted mt-2 text-[11px]">
+              Nested workflow depth limit reached; showing summary only.
+            </div>
+          ) : childRunState.error != null ? (
+            <ErrorBox className="mt-2">{childRunState.error}</ErrorBox>
+          ) : childRunState.loading && childRun == null ? (
+            <div className="text-muted mt-2 text-[11px]">Loading nested workflow…</div>
+          ) : childRun != null && childView != null ? (
+            <div className="border-border/70 mt-2 border-l pl-3">
+              <WorkflowTimeline
+                view={childView}
+                workspaceId={childRun.workspaceId}
+                nestedDepth={props.depth + 1}
+              />
+            </div>
+          ) : (
+            <div className="text-muted mt-2 text-[11px]">Nested workflow run is not available.</div>
+          )}
+        </div>
       </details>
     </li>
   );
@@ -1426,7 +1545,18 @@ export const WorkflowRunToolCall: React.FC<WorkflowRunToolCallProps> = ({
                         />
                       );
                     }
-                    if (row.kind === "workflow" || row.kind === "patch") {
+                    if (row.kind === "workflow") {
+                      return (
+                        <WorkflowChildRunRow
+                          key={getDisplayRowKey(row)}
+                          row={row}
+                          displayIndex={index + 1}
+                          workspaceId={run?.workspaceId ?? workspaceId}
+                          depth={0}
+                        />
+                      );
+                    }
+                    if (row.kind === "patch") {
                       return (
                         <WorkflowEventRow
                           key={getDisplayRowKey(row)}

--- a/src/browser/hooks/useWorkflowRunById.test.ts
+++ b/src/browser/hooks/useWorkflowRunById.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WorkflowRunRecord } from "@/common/types/workflow";
+import { getNewestWorkflowRunSnapshot } from "./useWorkflowRunById";
+
+function makeRun(input: {
+  status: WorkflowRunRecord["status"];
+  updatedAt: string;
+  sequence: number;
+}): WorkflowRunRecord {
+  return {
+    id: "wfr_child",
+    workspaceId: "workspace-1",
+    workflow: {
+      name: "implementation-loop",
+      description: "Implementation loop",
+      scope: "global",
+      executable: true,
+    },
+    source: "export default function workflow() { return null; }",
+    sourceHash: "sha256:test",
+    args: {},
+    status: input.status,
+    createdAt: "2026-06-26T00:00:00.000Z",
+    updatedAt: input.updatedAt,
+    events: [
+      {
+        sequence: input.sequence,
+        type: "status",
+        at: input.updatedAt,
+        status: input.status,
+      },
+    ],
+    steps: [],
+  };
+}
+
+describe("getNewestWorkflowRunSnapshot", () => {
+  test("keeps a terminal snapshot over a slower stale polling response", () => {
+    const terminal = makeRun({
+      status: "completed",
+      updatedAt: "2026-06-26T00:00:02.000Z",
+      sequence: 2,
+    });
+    const staleRunning = makeRun({
+      status: "running",
+      updatedAt: "2026-06-26T00:00:01.000Z",
+      sequence: 1,
+    });
+
+    expect(getNewestWorkflowRunSnapshot(terminal, staleRunning)).toBe(terminal);
+  });
+
+  test("uses event sequence when snapshots share an updatedAt timestamp", () => {
+    const older = makeRun({
+      status: "running",
+      updatedAt: "2026-06-26T00:00:02.000Z",
+      sequence: 2,
+    });
+    const newer = makeRun({
+      status: "completed",
+      updatedAt: "2026-06-26T00:00:02.000Z",
+      sequence: 3,
+    });
+
+    expect(getNewestWorkflowRunSnapshot(older, newer)).toBe(newer);
+  });
+});

--- a/src/browser/hooks/useWorkflowRunById.ts
+++ b/src/browser/hooks/useWorkflowRunById.ts
@@ -5,6 +5,43 @@ import { isActiveWorkflowRunStatus, type WorkflowRunRecord } from "@/common/type
 
 const WORKFLOW_RUN_REFRESH_INTERVAL_MS = 2_000;
 
+function getWorkflowRunTimestamp(value: string): number | null {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function getLatestWorkflowEventSequence(run: WorkflowRunRecord | null | undefined): number {
+  return run?.events.reduce((maxSequence, event) => Math.max(maxSequence, event.sequence), 0) ?? 0;
+}
+
+function compareWorkflowRunSnapshots(left: WorkflowRunRecord, right: WorkflowRunRecord): number {
+  const leftUpdatedAt = getWorkflowRunTimestamp(left.updatedAt);
+  const rightUpdatedAt = getWorkflowRunTimestamp(right.updatedAt);
+  if (leftUpdatedAt != null && rightUpdatedAt != null && leftUpdatedAt !== rightUpdatedAt) {
+    return leftUpdatedAt - rightUpdatedAt;
+  }
+  if (leftUpdatedAt != null && rightUpdatedAt == null) {
+    return 1;
+  }
+  if (leftUpdatedAt == null && rightUpdatedAt != null) {
+    return -1;
+  }
+  return getLatestWorkflowEventSequence(left) - getLatestWorkflowEventSequence(right);
+}
+
+export function getNewestWorkflowRunSnapshot(
+  current: WorkflowRunRecord | null,
+  next: WorkflowRunRecord | null
+): WorkflowRunRecord | null {
+  if (next == null) {
+    return current;
+  }
+  if (current == null || current.id !== next.id) {
+    return next;
+  }
+  return compareWorkflowRunSnapshots(current, next) > 0 ? current : next;
+}
+
 export interface UseWorkflowRunByIdResult {
   run: WorkflowRunRecord | null;
   loading: boolean;
@@ -43,7 +80,7 @@ export function useWorkflowRunById(input: {
         if (ignore) {
           return;
         }
-        setRun(nextRun);
+        setRun((currentRun) => getNewestWorkflowRunSnapshot(currentRun, nextRun));
         setError(null);
         setLoading(false);
         if (

--- a/src/browser/hooks/useWorkflowRunById.ts
+++ b/src/browser/hooks/useWorkflowRunById.ts
@@ -53,6 +53,7 @@ export function useWorkflowRunById(input: {
   runId?: string;
   enabled?: boolean;
   pollWhileActive?: boolean;
+  pollAfterTerminal?: boolean;
 }): UseWorkflowRunByIdResult {
   const apiState = useContext(APIContext);
   const [run, setRun] = useState<WorkflowRunRecord | null>(null);
@@ -85,6 +86,7 @@ export function useWorkflowRunById(input: {
         setLoading(false);
         if (
           input.pollWhileActive === true &&
+          input.pollAfterTerminal !== true &&
           nextRun != null &&
           !isActiveWorkflowRunStatus(nextRun.status) &&
           interval != null
@@ -114,7 +116,7 @@ export function useWorkflowRunById(input: {
         window.clearInterval(interval);
       }
     };
-  }, [api, enabled, input.pollWhileActive, runId, workspaceId]);
+  }, [api, enabled, input.pollAfterTerminal, input.pollWhileActive, runId, workspaceId]);
 
   if (run != null && run.id !== runId) {
     return { run: null, loading, error };

--- a/src/browser/hooks/useWorkflowRunById.ts
+++ b/src/browser/hooks/useWorkflowRunById.ts
@@ -1,0 +1,87 @@
+import { useContext, useEffect, useState } from "react";
+
+import { APIContext } from "@/browser/contexts/API";
+import { isActiveWorkflowRunStatus, type WorkflowRunRecord } from "@/common/types/workflow";
+
+const WORKFLOW_RUN_REFRESH_INTERVAL_MS = 2_000;
+
+export interface UseWorkflowRunByIdResult {
+  run: WorkflowRunRecord | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useWorkflowRunById(input: {
+  workspaceId?: string;
+  runId?: string;
+  enabled?: boolean;
+  pollWhileActive?: boolean;
+}): UseWorkflowRunByIdResult {
+  const apiState = useContext(APIContext);
+  const [run, setRun] = useState<WorkflowRunRecord | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const enabled = input.enabled !== false;
+  const api = apiState?.api;
+  const workspaceId = input.workspaceId;
+  const runId = input.runId;
+
+  useEffect(() => {
+    if (!enabled || api == null || workspaceId == null || runId == null) {
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let ignore = false;
+    let interval: number | null = null;
+    setLoading(true);
+
+    const refresh = async () => {
+      try {
+        const nextRun = await api.workflows.getRun({ workspaceId, runId });
+        if (ignore) {
+          return;
+        }
+        setRun(nextRun);
+        setError(null);
+        setLoading(false);
+        if (
+          input.pollWhileActive === true &&
+          nextRun != null &&
+          !isActiveWorkflowRunStatus(nextRun.status) &&
+          interval != null
+        ) {
+          window.clearInterval(interval);
+          interval = null;
+        }
+      } catch (fetchError) {
+        if (ignore) {
+          return;
+        }
+        setError(fetchError instanceof Error ? fetchError.message : "Failed to load workflow run");
+        setLoading(false);
+      }
+    };
+
+    void refresh();
+    if (input.pollWhileActive === true) {
+      interval = window.setInterval(() => {
+        void refresh();
+      }, WORKFLOW_RUN_REFRESH_INTERVAL_MS);
+    }
+
+    return () => {
+      ignore = true;
+      if (interval != null) {
+        window.clearInterval(interval);
+      }
+    };
+  }, [api, enabled, input.pollWhileActive, runId, workspaceId]);
+
+  if (run != null && run.id !== runId) {
+    return { run: null, loading, error };
+  }
+
+  return { run, loading, error };
+}


### PR DESCRIPTION
Summary

Render nested workflow runs inline in both workflow tool cards and the right-sidebar Workflows tab so parent workflows no longer hide child workflow progress.

Background

Nested workflow runs were already persisted and referenced by parent workflow events, but the UI only showed the parent event row. That made long-running nested workflows opaque because users could not see the child phases or steps from the parent surface.

Implementation

- Add `useWorkflowRunById` to fetch and poll a specific durable workflow run while it is active.
- Render nested workflow event rows in `WorkflowRunToolCall` as expandable inline child timelines.
- Project nested workflow run identity/status onto sidebar workflow step view models.
- Render nested workflow panels inside right-sidebar workflow steps, reusing the existing timeline recursively with a depth guard.
- Add Storybook fixtures for the tool-card and Workflows-tab nested workflow states.

Validation

- `bun test src/browser/features/RightSidebar/Workflows/projectWorkflowRun.test.ts src/browser/features/RightSidebar/Workflows/WorkflowTimeline.test.tsx src/browser/features/Tools/WorkflowRunToolCall.test.tsx`
- `env MUX_ESLINT_CONCURRENCY=1 make static-check`
- Dogfooded with Storybook + agent-browser screenshots for the tool card and Workflows tab nested workflow expansion.

Risks

Low-to-moderate UI risk in workflow rendering. The change keeps nested child runs out of top-level workflow history and only fetches child runs by known parent event IDs, with a recursion cap for deeply nested workflows.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$37.14`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=37.14 -->
