### PR TITLE
🤖 fix: dispatch queued messages after next step

### DIFF
--- a/src/node/services/agentSession.queueDispatch.test.ts
+++ b/src/node/services/agentSession.queueDispatch.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { Ok } from "@/common/types/result";
+import { createAgentSessionHarness } from "./agentSession.testHarness";
+
+const TEST_MODEL = "anthropic:claude-sonnet-4-5";
+
+function toolCallEndEvent(
+  workspaceId: string,
+  overrides?: { replay?: boolean }
+): Record<string, unknown> {
+  return {
+    type: "tool-call-end",
+    workspaceId,
+    messageId: "assistant-1",
+    ...(overrides?.replay === true ? { replay: true } : {}),
+    toolCallId: "tool-call-1",
+    toolName: "bash",
+    result: { success: true },
+    timestamp: Date.now(),
+  };
+}
+
+function streamStartEvent(workspaceId: string): Record<string, unknown> {
+  return {
+    type: "stream-start",
+    workspaceId,
+    messageId: "assistant-1",
+    model: TEST_MODEL,
+    startTime: Date.now(),
+  };
+}
+
+function streamAbortEvent(
+  workspaceId: string,
+  abortReason: "system" | "user"
+): Record<string, unknown> {
+  return {
+    type: "stream-abort",
+    workspaceId,
+    messageId: "assistant-1",
+    abortReason,
+    metadata: { duration: 1 },
+  };
+}
+
+async function waitForCondition(condition: () => boolean, timeoutMs = 500): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return condition();
+}
+
+describe("AgentSession queued message tool-call dispatch", () => {
+  test("soft-stops the current stream after a real tool call when a tool-end message is queued", async () => {
+    const workspaceId = "queue-dispatch-tool-end";
+    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
+      workspaceId,
+    });
+    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
+
+    try {
+      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
+      session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
+
+      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
+
+      expect(stopStream).toHaveBeenCalledWith(workspaceId, {
+        soft: true,
+        abortReason: "system",
+      });
+    } finally {
+      stopStream.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  test("does not stop the stream for turn-end queues or replayed tool events", async () => {
+    const turnEndWorkspaceId = "queue-dispatch-turn-end";
+    const turnEndHarness = await createAgentSessionHarness({ workspaceId: turnEndWorkspaceId });
+    const turnEndStopStream = spyOn(turnEndHarness.aiService, "stopStream").mockResolvedValue(
+      Ok(undefined)
+    );
+
+    try {
+      turnEndHarness.aiEmitter.emit("stream-start", streamStartEvent(turnEndWorkspaceId));
+      turnEndHarness.session.queueMessage("later", {
+        model: TEST_MODEL,
+        agentId: "exec",
+        queueDispatchMode: "turn-end",
+      });
+      turnEndHarness.aiEmitter.emit("tool-call-end", toolCallEndEvent(turnEndWorkspaceId));
+
+      expect(turnEndStopStream).not.toHaveBeenCalled();
+    } finally {
+      turnEndStopStream.mockRestore();
+      turnEndHarness.session.dispose();
+      await turnEndHarness.cleanup();
+    }
+
+    const replayWorkspaceId = "queue-dispatch-replay";
+    const replayHarness = await createAgentSessionHarness({ workspaceId: replayWorkspaceId });
+    const replayStopStream = spyOn(replayHarness.aiService, "stopStream").mockResolvedValue(
+      Ok(undefined)
+    );
+
+    try {
+      replayHarness.aiEmitter.emit("stream-start", streamStartEvent(replayWorkspaceId));
+      replayHarness.session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
+      replayHarness.aiEmitter.emit(
+        "tool-call-end",
+        toolCallEndEvent(replayWorkspaceId, { replay: true })
+      );
+
+      expect(replayStopStream).not.toHaveBeenCalled();
+    } finally {
+      replayStopStream.mockRestore();
+      replayHarness.session.dispose();
+      await replayHarness.cleanup();
+    }
+  });
+
+  test("sends the queued message after the system abort caused by tool-call dispatch", async () => {
+    const workspaceId = "queue-dispatch-after-system-abort";
+    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
+      workspaceId,
+    });
+    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
+    const sendQueuedMessages = spyOn(session, "sendQueuedMessages").mockImplementation(
+      () => undefined
+    );
+
+    try {
+      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
+      session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
+      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
+      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
+
+      const didDispatch = await waitForCondition(() => sendQueuedMessages.mock.calls.length > 0);
+      expect(didDispatch).toBe(true);
+      expect(sendQueuedMessages).toHaveBeenCalledTimes(1);
+    } finally {
+      sendQueuedMessages.mockRestore();
+      stopStream.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  test("dispatches a turn-end replacement after editing while abort is in flight", async () => {
+    const workspaceId = "queue-dispatch-edited-replacement";
+    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
+      workspaceId,
+    });
+    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
+    const sendQueuedMessages = spyOn(session, "sendQueuedMessages").mockImplementation(
+      () => undefined
+    );
+
+    try {
+      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
+      session.queueMessage("original follow up", { model: TEST_MODEL, agentId: "exec" });
+      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
+
+      session.clearQueue();
+      session.queueMessage("replacement follow up", {
+        model: TEST_MODEL,
+        agentId: "exec",
+        queueDispatchMode: "turn-end",
+      });
+      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
+
+      const didDispatch = await waitForCondition(() => sendQueuedMessages.mock.calls.length > 0);
+      expect(didDispatch).toBe(true);
+      expect(sendQueuedMessages).toHaveBeenCalledTimes(1);
+    } finally {
+      sendQueuedMessages.mockRestore();
+      stopStream.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  test("cancels a pending tool-end dispatch when a hard user interrupt starts", async () => {
+    const workspaceId = "queue-dispatch-hard-user-interrupt";
+    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
+      workspaceId,
+    });
+    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
+    const sendQueuedMessages = spyOn(session, "sendQueuedMessages").mockImplementation(
+      () => undefined
+    );
+
+    try {
+      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
+      session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
+      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
+
+      const interruptResult = await session.interruptStream();
+      expect(interruptResult.success).toBe(true);
+      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "system"));
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(sendQueuedMessages).not.toHaveBeenCalled();
+    } finally {
+      sendQueuedMessages.mockRestore();
+      stopStream.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+
+  test("does not send the queued message after a user abort", async () => {
+    const workspaceId = "queue-dispatch-user-abort";
+    const { session, cleanup, aiEmitter, aiService } = await createAgentSessionHarness({
+      workspaceId,
+    });
+    const stopStream = spyOn(aiService, "stopStream").mockResolvedValue(Ok(undefined));
+    const sendQueuedMessages = spyOn(session, "sendQueuedMessages").mockImplementation(
+      () => undefined
+    );
+
+    try {
+      aiEmitter.emit("stream-start", streamStartEvent(workspaceId));
+      session.queueMessage("follow up", { model: TEST_MODEL, agentId: "exec" });
+      aiEmitter.emit("tool-call-end", toolCallEndEvent(workspaceId));
+      aiEmitter.emit("stream-abort", streamAbortEvent(workspaceId, "user"));
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(sendQueuedMessages).not.toHaveBeenCalled();
+    } finally {
+      sendQueuedMessages.mockRestore();
+      stopStream.mockRestore();
+      session.dispose();
+      await cleanup();
+    }
+  });
+});

--- a/src/node/services/agentSession.ts
+++ b/src/node/services/agentSession.ts
@@ -357,6 +357,10 @@ export class AgentSession {
   private activePreparedTurnAbortController: AbortController | null = null;
   // When true, stream-end skips auto-flushing queued messages so an edit can truncate first.
   private deferQueuedFlushUntilAfterEdit = false;
+  // A tool-end queued message should preempt the current turn after the next real tool result.
+  // We keep this set until the requested stream-abort arrives, so a re-queued replacement
+  // can still dispatch even if the original queued draft was edited while the abort was in flight.
+  private queuedToolEndAbortInFlight = false;
 
   private idleWaiters: Array<() => void> = [];
   private pendingExternalManualFollowUps = 0;
@@ -3430,6 +3434,10 @@ export class AgentSession {
     // Explicit user interruption should immediately stop any pending auto-retry loop.
     this.retryManager.cancel();
 
+    if (options?.soft !== true) {
+      this.queuedToolEndAbortInFlight = false;
+    }
+
     // For hard interrupts, delete partial BEFORE stopping to prevent abort handler
     // from committing it. For soft interrupts, defer to stream-abort handler since
     // the stream continues running and would recreate the partial.
@@ -4533,6 +4541,10 @@ export class AgentSession {
       ) {
         this.onPostCompactionStateChange?.();
       }
+
+      if (payload.type === "tool-call-end" && payload.replay !== true) {
+        this.requestQueuedToolEndDispatchAfterCurrentTool();
+      }
     });
     forward("reasoning-delta", (payload) => {
       this.markActiveStreamHadAnyOutput();
@@ -4627,6 +4639,7 @@ export class AgentSession {
         );
 
         this.emitChatEvent(payload);
+        this.queuedToolEndAbortInFlight = false;
         return;
       }
 
@@ -4646,6 +4659,7 @@ export class AgentSession {
       const failedUserMessageId = this.activeStreamUserMessageId;
       const hadCompactionRequest = this.activeCompactionRequest !== undefined;
       const abortReason = "abortReason" in payload ? payload.abortReason : undefined;
+      const isQueuedToolEndAbort = this.queuedToolEndAbortInFlight && abortReason !== "user";
       if (abortReason === "user") {
         await this.workspaceGoalService?.recordUserStoppedStream(this.workspaceId);
       }
@@ -4674,13 +4688,18 @@ export class AgentSession {
       if (hadCompactionRequest && !this.disposed) {
         this.clearQueue();
       }
-      await this.handleStreamFailureForAutoRetry({
-        type: "aborted",
-        message: abortReason,
-      });
+      if (!isQueuedToolEndAbort) {
+        await this.handleStreamFailureForAutoRetry({
+          type: "aborted",
+          message: abortReason,
+        });
+      }
       await this.updateStartupAutoRetryAbandonFromAbort(abortReason, failedUserMessageId);
       this.emitChatEvent(payload);
-      this.setTurnPhase(TurnPhase.IDLE);
+      const dispatchedQueuedMessage = this.dispatchQueuedToolEndMessageAfterAbort(abortReason);
+      if (!dispatchedQueuedMessage) {
+        this.setTurnPhase(TurnPhase.IDLE);
+      }
     });
     forward("runtime-status", (payload) => {
       if (payload.type === "runtime-status") {
@@ -4783,6 +4802,7 @@ export class AgentSession {
         const hadQueuedMessages = this.hasPendingManualFollowUp();
         if (this.deferQueuedFlushUntilAfterEdit) {
           // Clear the queued message flag so the next turn's tools don't early-return.
+          this.queuedToolEndAbortInFlight = false;
           this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
           // Do not dispatch stream-end follow-ups while the edit flow is waiting
           // for IDLE; truncation must run before any synthetic turn resumes.
@@ -5086,6 +5106,48 @@ export class AgentSession {
     );
   }
 
+  private requestQueuedToolEndDispatchAfterCurrentTool(): void {
+    if (
+      this.turnPhase !== TurnPhase.STREAMING ||
+      this.queuedToolEndAbortInFlight ||
+      !this.hasQueuedMessages("tool-end")
+    ) {
+      return;
+    }
+
+    this.queuedToolEndAbortInFlight = true;
+    void this.aiService
+      .stopStream(this.workspaceId, { soft: true, abortReason: "system" })
+      .then((result) => {
+        if (!result.success) {
+          this.queuedToolEndAbortInFlight = false;
+          log.warn("Failed to stop stream for queued tool-end message dispatch", {
+            workspaceId: this.workspaceId,
+            error: result.error,
+          });
+        }
+      });
+  }
+
+  private dispatchQueuedToolEndMessageAfterAbort(
+    abortReason: StreamAbortReason | undefined
+  ): boolean {
+    if (!this.queuedToolEndAbortInFlight) {
+      return false;
+    }
+
+    const shouldDispatch =
+      abortReason !== "user" && !this.deferQueuedFlushUntilAfterEdit && this.hasQueuedMessages();
+    this.queuedToolEndAbortInFlight = false;
+
+    if (!shouldDispatch) {
+      return false;
+    }
+
+    this.sendQueuedMessages();
+    return true;
+  }
+
   async waitForPendingStreamErrorRecoveryDecision(): Promise<void> {
     await this.streamErrorRecoveryDecision?.promise;
   }
@@ -5146,6 +5208,7 @@ export class AgentSession {
     }
 
     // Clear the queued message flag (even if queue is empty, to handle race conditions)
+    this.queuedToolEndAbortInFlight = false;
     this.backgroundProcessManager.setMessageQueued(this.workspaceId, false);
 
     if (!this.messageQueue.isEmpty()) {


### PR DESCRIPTION
## Summary

Dispatch queued "Send after step" follow-ups immediately after the next real tool call by soft-stopping the active stream and sending the queued message from stream-abort cleanup.

## Background

A background bash monitor wake-up can queue a follow-up while the agent is still in the current turn. Waiting until full turn end lets unrelated idle drains or monitor work outrun the user's queued message. The intended behavior is for the queued message to take over after the next tool step finishes, while preserving the existing UI wording.

## Implementation

- Track a pending tool-end queued dispatch inside `AgentSession`.
- On live `tool-call-end`, soft-stop the current stream when a tool-end queued message exists.
- Dispatch the queued message from the resulting system `stream-abort`, before notifying idle waiters.
- Keep turn-end queued messages and replayed tool-call-end events unchanged.
- Add focused unit coverage for tool-end, turn-end, replay, system-abort dispatch, and user-abort restoration behavior.

## Validation

- `bun test src/node/services/agentSession.queueDispatch.test.ts`
- `bun test tests/ui/chat/queuedMessageBanner.test.tsx`
- `make typecheck`
- `env MUX_ESLINT_CONCURRENCY=1 make lint`
- `env MUX_ESLINT_CONCURRENCY=1 make static-check`

## Risks

Moderate: this touches stream/queue orchestration. The change is scoped to tool-end queued messages after live tool-call-end events, skips replay and turn-end queues, and waits for stream-abort cleanup before starting the replacement turn to avoid the historical active-stream race.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$25.53`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=25.53 -->
