### PR TITLE
🤖 fix: keep heartbeat message editable when disabled

### DIFF
--- a/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.stories.tsx
+++ b/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.stories.tsx
@@ -50,16 +50,24 @@ function createWorkspaceContextValue(): WorkspaceContextValue {
   } as unknown as WorkspaceContextValue;
 }
 
-function WorkspaceHeartbeatModalStoryShell(props: { children: ReactNode }) {
-  const settings: HeartbeatSettings = {
-    enabled: true,
-    intervalMs: 7 * 60_000,
-    contextMode: "compact",
-    message: LONG_HEARTBEAT_MESSAGE,
-  };
+const enabledLongMessageSettings: HeartbeatSettings = {
+  enabled: true,
+  intervalMs: 7 * 60_000,
+  contextMode: "compact",
+  message: LONG_HEARTBEAT_MESSAGE,
+};
 
+const disabledLongMessageSettings: HeartbeatSettings = {
+  ...enabledLongMessageSettings,
+  enabled: false,
+};
+
+function WorkspaceHeartbeatModalStoryShell(props: {
+  children: ReactNode;
+  settings: HeartbeatSettings;
+}) {
   return (
-    <APIProvider client={createHeartbeatStoryApi(settings)}>
+    <APIProvider client={createHeartbeatStoryApi(props.settings)}>
       <WorkspaceContext.Provider value={createWorkspaceContextValue()}>
         <div className="bg-background min-h-screen">{props.children}</div>
       </WorkspaceContext.Provider>
@@ -67,9 +75,9 @@ function WorkspaceHeartbeatModalStoryShell(props: { children: ReactNode }) {
   );
 }
 
-function renderOpenModal() {
+function renderOpenModal(settings: HeartbeatSettings = enabledLongMessageSettings) {
   return (
-    <WorkspaceHeartbeatModalStoryShell>
+    <WorkspaceHeartbeatModalStoryShell settings={settings}>
       <WorkspaceHeartbeatModal
         workspaceId={WORKSPACE_ID}
         open={true}
@@ -126,7 +134,7 @@ export const LongMessageDesktop: Story = {
       },
     },
   },
-  render: renderOpenModal,
+  render: () => renderOpenModal(),
   play: async ({ canvasElement }) => {
     await assertHeartbeatModalLoaded(canvasElement);
   },
@@ -143,7 +151,41 @@ export const LongMessageMobile: Story = {
       },
     },
   },
-  render: renderOpenModal,
+  render: () => renderOpenModal(),
+  play: async ({ canvasElement }) => {
+    await assertHeartbeatModalLoaded(canvasElement);
+  },
+};
+
+export const DisabledLongMessageDesktop: Story = {
+  globals: {
+    viewport: { value: "desktop", isRotated: false },
+  },
+  parameters: {
+    chromatic: {
+      modes: {
+        "dark-desktop-disabled": { theme: "dark", viewport: { width: 1280, height: 800 } },
+      },
+    },
+  },
+  render: () => renderOpenModal(disabledLongMessageSettings),
+  play: async ({ canvasElement }) => {
+    await assertHeartbeatModalLoaded(canvasElement);
+  },
+};
+
+export const DisabledLongMessageMobile: Story = {
+  globals: {
+    viewport: { value: "mobile1", isRotated: false },
+  },
+  parameters: {
+    chromatic: {
+      modes: {
+        "dark-mobile-disabled": { theme: "dark", viewport: { width: 375, height: 667 } },
+      },
+    },
+  },
+  render: () => renderOpenModal(disabledLongMessageSettings),
   play: async ({ canvasElement }) => {
     await assertHeartbeatModalLoaded(canvasElement);
   },

--- a/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx
+++ b/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx
@@ -142,7 +142,7 @@ describe("WorkspaceHeartbeatModal", () => {
     cleanupDom = null;
   });
 
-  test("reveals the message field when enabled and saves a custom message", async () => {
+  test("keeps the message field editable while heartbeats are disabled", async () => {
     settingsByWorkspaceId.set(
       "ws-1",
       createHeartbeatSettings({
@@ -155,15 +155,18 @@ describe("WorkspaceHeartbeatModal", () => {
       <WorkspaceHeartbeatModal workspaceId="ws-1" open={true} onOpenChange={onOpenChange} />
     );
 
-    expect(view.queryByLabelText("Heartbeat message")).toBeNull();
-
-    fireEvent.click(view.getByRole("switch", { name: "Enable workspace heartbeats" }));
-
     const messageField = (await waitFor(() =>
       view.getByLabelText("Heartbeat message")
     )) as HTMLTextAreaElement;
+    expect(messageField.disabled).toBe(false);
     expect(messageField.value).toBe("Review the current workspace status before acting.");
     expect(messageField.placeholder).toBe(HEARTBEAT_DEFAULT_MESSAGE_BODY);
+
+    const enableSwitch = view.getByRole("switch", { name: "Enable workspace heartbeats" });
+    fireEvent.click(enableSwitch);
+    expect(view.getByLabelText("Heartbeat message")).toBe(messageField);
+    fireEvent.click(enableSwitch);
+    expect(view.getByLabelText("Heartbeat message")).toBe(messageField);
 
     fireEvent.input(messageField, {
       target: { value: "Check the pending review queue and summarize next steps." },
@@ -178,7 +181,7 @@ describe("WorkspaceHeartbeatModal", () => {
         {
           workspaceId: "ws-1",
           next: {
-            enabled: true,
+            enabled: false,
             intervalMs: HEARTBEAT_DEFAULT_INTERVAL_MS,
             contextMode: HEARTBEAT_DEFAULT_CONTEXT_MODE,
             message: "Check the pending review queue and summarize next steps.",
@@ -232,11 +235,7 @@ describe("WorkspaceHeartbeatModal", () => {
     expect(workspaceHeartbeatGetMock).toHaveBeenCalledWith({ workspaceId: "ws-1" });
     expect(getConfigMock).toHaveBeenCalled();
 
-    fireEvent.click(view.getByRole("switch", { name: "Enable workspace heartbeats" }));
-
-    const messageField = (await waitFor(() =>
-      view.getByLabelText("Heartbeat message")
-    )) as HTMLTextAreaElement;
+    const messageField = view.getByLabelText("Heartbeat message") as HTMLTextAreaElement;
     // Global prompt is not seeded into the form to avoid persisting it as a workspace
     // override on save. The backend handles prompt fallback at execution time.
     expect(messageField.value).toBe("");

--- a/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.tsx
+++ b/src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.tsx
@@ -218,14 +218,8 @@ export function WorkspaceHeartbeatModal(props: WorkspaceHeartbeatModalProps) {
                 them.
               </p>
 
-              {/* Keep custom heartbeat instructions in a roomy column so long prompts stay readable. */}
-              <div
-                className={
-                  draftEnabled
-                    ? "grid gap-4 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)]"
-                    : "grid gap-4"
-                }
-              >
+              {/* Keep custom heartbeat instructions visible even when disabled so prompts can be edited before scheduling resumes. */}
+              <div className="grid gap-4 lg:grid-cols-[minmax(16rem,20rem)_minmax(0,1fr)]">
                 <div className="border-border rounded-lg border p-4">
                   <div className="flex items-center justify-between gap-4">
                     <div className="min-w-0 flex-1">
@@ -306,30 +300,28 @@ export function WorkspaceHeartbeatModal(props: WorkspaceHeartbeatModalProps) {
                   </div>
                 </div>
 
-                {draftEnabled && (
-                  <div className="border-border rounded-lg border p-4">
-                    <label htmlFor="workspace-heartbeat-message" className="block">
-                      <div className="text-foreground text-sm font-medium">Message</div>
-                      <div className="text-muted mt-1 text-xs">
-                        Leave empty to use the default heartbeat message.
-                      </div>
-                    </label>
-                    <textarea
-                      ref={messageTextareaRef}
-                      id="workspace-heartbeat-message"
-                      rows={10}
-                      value={draftMessage}
-                      onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
-                        setDraftMessage(event.target.value);
-                        setDraftDirty(true);
-                      }}
-                      disabled={isSaving}
-                      className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent mt-3 min-h-[240px] w-full resize-y rounded-md border p-3 text-sm leading-relaxed focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 lg:min-h-[320px]"
-                      placeholder={globalDefaultPrompt ?? HEARTBEAT_DEFAULT_MESSAGE_BODY}
-                      aria-label="Heartbeat message"
-                    />
-                  </div>
-                )}
+                <div className="border-border rounded-lg border p-4">
+                  <label htmlFor="workspace-heartbeat-message" className="block">
+                    <div className="text-foreground text-sm font-medium">Message</div>
+                    <div className="text-muted mt-1 text-xs">
+                      Leave empty to use the default heartbeat message.
+                    </div>
+                  </label>
+                  <textarea
+                    ref={messageTextareaRef}
+                    id="workspace-heartbeat-message"
+                    rows={10}
+                    value={draftMessage}
+                    onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                      setDraftMessage(event.target.value);
+                      setDraftDirty(true);
+                    }}
+                    disabled={isSaving}
+                    className="border-border-medium bg-background-secondary text-foreground focus:border-accent focus:ring-accent mt-3 min-h-[240px] w-full resize-y rounded-md border p-3 text-sm leading-relaxed focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 lg:min-h-[320px]"
+                    placeholder={globalDefaultPrompt ?? HEARTBEAT_DEFAULT_MESSAGE_BODY}
+                    aria-label="Heartbeat message"
+                  />
+                </div>
               </div>
 
               {errorMessages.length > 0 && (


### PR DESCRIPTION
## Summary

Keep the workspace heartbeat message editor visible and editable even when heartbeat scheduling is disabled.

## Background

The heartbeat configuration dialog previously hid the custom message textarea when the workspace heartbeat switch was off. That made it hard to inspect or revise the stored heartbeat prompt before re-enabling scheduled follow-ups.

## Implementation

- Always render the message textarea alongside the heartbeat scheduling controls.
- Preserve the roomy two-column layout on desktop and stacked layout on narrow viewports.
- Update modal tests so the disabled state verifies the textarea remains editable and survives enable/disable toggles.
- Add disabled long-message Storybook stories for desktop and mobile viewport coverage.

## Validation

- `bun test src/browser/components/WorkspaceHeartbeatModal/WorkspaceHeartbeatModal.test.tsx`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- Dogfooded the disabled heartbeat dialog in Storybook at 1280×800 and 375×667, including toggling the switch and editing the message while disabled.

## Risks

Low. The change only removes conditional rendering around an existing textarea and updates tests/stories for the new always-visible behavior.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$6.27`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=6.27 -->
