### PR TITLE
feat: add agent_skill_list tool-call card

### DIFF
--- a/src/browser/features/Tools/AgentSkillListToolCall.stories.tsx
+++ b/src/browser/features/Tools/AgentSkillListToolCall.stories.tsx
@@ -1,0 +1,191 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AgentSkillListToolCall } from "@/browser/features/Tools/AgentSkillListToolCall";
+import { CHROMATIC_DISABLED, lightweightMeta, StoryUiShell } from "@/browser/stories/meta.js";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+
+const meta = {
+  ...lightweightMeta,
+  title: "App/Chat/Tools/AgentSkillList",
+  component: AgentSkillListToolCall,
+  parameters: {
+    ...lightweightMeta.parameters,
+    // The repo-wide Chromatic snapshot budget (tests/ui/storybook/budget.test.ts) is
+    // already at its ceiling, so these states stay out of paid visual snapshots. They
+    // still render under local Storybook and the CI Storybook test-runner smoke pass.
+    chromatic: CHROMATIC_DISABLED,
+  },
+  decorators: [
+    (Story) => (
+      <StoryUiShell>
+        <div className="bg-background p-6">
+          <div className="w-full max-w-2xl">
+            <Story />
+          </div>
+        </div>
+      </StoryUiShell>
+    ),
+  ],
+} satisfies Meta<typeof AgentSkillListToolCall>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const BROWSER_DESC =
+  "Browser automation CLI for AI agents. Use when the user needs to interact with websites — " +
+  "navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, " +
+  "testing web apps, or automating any browser task. Triggers include requests to “open a " +
+  "website”, “fill out a form”, “click a button”, or “take a screenshot”.";
+
+const ADVERTISED: AgentSkillDescriptor[] = [
+  { name: "agent-browser", scope: "project", description: BROWSER_DESC },
+  {
+    name: "db-console",
+    scope: "project",
+    description:
+      "Run read-only SQL against the project’s dev database, inspect schema, and summarize " +
+      "results. Use when the user asks to look up a record, check a table, or debug a query. " +
+      "Never issues writes or migrations.",
+  },
+  {
+    name: "linear",
+    scope: "global",
+    description:
+      "Search, create, and update Linear issues and projects. Use when the user references a " +
+      "ticket, asks to file a bug, or wants to move an issue between states.",
+  },
+  {
+    name: "pdf",
+    scope: "built-in",
+    description:
+      "Read, search, split, and fill PDF documents and extract text, tables, and form fields. " +
+      "Use whenever the user attaches a PDF or asks to read, summarize, or edit one.",
+  },
+  {
+    name: "docx",
+    scope: "built-in",
+    description:
+      "Author and revise Microsoft Word documents with styles, headings, and structure. Use " +
+      "when the user wants a .docx report or to edit a Word file they shared.",
+  },
+];
+
+const UNADVERTISED: AgentSkillDescriptor[] = [
+  {
+    name: "orchestrator",
+    scope: "project",
+    advertise: false,
+    description:
+      "Internal planning skill that decomposes a task into sub-agent steps and sequences their " +
+      "workspaces. Invoked by the task runner — not intended for direct use.",
+  },
+  {
+    name: "release-notes",
+    scope: "global",
+    advertise: false,
+    description:
+      "Generate changelog entries and release notes from merged PRs over a commit range. A " +
+      "power-user workflow kept out of the default skill index.",
+  },
+];
+
+/** Listed · advertised skills only (the default), grouped by scope. */
+export const Listed: Story = {
+  args: {
+    args: { includeUnadvertised: false },
+    status: "completed",
+    defaultExpanded: true,
+    result: { success: true, skills: ADVERTISED },
+  },
+};
+
+/** Listed · including unadvertised skills (the eye-off chip marks them). */
+export const IncludingUnadvertised: Story = {
+  args: {
+    args: { includeUnadvertised: true },
+    status: "completed",
+    defaultExpanded: true,
+    result: {
+      success: true,
+      skills: [ADVERTISED[0], UNADVERTISED[0], ADVERTISED[2], UNADVERTISED[1], ADVERTISED[3]],
+    },
+  },
+};
+
+/** The glanceable resting state — collapsed to a count. */
+export const Collapsed: Story = {
+  args: {
+    args: { includeUnadvertised: false },
+    status: "completed",
+    result: { success: true, skills: ADVERTISED },
+  },
+};
+
+/** Listed · nothing configured in this workspace. */
+export const NothingConfigured: Story = {
+  args: {
+    args: { includeUnadvertised: false },
+    status: "completed",
+    defaultExpanded: true,
+    result: { success: true, skills: [] },
+  },
+};
+
+/** Mid-flight, before the result arrives. */
+export const Executing: Story = {
+  args: {
+    args: { includeUnadvertised: false },
+    status: "executing",
+    defaultExpanded: true,
+  },
+};
+
+/** Error · the skills directory could not be read. */
+export const ErrorResult: Story = {
+  args: {
+    args: { includeUnadvertised: false },
+    status: "failed",
+    defaultExpanded: true,
+    result: { success: false, error: "Skills directory is unreadable: EACCES .mux/skills" },
+  },
+};
+
+/**
+ * Narrow (~375px) viewport. Pinned to a fixed-width container because the Storybook
+ * test-runner renders at desktop width and ignores viewport / Chromatic modes, so the
+ * mobile case must be forced with a wrapper. The play fails if the long browser-skill
+ * description or scope rows overflow horizontally instead of wrapping/clamping.
+ */
+export const NarrowViewport: Story = {
+  args: {
+    args: { includeUnadvertised: true },
+    status: "completed",
+    defaultExpanded: true,
+    result: { success: true, skills: [ADVERTISED[0], UNADVERTISED[0], ADVERTISED[3]] },
+  },
+  decorators: [
+    (Story) => (
+      <div data-testid="skill-list-card-container" className="w-[375px]">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    if (!canvasElement.textContent?.includes("agent-browser")) {
+      throw new Error("AgentSkillList card did not render its skills");
+    }
+    const container = canvasElement.querySelector('[data-testid="skill-list-card-container"]');
+    if (!(container instanceof HTMLElement)) {
+      throw new Error("AgentSkillList story container not found");
+    }
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    );
+    if (container.scrollWidth > container.clientWidth + 1) {
+      throw new Error(
+        `AgentSkillList tool card overflowed its ${container.clientWidth}px container by ` +
+          `${container.scrollWidth - container.clientWidth}px`
+      );
+    }
+  },
+};

--- a/src/browser/features/Tools/AgentSkillListToolCall.tsx
+++ b/src/browser/features/Tools/AgentSkillListToolCall.tsx
@@ -1,0 +1,305 @@
+import React from "react";
+import { ChevronRight, EyeOff } from "lucide-react";
+import { z } from "zod";
+import { cn } from "@/common/lib/utils";
+import { AgentSkillDescriptorSchema } from "@/common/orpc/schemas";
+import type { AgentSkillDescriptor, AgentSkillScope } from "@/common/types/agentSkill";
+import type { AgentSkillListToolArgs } from "@/common/types/tools";
+import {
+  ErrorBox,
+  ExpandIcon,
+  LoadingDots,
+  StatusIndicator,
+  ToolContainer,
+  ToolDetails,
+  ToolHeader,
+  ToolIcon,
+} from "./Shared/ToolPrimitives";
+import {
+  getStatusDisplay,
+  isToolErrorResult,
+  unwrapResult,
+  useToolExpansion,
+  type ToolStatus,
+} from "./Shared/toolUtils";
+
+/**
+ * Transcript card for the `agent_skill_list` tool — the call the agent makes to
+ * discover which skills it can invoke. Collapsed it reads as a glanceable count
+ * ("Listed skills · N skills"); expanded it groups skills by scope (project /
+ * global / built-in) and lets you open any row to read the full description and
+ * how to invoke it.
+ *
+ * Binds to the real backend shape (AgentSkillListToolResult): a success carries
+ * `skills: AgentSkillDescriptor[]`, a failure carries `error`. The source mockup
+ * also sketched a "skills that failed to load" panel, but the tool result never
+ * carries load diagnostics — the backend logs and skips invalid skills, and that
+ * surface lives in the session-level SkillIndicator — so it is intentionally
+ * omitted here rather than wired to data that can never arrive.
+ */
+
+// Scope → label + dot/label color. Project and global reuse the Mux mode hues
+// (teal / indigo); built-in is neutral. Colors come from globals.css theme tokens
+// (`--color-task-mode` etc.) via utilities — never hardcoded — so they track the
+// active theme. Record keyed by scope so a new AgentSkillScope is a compile error.
+const SCOPE_META: Record<AgentSkillScope, { label: string; dotClass: string; labelClass: string }> =
+  {
+    project: { label: "Project", dotClass: "bg-task-mode", labelClass: "text-task-mode" },
+    global: { label: "Global", dotClass: "bg-ask-mode", labelClass: "text-ask-mode" },
+    "built-in": {
+      label: "Built-in",
+      dotClass: "bg-muted-foreground",
+      labelClass: "text-muted-foreground",
+    },
+  };
+
+// Render order: project first (most local), then global, then shipped built-ins —
+// mirrors the backend listing order and the SkillIndicator popover.
+const SCOPE_ORDER: AgentSkillScope[] = ["project", "global", "built-in"];
+
+export interface SkillScopeGroup {
+  scope: AgentSkillScope;
+  label: string;
+  dotClass: string;
+  labelClass: string;
+  skills: AgentSkillDescriptor[];
+}
+
+/** Group skills by scope in a stable scope order, dropping empty groups. */
+export function groupSkillsByScope(skills: AgentSkillDescriptor[]): SkillScopeGroup[] {
+  const byScope = new Map<AgentSkillScope, AgentSkillDescriptor[]>();
+  for (const skill of skills) {
+    const existing = byScope.get(skill.scope) ?? [];
+    existing.push(skill);
+    byScope.set(skill.scope, existing);
+  }
+  return SCOPE_ORDER.filter((scope) => (byScope.get(scope)?.length ?? 0) > 0).map((scope) => ({
+    scope,
+    ...SCOPE_META[scope],
+    skills: byScope.get(scope) ?? [],
+  }));
+}
+
+// Loosely shaped success container; individual skills are validated per-row below
+// so one malformed descriptor can't blank the whole list (self-healing).
+const SkillListSuccessSchema = z.object({
+  success: z.literal(true),
+  skills: z.array(z.unknown()),
+});
+
+export type SkillListView =
+  | { kind: "skills"; skills: AgentSkillDescriptor[] }
+  | { kind: "error"; error: string }
+  | { kind: "none" };
+
+/**
+ * Normalize a persisted tool result into a render view. Unwraps the SDK JSON
+ * container first, then detects both the thrown `{ success: false, error }` shape
+ * and the nested `{ error }` shape that code_execution/PTC reconstructs (no
+ * `success` flag), then validates the success payload — filtering any malformed
+ * skill rows. Returns `none` for pending / unrecognized output so the card
+ * degrades gracefully instead of throwing.
+ */
+export function toSkillListView(result: unknown): SkillListView {
+  const unwrapped = unwrapResult(result);
+  if (unwrapped == null || typeof unwrapped !== "object") return { kind: "none" };
+
+  if (isToolErrorResult(unwrapped)) return { kind: "error", error: unwrapped.error };
+  if (
+    !("success" in unwrapped) &&
+    "error" in unwrapped &&
+    typeof (unwrapped as { error: unknown }).error === "string"
+  ) {
+    return { kind: "error", error: (unwrapped as { error: string }).error };
+  }
+
+  const parsed = SkillListSuccessSchema.safeParse(unwrapped);
+  if (!parsed.success) return { kind: "none" };
+
+  const skills = parsed.data.skills.flatMap((entry) => {
+    const skill = AgentSkillDescriptorSchema.safeParse(entry);
+    return skill.success ? [skill.data] : [];
+  });
+  return { kind: "skills", skills };
+}
+
+const InlineCode: React.FC<React.PropsWithChildren> = (props) => (
+  <span className="text-foreground rounded-sm bg-white/10 px-1 py-0.5 font-mono break-all">
+    {props.children}
+  </span>
+);
+
+const UnadvertisedChip: React.FC = () => (
+  <span className="text-warning bg-warning-overlay border-warning/40 inline-flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-px text-[10px] leading-none">
+    <EyeOff aria-hidden="true" className="h-2.5 w-2.5" />
+    unadvertised
+  </span>
+);
+
+const SkillGroupHeader: React.FC<{ group: SkillScopeGroup }> = (props) => (
+  <div className="flex items-center gap-1.5 px-2.5 pt-2 pb-1">
+    <span className={cn("h-1.5 w-1.5 shrink-0 rounded-[2px]", props.group.dotClass)} />
+    <span
+      className={cn("text-[10px] font-semibold tracking-wider uppercase", props.group.labelClass)}
+    >
+      {props.group.label}
+    </span>
+    <span className="text-muted text-[10px]">{props.group.skills.length}</span>
+  </div>
+);
+
+// A single skill row. Collapsed it shows the name + a 2-line clamped description
+// (descriptions can run to 1024 chars); clicking expands it in place to the full
+// text plus how to invoke it. Rendered as a button so the disclosure is reachable
+// by keyboard, not just pointer.
+const SkillRow: React.FC<{ skill: AgentSkillDescriptor; first: boolean }> = (props) => {
+  const [open, setOpen] = React.useState(false);
+  const unadvertised = props.skill.advertise === false;
+  return (
+    <button
+      type="button"
+      aria-expanded={open}
+      onClick={() => setOpen((value) => !value)}
+      className={cn(
+        "block w-full rounded px-2 py-1.5 text-left transition-colors hover:bg-white/5",
+        !props.first && "border-t border-white/5"
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="text-foreground text-[12.5px] font-medium break-words">
+              {props.skill.name}
+            </span>
+            {unadvertised && <UnadvertisedChip />}
+          </div>
+          <div
+            className={cn(
+              "text-secondary mt-0.5 text-[11.5px] leading-snug break-words",
+              !open && "line-clamp-2"
+            )}
+          >
+            {props.skill.description}
+          </div>
+          {open && (
+            <div className="text-muted mt-1.5 text-[11px] leading-snug">
+              {unadvertised && (
+                <span className="text-warning">
+                  Hidden from the skill index — call it explicitly.{" "}
+                </span>
+              )}
+              Invoke with <InlineCode>${props.skill.name}</InlineCode> or read it in full via{" "}
+              <InlineCode>agent_skill_read</InlineCode>.
+            </div>
+          )}
+        </div>
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            "text-muted mt-0.5 h-3 w-3 shrink-0 transition-transform duration-200",
+            open && "rotate-90"
+          )}
+        />
+      </div>
+    </button>
+  );
+};
+
+interface AgentSkillListToolCallProps {
+  args: AgentSkillListToolArgs;
+  result?: unknown;
+  status?: ToolStatus;
+  /** Initial expansion fallback (until the user toggles this tool in the workspace). */
+  defaultExpanded?: boolean;
+}
+
+export const AgentSkillListToolCall: React.FC<AgentSkillListToolCallProps> = (props) => {
+  const status = props.status ?? "pending";
+  const { expanded, toggleExpanded } = useToolExpansion(props.defaultExpanded ?? false);
+
+  const view = toSkillListView(props.result);
+  const skills = view.kind === "skills" ? view.skills : [];
+  const groups = groupSkillsByScope(skills);
+  const unadvertisedCount = skills.filter((skill) => skill.advertise === false).length;
+  // `includeUnadvertised` only narrows the empty-state copy: did the agent ask for the
+  // full set and still find nothing, or just the advertised set?
+  const includedUnadvertised = props.args.includeUnadvertised === true;
+
+  const verb =
+    status === "executing"
+      ? "Listing skills"
+      : view.kind === "skills"
+        ? "Listed skills"
+        : "List skills";
+
+  return (
+    <ToolContainer expanded={expanded} className="@container">
+      <ToolHeader onClick={toggleExpanded}>
+        <ExpandIcon expanded={expanded}>▶</ExpandIcon>
+        <ToolIcon toolName="agent_skill_list" />
+        <span className="text-secondary font-medium whitespace-nowrap">{verb}</span>
+        {view.kind === "skills" && (
+          <span className="text-muted whitespace-nowrap">
+            {skills.length} {skills.length === 1 ? "skill" : "skills"}
+          </span>
+        )}
+        {unadvertisedCount > 0 && (
+          <span className="text-muted hidden whitespace-nowrap @sm:inline">
+            · {unadvertisedCount} unadvertised
+          </span>
+        )}
+        <StatusIndicator status={status}>{getStatusDisplay(status)}</StatusIndicator>
+      </ToolHeader>
+
+      {expanded && (
+        <ToolDetails>
+          {view.kind === "error" && <ErrorBox>{view.error}</ErrorBox>}
+
+          {status === "executing" && view.kind !== "error" && (
+            <div className="text-muted px-1 py-1 text-[11px] italic">
+              Scanning available skills
+              <LoadingDots />
+            </div>
+          )}
+
+          {view.kind === "skills" && skills.length === 0 && status !== "executing" && (
+            <div className="text-muted px-1 py-1 text-[11px] italic">
+              {includedUnadvertised
+                ? "No skills are available in this workspace."
+                : "No advertised skills are available in this workspace."}
+            </div>
+          )}
+
+          {groups.length > 0 && (
+            <div className="bg-code-bg overflow-hidden rounded">
+              {groups.map((group, index) => (
+                <div key={group.scope} className={cn(index > 0 && "border-t border-white/10")}>
+                  <SkillGroupHeader group={group} />
+                  <div className="px-1.5 pb-1.5">
+                    {group.skills.map((skill, skillIndex) => (
+                      <SkillRow
+                        key={`${group.scope}:${skill.name}`}
+                        skill={skill}
+                        first={skillIndex === 0}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {skills.length > 0 && (
+            <div className="text-muted mt-2 px-1 text-[10.5px] leading-relaxed">
+              Skills are project-local, global, or built-in — invoke any of them inline with{" "}
+              <InlineCode>$name</InlineCode>
+              {unadvertisedCount > 0
+                ? "; unadvertised skills stay out of the index but remain callable by name."
+                : "."}
+            </div>
+          )}
+        </ToolDetails>
+      )}
+    </ToolContainer>
+  );
+};

--- a/src/browser/features/Tools/AgentSkillListToolCall.ui.test.tsx
+++ b/src/browser/features/Tools/AgentSkillListToolCall.ui.test.tsx
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { GlobalWindow } from "happy-dom";
+import type { ReactElement } from "react";
+
+import { TooltipProvider } from "@/browser/components/Tooltip/Tooltip";
+import { ThemeProvider } from "@/browser/contexts/ThemeContext";
+import { MessageListProvider } from "@/browser/features/Messages/MessageListContext";
+import { ToolNameProvider } from "@/browser/features/Messages/ToolNameContext";
+import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
+import {
+  AgentSkillListToolCall,
+  groupSkillsByScope,
+  toSkillListView,
+} from "./AgentSkillListToolCall";
+
+const skill = (
+  name: string,
+  scope: AgentSkillDescriptor["scope"],
+  extra: Partial<AgentSkillDescriptor> = {}
+): AgentSkillDescriptor => ({ name, scope, description: `${name} description`, ...extra });
+
+describe("groupSkillsByScope", () => {
+  test("orders groups project → global → built-in regardless of input order", () => {
+    const groups = groupSkillsByScope([
+      skill("z-builtin", "built-in"),
+      skill("a-global", "global"),
+      skill("m-project", "project"),
+    ]);
+    expect(groups.map((group) => group.scope)).toEqual(["project", "global", "built-in"]);
+  });
+
+  test("drops empty scopes and keeps every skill in its group", () => {
+    const groups = groupSkillsByScope([
+      skill("one", "project"),
+      skill("two", "project"),
+      skill("three", "built-in"),
+    ]);
+    expect(groups.map((group) => group.scope)).toEqual(["project", "built-in"]);
+    expect(groups[0].skills.map((skillItem) => skillItem.name)).toEqual(["one", "two"]);
+    expect(groups[1].skills).toHaveLength(1);
+  });
+
+  test("returns nothing for an empty list", () => {
+    expect(groupSkillsByScope([])).toEqual([]);
+  });
+});
+
+describe("toSkillListView", () => {
+  test("returns the skills from a success result", () => {
+    const view = toSkillListView({ success: true, skills: [skill("a", "project")] });
+    expect(view).toEqual({ kind: "skills", skills: [skill("a", "project")] });
+  });
+
+  test("filters malformed skill entries instead of blanking the whole list (self-healing)", () => {
+    const view = toSkillListView({
+      success: true,
+      skills: [
+        skill("valid-one", "project"),
+        { name: "Has Spaces", scope: "project", description: "bad name" },
+        { name: "bad-scope", scope: "nope", description: "x" },
+      ],
+    });
+    expect(view.kind).toBe("skills");
+    expect(view.kind === "skills" && view.skills.map((s) => s.name)).toEqual(["valid-one"]);
+  });
+
+  test("surfaces the thrown { success: false, error } shape", () => {
+    expect(toSkillListView({ success: false, error: "EACCES" })).toEqual({
+      kind: "error",
+      error: "EACCES",
+    });
+  });
+
+  test("surfaces a nested { error } shape with no success flag (code_execution/PTC)", () => {
+    expect(toSkillListView({ error: "directory unreadable" })).toEqual({
+      kind: "error",
+      error: "directory unreadable",
+    });
+  });
+
+  test("unwraps the SDK JSON container before parsing", () => {
+    const view = toSkillListView({
+      type: "json",
+      value: { success: true, skills: [skill("from-container", "global")] },
+    });
+    expect(view.kind === "skills" && view.skills.map((s) => s.name)).toEqual(["from-container"]);
+  });
+
+  test("returns none for pending / unrecognized output", () => {
+    expect(toSkillListView(undefined)).toEqual({ kind: "none" });
+    expect(toSkillListView({ unexpected: "shape" })).toEqual({ kind: "none" });
+  });
+});
+
+const TEST_WORKSPACE_ID = "agent-skill-list-test";
+
+// ToolIcon renders a Radix Tooltip which requires a TooltipProvider and contexts.
+function renderWithProviders(ui: ReactElement) {
+  return render(
+    <ThemeProvider forcedTheme="dark">
+      <MessageListProvider value={{ workspaceId: TEST_WORKSPACE_ID, latestMessageId: null }}>
+        <ToolNameProvider toolName="agent_skill_list">
+          <TooltipProvider>{ui}</TooltipProvider>
+        </ToolNameProvider>
+      </MessageListProvider>
+    </ThemeProvider>
+  );
+}
+
+describe("AgentSkillListToolCall", () => {
+  beforeEach(() => {
+    globalThis.window = new GlobalWindow() as unknown as Window & typeof globalThis;
+    globalThis.document = globalThis.window.document;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    globalThis.document = undefined as unknown as Document;
+  });
+
+  test("expanded card groups skills under scope labels", () => {
+    const view = renderWithProviders(
+      <AgentSkillListToolCall
+        args={{ includeUnadvertised: false }}
+        status="completed"
+        defaultExpanded
+        result={{
+          success: true,
+          skills: [skill("agent-browser", "project"), skill("pdf", "built-in")],
+        }}
+      />
+    );
+    // Scope group headers render only for scopes that have skills.
+    expect(view.queryByText("Project")).not.toBeNull();
+    expect(view.queryByText("Built-in")).not.toBeNull();
+    expect(view.queryByText("Global")).toBeNull();
+    expect(view.queryByText("agent-browser")).not.toBeNull();
+  });
+
+  test("a skill row reveals its invoke hint only after it is expanded", () => {
+    const view = renderWithProviders(
+      <AgentSkillListToolCall
+        args={{ includeUnadvertised: true }}
+        status="completed"
+        defaultExpanded
+        result={{
+          success: true,
+          skills: [skill("orchestrator", "project", { advertise: false })],
+        }}
+      />
+    );
+    // The unadvertised warning + invoke hint live inside the per-row disclosure.
+    expect(view.queryByText(/Hidden from the skill index/)).toBeNull();
+
+    const nameNode = view.getByText("orchestrator");
+    const rowButton = nameNode.closest("button");
+    expect(rowButton).not.toBeNull();
+    fireEvent.click(rowButton!);
+
+    expect(view.queryByText(/Hidden from the skill index/)).not.toBeNull();
+    expect(view.queryByText("agent_skill_read")).not.toBeNull();
+  });
+
+  test("renders the shared error box and no skills box for a failed result", () => {
+    const view = renderWithProviders(
+      <AgentSkillListToolCall
+        args={{ includeUnadvertised: false }}
+        status="failed"
+        defaultExpanded
+        result={{ success: false, error: "Skills directory is unreadable: EACCES .mux/skills" }}
+      />
+    );
+    expect(view.queryByText("Skills directory is unreadable: EACCES .mux/skills")).not.toBeNull();
+    // No scope groups when the call failed.
+    expect(view.queryByText("Project")).toBeNull();
+  });
+
+  test("distinguishes the empty state by whether unadvertised skills were requested", () => {
+    const advertisedOnly = renderWithProviders(
+      <AgentSkillListToolCall
+        args={{ includeUnadvertised: false }}
+        status="completed"
+        defaultExpanded
+        result={{ success: true, skills: [] }}
+      />
+    );
+    expect(advertisedOnly.queryByText(/No advertised skills are available/)).not.toBeNull();
+    cleanup();
+
+    const allSkills = renderWithProviders(
+      <AgentSkillListToolCall
+        args={{ includeUnadvertised: true }}
+        status="completed"
+        defaultExpanded
+        result={{ success: true, skills: [] }}
+      />
+    );
+    expect(allSkills.queryByText("No skills are available in this workspace.")).not.toBeNull();
+  });
+});

--- a/src/browser/features/Tools/Shared/ToolPrimitives.tsx
+++ b/src/browser/features/Tools/Shared/ToolPrimitives.tsx
@@ -20,6 +20,7 @@ import {
   Hand,
   Keyboard,
   Layers,
+  LayoutGrid,
   Lightbulb,
   MessageCircleQuestion,
   Monitor,
@@ -245,6 +246,9 @@ export const TOOL_NAME_TO_ICON: Partial<Record<string, LucideIcon>> = {
   agent_report: FileText,
   agent_skill_read: GraduationCap,
   agent_skill_read_file: GraduationCap,
+  // LayoutGrid (a 2×2 catalog of tiles) reads as "the index of skills you can pick
+  // from" — distinct from the GraduationCap used when reading a single skill.
+  agent_skill_list: LayoutGrid,
   advisor: Lightbulb,
   ask_user_question: MessageCircleQuestion,
   file_read: BookOpen,

--- a/src/browser/features/Tools/Shared/getToolComponent.test.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { AgentReportToolCall } from "../AgentReportToolCall";
+import { AgentSkillListToolCall } from "../AgentSkillListToolCall";
 import { AgentSkillReadFileToolCall } from "../AgentSkillReadFileToolCall";
 import { AgentSkillReadToolCall } from "../AgentSkillReadToolCall";
 import { CompleteGoalToolCall } from "../CompleteGoalToolCall";
@@ -61,6 +62,20 @@ describe("getToolComponent", () => {
       filePath: "references/README.md",
     });
     expect(component).toBe(AgentSkillReadFileToolCall);
+  });
+
+  test("returns AgentSkillListToolCall for agent_skill_list", () => {
+    expect(getToolComponent("agent_skill_list", {})).toBe(AgentSkillListToolCall);
+    expect(getToolComponent("agent_skill_list", { includeUnadvertised: true })).toBe(
+      AgentSkillListToolCall
+    );
+  });
+
+  test("agent_skill_list falls back to GenericToolCall when args don't conform", () => {
+    // includeUnadvertised is boolean.nullish(); a string fails the schema.
+    expect(getToolComponent("agent_skill_list", { includeUnadvertised: "yes" })).toBe(
+      GenericToolCall
+    );
   });
 
   test("returns DesktopScreenshotToolCall for desktop_screenshot", () => {

--- a/src/browser/features/Tools/Shared/getToolComponent.ts
+++ b/src/browser/features/Tools/Shared/getToolComponent.ts
@@ -18,6 +18,7 @@ import { DesktopScreenshotToolCall } from "../DesktopScreenshotToolCall";
 import { FileEditToolCall } from "../FileEditToolCall";
 import { AgentSkillReadToolCall } from "../AgentSkillReadToolCall";
 import { AgentSkillReadFileToolCall } from "../AgentSkillReadFileToolCall";
+import { AgentSkillListToolCall } from "../AgentSkillListToolCall";
 import { FileReadToolCall } from "../FileReadToolCall";
 import { MemoryToolCall } from "../MemoryToolCall";
 import { WebFetchToolCall } from "../WebFetchToolCall";
@@ -129,6 +130,10 @@ const TOOL_REGISTRY: Record<string, ToolRegistryEntry> = {
   agent_skill_read_file: {
     component: AgentSkillReadFileToolCall,
     schema: TOOL_DEFINITIONS.agent_skill_read_file.schema,
+  },
+  agent_skill_list: {
+    component: AgentSkillListToolCall,
+    schema: TOOL_DEFINITIONS.agent_skill_list.schema,
   },
   file_edit_replace_string: {
     component: FileEditToolCall,

--- a/src/common/types/tools.ts
+++ b/src/common/types/tools.ts
@@ -56,7 +56,8 @@ export type AgentSkillReadFileToolArgs = z.infer<
 >;
 export type AgentSkillReadFileToolResult = z.infer<typeof AgentSkillReadFileToolResultSchema>;
 
-// agent_skill_list result
+// agent_skill_list args + result
+export type AgentSkillListToolArgs = z.infer<typeof TOOL_DEFINITIONS.agent_skill_list.schema>;
 export type AgentSkillListToolResult =
   | { success: true; skills: AgentSkillDescriptor[] }
   | { success: false; error: string };


### PR DESCRIPTION
## Summary

Adds a dedicated transcript card for the `agent_skill_list` tool, ported from the "Agent Skill List Tool Call" mockup in the Mux Design System. Collapsed, it reads as a glanceable count ("Listed skills · N skills"); expanded, it groups the discovered skills by scope (project / global / built-in) and lets you open any row to read the full description and how to invoke it.

## Background

`agent_skill_list` previously fell through to the `GenericToolCall` renderer (raw JSON). This brings it in line with the other skill-family cards (`agent_skill_read` / `agent_skill_read_file`) and the session-level `SkillIndicator`, giving the skill-discovery call a first-class, scannable presentation.

## Implementation

- New `AgentSkillListToolCall` built on the shared tool primitives, modeled on the newest card template (`HeartbeatToolCall`).
- **Bound to the real backend shape** (`AgentSkillListToolResult = { success: true; skills } | { success: false; error }`), not the mockup's invented shape. Two exported pure helpers carry the logic:
  - `groupSkillsByScope` — stable scope ordering, drops empty groups.
  - `toSkillListView` — unwraps the SDK JSON container, detects both the thrown `{ success:false, error }` and the nested `{ error }` (code_execution/PTC) failure shapes, and validates the success payload, filtering any malformed skill rows (self-healing).
- Scope colors use existing theme tokens (`--color-task-mode` teal / `--color-ask-mode` indigo / `--color-muted-foreground` neutral); no hardcoded hex.
- Per-row disclosure is a real `<button>` (keyboard-reachable) with 2-line clamped descriptions; unadvertised skills get an `EyeOff` chip and a "call it explicitly" note. Invocation is surfaced with the `$name` inline syntax; scopes are described as project-local / global / built-in.
- Registered in `getToolComponent` with the tool's own schema (bad args still degrade to `GenericToolCall`); added a `LayoutGrid` header icon and the `AgentSkillListToolArgs` type.

### Notable deviation from the mockup

The mockup sketched a "N skills failed to load" / issues panel. The real `agent_skill_list` result carries **no** load diagnostics (the backend logs-and-skips invalid skills, and that surface already lives in `SkillIndicator`), so wiring it here would be dead UI — it is intentionally omitted.

## Validation

- Behavioral unit tests for `groupSkillsByScope` and `toSkillListView` (ordering, malformed-row filtering, JSON-container unwrap, both failure shapes), plus rendered tests for scope grouping, the per-row disclosure interaction, the error branch, and the scope-aware empty state.
- Registration test in `getToolComponent.test.ts`.
- Storybook stories for all states incl. a pinned 375px story with an overflow-guard play; verified each state visually via Storybook + agent-browser screenshots.

> Note: `Test / E2E (macos)` is currently red due to a repo-wide CI infra bug (Node 24 / extract-zip breaking Playwright + Electron installs), unrelated to this card. Fixed separately; this PR will be rebased once that lands.

## Risks

Low. Additive — a new card plus a one-line registry entry, an additive icon-map entry, and a derived args type. Unrecognized/old result shapes self-heal to the generic renderer. No backend or shared-runtime logic changed.
