### PR TITLE
🤖 fix: queue bash monitor wakes at tool boundaries

### DIFF
--- a/src/node/services/bashMonitorWakeStore.test.ts
+++ b/src/node/services/bashMonitorWakeStore.test.ts
@@ -113,6 +113,49 @@ describe("BashMonitorWakeStore", () => {
     expect(pending[0].status).toBe("pending");
   });
 
+  test("markSupersededSnapshot marks an unchanged pending snapshot as superseded", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR one"], totalMatches: 1 }));
+    const snapshot = (await store.listPending("owner-1"))[0];
+    expect(snapshot).toBeDefined();
+    if (!snapshot) throw new Error("Expected pending snapshot");
+
+    const superseded = await store.markSupersededSnapshot("owner-1", snapshot);
+
+    expect(superseded).toBe(true);
+    expect(await store.listPending("owner-1")).toHaveLength(0);
+    const stored = await store.get("owner-1", snapshot.id);
+    expect(stored?.status).toBe("superseded");
+    expect(stored?.deliveredAt).toBeUndefined();
+  });
+
+  test("markSupersededSnapshot preserves matches merged after the canceled snapshot", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR one"], totalMatches: 1 }));
+    const snapshot = (await store.listPending("owner-1"))[0];
+    expect(snapshot).toBeDefined();
+    if (!snapshot) throw new Error("Expected pending snapshot");
+    await store.enqueueOrMergePending(payload({ lines: ["ERROR two"], totalMatches: 2 }));
+
+    const superseded = await store.markSupersededSnapshot("owner-1", snapshot);
+
+    expect(superseded).toBe(false);
+    const pending = await store.listPending("owner-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].lines).toEqual(["ERROR two"]);
+    expect(pending[0].status).toBe("pending");
+  });
+
+  test("markSupersededSnapshot succeeds when the snapshot is already non-pending", async () => {
+    const store = new BashMonitorWakeStore(makeConfig(rootDir));
+    const snapshot = await store.enqueueOrMergePending(payload({ lines: ["ERROR one"] }));
+    await store.markDelivered("owner-1", snapshot.id);
+
+    const superseded = await store.markSupersededSnapshot("owner-1", snapshot);
+    expect(superseded).toBe(true);
+    expect(await store.listPending("owner-1")).toHaveLength(0);
+  });
+
   test("listPendingOwnerWorkspaceIds finds pending wakes across session dirs", async () => {
     const store = new BashMonitorWakeStore(makeConfig(rootDir));
     await store.enqueueOrMergePending(payload({ workspaceId: "owner-b" }));

--- a/src/node/services/bashMonitorWakeStore.ts
+++ b/src/node/services/bashMonitorWakeStore.ts
@@ -262,7 +262,23 @@ export class BashMonitorWakeStore {
     ownerWorkspaceId: string,
     snapshot: BashMonitorWakeRecord
   ): Promise<boolean> {
-    assert(snapshot.id.trim().length > 0, "markDeliveredSnapshot requires snapshot id");
+    return this.transitionSnapshot(ownerWorkspaceId, snapshot, "delivered");
+  }
+
+  async markSupersededSnapshot(
+    ownerWorkspaceId: string,
+    snapshot: BashMonitorWakeRecord
+  ): Promise<boolean> {
+    return this.transitionSnapshot(ownerWorkspaceId, snapshot, "superseded");
+  }
+
+  private async transitionSnapshot(
+    ownerWorkspaceId: string,
+    snapshot: BashMonitorWakeRecord,
+    status: "delivered" | "superseded"
+  ): Promise<boolean> {
+    assert(ownerWorkspaceId.trim().length > 0, "transitionSnapshot requires ownerWorkspaceId");
+    assert(snapshot.id.trim().length > 0, "transitionSnapshot requires snapshot id");
     const key = `${ownerWorkspaceId}:${snapshot.id}`;
     return this.locks.withLock(key, async () => {
       const current = await this.get(ownerWorkspaceId, snapshot.id);
@@ -275,25 +291,14 @@ export class BashMonitorWakeStore {
         current.lines.length === snapshot.lines.length &&
         current.lines.every((line, index) => line === snapshot.lines[index]);
       if (isSnapshotUnchanged) {
-        const now = new Date().toISOString();
-        await this.write({
-          ...current,
-          status: "delivered",
-          updatedAt: now,
-          deliveredAt: now,
-        });
+        await this.write(this.withTerminalStatus(current, status));
         return true;
       }
 
       const remainingLines = removeDeliveredLineOverlap(current.lines, snapshot.lines);
       const remainingDroppedLines = Math.max(0, current.droppedLines - snapshot.droppedLines);
       if (remainingLines.length === 0 && remainingDroppedLines === 0) {
-        await this.write({
-          ...current,
-          status: "delivered",
-          updatedAt: new Date().toISOString(),
-          deliveredAt: new Date().toISOString(),
-        });
+        await this.write(this.withTerminalStatus(current, status));
         return true;
       }
 
@@ -305,6 +310,19 @@ export class BashMonitorWakeStore {
       });
       return false;
     });
+  }
+
+  private withTerminalStatus(
+    record: BashMonitorWakeRecord,
+    status: "delivered" | "superseded"
+  ): BashMonitorWakeRecord {
+    const now = new Date().toISOString();
+    return {
+      ...record,
+      status,
+      updatedAt: now,
+      ...(status === "delivered" ? { deliveredAt: now } : {}),
+    };
   }
 
   async markDelivered(ownerWorkspaceId: string, id: string): Promise<void> {

--- a/src/node/services/workspaceService.test.ts
+++ b/src/node/services/workspaceService.test.ts
@@ -238,7 +238,12 @@ describe("WorkspaceService bash monitor wakes", () => {
         backgroundProcessManager,
         aiService: createMockAIService({ isStreaming: mock(() => false) }),
       });
-      const sendSpy = spyOn(workspaceService, "sendMessage").mockResolvedValue(Ok(undefined));
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
 
       backgroundProcessManager.emit("monitor:match", workspaceId, {
         processId: "proc-1",
@@ -255,11 +260,668 @@ describe("WorkspaceService bash monitor wakes", () => {
       expect(sendSpy.mock.calls[0][0]).toBe(workspaceId);
       expect(sendSpy.mock.calls[0][1]).toContain("A background bash monitor matched output.");
       expect(sendSpy.mock.calls[0][1]).toContain("FAILED one");
+      expect(sendSpy.mock.calls[0][2]).toMatchObject({ queueDispatchMode: "tool-end" });
       expect(sendSpy.mock.calls[0][3]).toMatchObject({
         synthetic: true,
         agentInitiated: true,
-        requireIdle: true,
+        skipAutoResumeReset: true,
       });
+      expect(sendSpy.mock.calls[0][3]?.requireIdle).toBeUndefined();
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("queues monitor wakes immediately for a session-backed streaming owner", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-streaming-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasQueuedMessages").mockReturnValue(false);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      const waitForIdleSpy = spyOn(
+        workspaceService,
+        "waitForIdleAndNoQueuedMessages"
+      ).mockResolvedValue();
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Ok(undefined);
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED streaming"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      expect(sendSpy.mock.calls[0][2]).toMatchObject({ queueDispatchMode: "tool-end" });
+      expect(sendSpy.mock.calls[0][3]?.requireIdle).toBeUndefined();
+      expect(waitForIdleSpy).not.toHaveBeenCalled();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("leaves monitor wakes pending and retries after idle when a busy queue send is rejected", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-busy-rejected-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasQueuedMessages").mockReturnValue(false);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      const waitForIdleSpy = spyOn(
+        workspaceService,
+        "waitForIdleAndNoQueuedMessages"
+      ).mockImplementation(() => new Promise(() => undefined));
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockResolvedValue(
+        Err({ type: "unknown", raw: "busy rejection" })
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED rejected"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      expect(waitForIdleSpy).toHaveBeenCalledWith(workspaceId);
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("defers monitor wakes while the owner session is busy after streaming ends", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-completing-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      const waitForIdleSpy = spyOn(
+        workspaceService,
+        "waitForIdleAndNoQueuedMessages"
+      ).mockImplementation(() => new Promise(() => undefined));
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockResolvedValue(Ok(undefined));
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED completing"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => waitForIdleSpy.mock.calls.length === 1);
+      expect(sendSpy).not.toHaveBeenCalled();
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("leaves idle rejected monitor wakes pending without scheduling a retry loop", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-idle-rejected-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(false);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      const waitForIdleSpy = spyOn(
+        workspaceService,
+        "waitForIdleAndNoQueuedMessages"
+      ).mockResolvedValue();
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockResolvedValue(
+        Err({ type: "unknown", raw: "idle rejection" })
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED idle rejected"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      expect(waitForIdleSpy).not.toHaveBeenCalled();
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("keeps an accepted monitor wake pending when stream startup fails before streaming", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-startup-failure-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => false) }),
+      });
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          return Err({ type: "unknown", raw: "startup failed" });
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED startup"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      await drainPendingDispatches();
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(1);
+      sendSpy.mockRestore();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("keeps a queued monitor wake pending when accepted dispatch fails before stream start", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-queued-startup-failure-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          await args[3]?.onAcceptedPreStreamFailure?.({ type: "unknown", raw: "startup failed" });
+          return Ok(undefined);
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED queued startup"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      await drainPendingDispatches();
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      expect(await wakeStore.listPending(workspaceId)).toHaveLength(1);
+      sendSpy.mockRestore();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("marks an accepted monitor wake delivered when startup retry later starts streaming", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-startup-retry-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const aiService = Object.assign(new EventEmitter(), {
+        isStreaming: mock(() => true),
+      }) as unknown as AIService & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService,
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          await args[3]?.onAcceptedPreStreamFailure?.({
+            type: "unknown",
+            raw: "runtime not ready",
+          });
+          return Ok(undefined);
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED retry"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      aiService.emit("stream-start", { workspaceId, model: "openai:gpt-4o-mini" });
+
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
+      sendSpy.mockRestore();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("marks an accepted monitor wake delivered after the stream starts", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-started-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const aiService = Object.assign(new EventEmitter(), {
+        isStreaming: mock(() => true),
+      }) as unknown as AIService & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService,
+      });
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockReturnValue(false);
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        async (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          await args[3]?.onAccepted?.();
+          aiService.emit("stream-start", { workspaceId, model: "openai:gpt-4o-mini" });
+          return Ok(undefined);
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED started"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: { listPending: (id: string) => Promise<unknown[]> };
+        }
+      ).bashMonitorWakeStore;
+      await waitForCondition(async () => (await wakeStore.listPending(workspaceId)).length === 0);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("canceled queued monitor wakes supersede only the canceled snapshot", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-canceled-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      let queueHasPendingMonitorWake = false;
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasQueuedMessages").mockImplementation(
+        () => queueHasPendingMonitorWake
+      );
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockImplementation(
+        () => queueHasPendingMonitorWake
+      );
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => new Promise(() => undefined)
+      );
+      type SendInternal = NonNullable<Parameters<WorkspaceService["sendMessage"]>[3]>;
+      let onCanceled: SendInternal["onCanceled"] | undefined;
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          onCanceled = args[3]?.onCanceled;
+          queueHasPendingMonitorWake = true;
+          return Promise.resolve(Ok(undefined));
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED first"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED second"],
+        totalMatches: 2,
+        timestamp: Date.now(),
+      });
+      await drainPendingDispatches();
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+
+      if (onCanceled == null) throw new Error("Expected monitor wake onCanceled callback");
+      await onCanceled("cleared by user");
+
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: {
+            listPending: (id: string) => Promise<Array<{ lines: string[]; status: string }>>;
+          };
+        }
+      ).bashMonitorWakeStore;
+      const pending = await wakeStore.listPending(workspaceId);
+      expect(pending).toHaveLength(1);
+      expect(pending[0].lines).toEqual(["FAILED second"]);
+      expect(pending[0].status).toBe("pending");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("does not requeue a canceled monitor wake while supersession is still writing", async () => {
+    const { config, cleanup } = await createTestHistoryService();
+    try {
+      const workspaceId = "bash-monitor-cancel-race-owner";
+      const projectPath = path.join(config.rootDir, "project");
+      await config.addWorkspace(projectPath, {
+        id: workspaceId,
+        name: workspaceId,
+        projectName: "project",
+        projectPath,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        runtimeConfig: { type: "local" },
+      });
+
+      const backgroundProcessManager = Object.assign(new EventEmitter(), {
+        cleanup: mock(() => Promise.resolve()),
+      }) as unknown as BackgroundProcessManager & EventEmitter;
+      const workspaceService = createWorkspaceServiceForTest({
+        config,
+        backgroundProcessManager,
+        aiService: createMockAIService({ isStreaming: mock(() => true) }),
+      });
+      let queueHasPendingMonitorWake = false;
+      spyOn(workspaceService, "isBusyForMessage").mockReturnValue(true);
+      spyOn(workspaceService, "hasPendingQueuedOrPreparingTurn").mockImplementation(
+        () => queueHasPendingMonitorWake
+      );
+      const idleDeferred = createDeferred<void>();
+      spyOn(workspaceService, "waitForIdleAndNoQueuedMessages").mockImplementation(
+        () => idleDeferred.promise
+      );
+      type SendInternal = NonNullable<Parameters<WorkspaceService["sendMessage"]>[3]>;
+      let onCanceled: SendInternal["onCanceled"] | undefined;
+      const sendSpy = spyOn(workspaceService, "sendMessage").mockImplementation(
+        (...args: Parameters<WorkspaceService["sendMessage"]>) => {
+          onCanceled = args[3]?.onCanceled;
+          queueHasPendingMonitorWake = true;
+          return Promise.resolve(Ok(undefined));
+        }
+      );
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED first"],
+        totalMatches: 1,
+        timestamp: Date.now(),
+      });
+      await waitForCondition(() => sendSpy.mock.calls.length === 1);
+
+      backgroundProcessManager.emit("monitor:match", workspaceId, {
+        processId: "proc-1",
+        taskId: "bash:proc-1",
+        workspaceId,
+        filter: "FAILED",
+        filterExclude: false,
+        lines: ["FAILED second"],
+        totalMatches: 2,
+        timestamp: Date.now(),
+      });
+      await drainPendingDispatches();
+
+      const wakeStore = (
+        workspaceService as unknown as {
+          bashMonitorWakeStore: {
+            markSupersededSnapshot: (...args: unknown[]) => Promise<boolean>;
+            listPending: (id: string) => Promise<Array<{ lines: string[] }>>;
+          };
+        }
+      ).bashMonitorWakeStore;
+      const originalMarkSuperseded = wakeStore.markSupersededSnapshot.bind(wakeStore);
+      const supersedeStarted = createDeferred<void>();
+      const releaseSupersede = createDeferred<void>();
+      spyOn(wakeStore, "markSupersededSnapshot").mockImplementation(async (...args: unknown[]) => {
+        supersedeStarted.resolve();
+        await releaseSupersede.promise;
+        return originalMarkSuperseded(...args);
+      });
+
+      if (onCanceled == null) throw new Error("Expected monitor wake onCanceled callback");
+      const cancelPromise = onCanceled("cleared by user");
+      await supersedeStarted.promise;
+      queueHasPendingMonitorWake = false;
+      idleDeferred.resolve();
+
+      await drainPendingDispatches();
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+
+      releaseSupersede.resolve();
+      await cancelPromise;
+      const pending = await wakeStore.listPending(workspaceId);
+      expect(pending).toHaveLength(1);
+      expect(pending[0].lines).toEqual(["FAILED second"]);
     } finally {
       await cleanup();
     }

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -405,17 +405,6 @@ function isTerminalWorkflowTaskAwaitResultMessage(message: MuxMessage, runId: st
   });
 }
 
-function isWorkspaceBusyIdleOnlySend(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "type" in error &&
-    error.type === "unknown" &&
-    "raw" in error &&
-    error.raw === IDLE_ONLY_BUSY_SKIP_MESSAGE
-  );
-}
-
 function sanitizeHeartbeatMessage(message: unknown): string | undefined {
   if (typeof message !== "string") {
     return undefined;
@@ -1538,6 +1527,7 @@ export class WorkspaceService extends EventEmitter {
   private readonly bashMonitorWakeStore: BashMonitorWakeStore;
   private readonly pendingBashMonitorWakeDrainsByOwner = new Map<string, Promise<void>>();
   private readonly pendingBashMonitorWakeIdleWaitsByOwner = new Map<string, Promise<void>>();
+  private readonly cancelingBashMonitorWakeKeys = new Set<string>();
   private readonly pendingBashMonitorWakeDrains = new Set<Promise<void>>();
   private readonly bashMonitorMatchListener = (
     _workspaceId: string,
@@ -1704,8 +1694,17 @@ export class WorkspaceService extends EventEmitter {
     this.pendingBashMonitorWakeDrains.add(promise);
   }
 
+  private bashMonitorWakeKey(ownerWorkspaceId: string, wakeId: string): string {
+    assert(ownerWorkspaceId.trim().length > 0, "bashMonitorWakeKey requires ownerWorkspaceId");
+    assert(wakeId.trim().length > 0, "bashMonitorWakeKey requires wakeId");
+    return `${ownerWorkspaceId}:${wakeId}`;
+  }
+
   private async drainBashMonitorWakes(ownerWorkspaceId: string): Promise<void> {
-    const pending = await this.bashMonitorWakeStore.listPending(ownerWorkspaceId);
+    const pending = (await this.bashMonitorWakeStore.listPending(ownerWorkspaceId)).filter(
+      (record) =>
+        !this.cancelingBashMonitorWakeKeys.has(this.bashMonitorWakeKey(ownerWorkspaceId, record.id))
+    );
     if (pending.length === 0) return;
 
     const cfg = this.config.loadConfigOrDefault();
@@ -1719,14 +1718,17 @@ export class WorkspaceService extends EventEmitter {
 
     const ownerHasPendingQueuedPreparingOrRetry =
       this.hasPendingQueuedOrPreparingTurn(ownerWorkspaceId);
-    const ownerHasSessionBackedBusyState =
-      this.isBusyForMessage(ownerWorkspaceId) ||
-      this.hasQueuedMessages(ownerWorkspaceId) ||
-      ownerHasPendingQueuedPreparingOrRetry;
-    if (this.aiService.isStreaming(ownerWorkspaceId) || ownerHasSessionBackedBusyState) {
-      if (ownerHasSessionBackedBusyState) {
-        this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
-      }
+    const ownerHasSessionBackedBusyState = this.isBusyForMessage(ownerWorkspaceId);
+    const ownerHasAiServiceStream = this.aiService.isStreaming(ownerWorkspaceId);
+    if (
+      ownerHasPendingQueuedPreparingOrRetry ||
+      (ownerHasSessionBackedBusyState && !ownerHasAiServiceStream)
+    ) {
+      this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
+      return;
+    }
+
+    if (ownerHasAiServiceStream && !ownerHasSessionBackedBusyState) {
       return;
     }
 
@@ -1737,7 +1739,22 @@ export class WorkspaceService extends EventEmitter {
     }
 
     const prompt = buildBashMonitorWakePrompt(pending);
-    const markDelivered = async (records: readonly BashMonitorWakeRecord[]): Promise<boolean> => {
+    const retryAfterIdleIfBusy = (reason: string): void => {
+      if (
+        this.isBusyForMessage(ownerWorkspaceId) ||
+        this.hasPendingQueuedOrPreparingTurn(ownerWorkspaceId)
+      ) {
+        this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
+        return;
+      }
+      log.debug("Bash monitor wake left pending without immediate retry", {
+        ownerWorkspaceId,
+        reason,
+      });
+    };
+    const markDeliveredAfterAccepted = async (
+      records: readonly BashMonitorWakeRecord[]
+    ): Promise<void> => {
       let hasUndeliveredMergedMatches = false;
       for (const record of records) {
         const delivered = await this.bashMonitorWakeStore.markDeliveredSnapshot(
@@ -1748,30 +1765,136 @@ export class WorkspaceService extends EventEmitter {
           hasUndeliveredMergedMatches = true;
         }
       }
-      return hasUndeliveredMergedMatches;
+      if (hasUndeliveredMergedMatches) {
+        this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
+      }
+    };
+    const markSupersededAfterCanceled = async (
+      records: readonly BashMonitorWakeRecord[]
+    ): Promise<void> => {
+      let hasNewMergedMatches = false;
+      for (const record of records) {
+        const superseded = await this.bashMonitorWakeStore.markSupersededSnapshot(
+          ownerWorkspaceId,
+          record
+        );
+        if (!superseded) {
+          hasNewMergedMatches = true;
+        }
+      }
+      if (hasNewMergedMatches) {
+        this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
+      }
     };
 
-    const sendResult = await this.sendMessage(ownerWorkspaceId, prompt, sendOptions, {
-      skipAutoResumeReset: true,
-      synthetic: true,
-      agentInitiated: true,
-      requireIdle: true,
-    });
+    // `onAccepted` only proves the synthetic user turn reached history; keep
+    // the wake pending until the provider stream starts so startup failures can retry it.
+    let accepted = false;
+    let delivered = false;
+    let startupFailed = false;
+    let removeStreamStartListener: (() => void) | undefined;
+    const removeDeliveryListener = (): void => {
+      removeStreamStartListener?.();
+      removeStreamStartListener = undefined;
+    };
+    const isOwnerStreamStart = (data: unknown): data is { workspaceId: string } =>
+      typeof data === "object" &&
+      data !== null &&
+      "workspaceId" in data &&
+      data.workspaceId === ownerWorkspaceId;
+    const markDeliveredOnce = async (): Promise<void> => {
+      if (delivered) return;
+      delivered = true;
+      removeDeliveryListener();
+      try {
+        await markDeliveredAfterAccepted(pending);
+      } catch (error) {
+        log.error("Failed to mark bash monitor wake delivered after accepted send", {
+          ownerWorkspaceId,
+          error,
+        });
+      }
+    };
+    const armDeliveryAfterStreamStart = (): void => {
+      removeDeliveryListener();
+      const onStreamStart = (data: unknown): void => {
+        if (isOwnerStreamStart(data)) {
+          void markDeliveredOnce();
+        }
+      };
+      this.aiService.on("stream-start", onStreamStart);
+      removeStreamStartListener = () => this.aiService.off("stream-start", onStreamStart);
+    };
+
+    const sendResult = await this.sendMessage(
+      ownerWorkspaceId,
+      prompt,
+      { ...sendOptions, queueDispatchMode: "tool-end" },
+      {
+        skipAutoResumeReset: true,
+        synthetic: true,
+        agentInitiated: true,
+        onAccepted: () => {
+          accepted = true;
+          armDeliveryAfterStreamStart();
+        },
+        onAcceptedPreStreamFailure: (error) => {
+          startupFailed = true;
+          if (!accepted) {
+            removeDeliveryListener();
+          }
+          if (delivered) return;
+          log.debug("Bash monitor wake accepted send failed before stream start; leaving pending", {
+            ownerWorkspaceId,
+            error,
+          });
+          retryAfterIdleIfBusy("pre-stream failure");
+        },
+        onCanceled: async (reason) => {
+          removeDeliveryListener();
+          if (delivered) return;
+          const cancelingKeys = pending.map((record) =>
+            this.bashMonitorWakeKey(ownerWorkspaceId, record.id)
+          );
+          for (const key of cancelingKeys) {
+            this.cancelingBashMonitorWakeKeys.add(key);
+          }
+          log.debug("Bash monitor wake queue was canceled; superseding canceled snapshot", {
+            ownerWorkspaceId,
+            reason,
+          });
+          try {
+            await markSupersededAfterCanceled(pending);
+          } catch (error) {
+            log.error("Failed to supersede canceled bash monitor wake snapshot", {
+              ownerWorkspaceId,
+              error,
+            });
+          } finally {
+            for (const key of cancelingKeys) {
+              this.cancelingBashMonitorWakeKeys.delete(key);
+            }
+          }
+        },
+      }
+    );
 
     if (!sendResult.success) {
-      log.debug("Bash monitor wake-up not accepted; leaving pending", {
-        ownerWorkspaceId,
-        error: sendResult.error,
-      });
-      if (isWorkspaceBusyIdleOnlySend(sendResult.error)) {
-        this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
+      if (!accepted) {
+        removeDeliveryListener();
+      }
+      if (!delivered) {
+        log.debug("Bash monitor wake-up not accepted; leaving pending", {
+          ownerWorkspaceId,
+          error: sendResult.error,
+        });
+        retryAfterIdleIfBusy("sendMessage rejected");
       }
       return;
     }
 
-    const hasUndeliveredMergedMatches = await markDelivered(pending);
-    if (hasUndeliveredMergedMatches) {
-      this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
+    if (accepted && !startupFailed) {
+      await markDeliveredOnce();
     }
   }
 


### PR DESCRIPTION
Summary
- Route background bash monitor wake-ups through the existing tool-end queue path while an owner workspace has a session-backed active stream.
- Mark monitor wake records delivered only after the synthetic user message is accepted, and supersede canceled queued snapshots without dropping later merged matches.
- Add focused store and workspace coverage for delivery, cancellation, active-stream queueing, deferral, and rejection behavior.

Background
Bash monitor matches were persisted promptly but held until the owner workspace naturally became idle. This made condition-driven monitor wakes less useful during long active turns. The change reuses AgentSession's existing tool-end queue behavior so the active stream soft-stops at the next real tool boundary and dispatches the synthetic monitor wake as the next turn.

Implementation
- `WorkspaceService.drainBashMonitorWakes()` now classifies owner state before dispatch: queue immediately for session-backed active streams, defer for unsafe busy/queued/preparing/retry states, and avoid starting concurrent streams when only AIService reports streaming.
- Monitor sends now pass `queueDispatchMode: "tool-end"`, arm delivery on stream start after `onAccepted` (including startup retry stream-starts), and use pre-stream failure/cancel callbacks to keep wake-store state crash-safe without dropping startup failures.
- `BashMonitorWakeStore` gained snapshot-safe supersession that mirrors delivered snapshot handling while preserving newer merged lines; `WorkspaceService` also suppresses drains for snapshots whose cancellation write is still in flight.

Validation
- `bun test src/node/services/backgroundProcessManager.test.ts --test-name-pattern "monitor"`
- `bun test src/node/services/bashMonitorWakeStore.test.ts`
- `bun test src/node/services/workspaceService.test.ts --test-name-pattern "monitor|queue|wake"`
- `bun test src/node/services/agentSession.queueDispatch.test.ts`
- `bun test src/node/services/messageQueue.test.ts`
- `make typecheck`
- `make lint`
- `make static-check`
- Dogfooded monitor wake behavior with terminal evidence for active-stream queueing, idle delivery, merged cancellation safety, and next-tool-boundary queue dispatch. UI capture was blocked in this workspace because DISPLAY/WAYLAND_DISPLAY were unset and Xvfb was unavailable.

Risks
- Medium risk in monitor wake dispatch timing: the change touches asynchronous queue/drain behavior, but it intentionally reuses the existing AgentSession queue path and has targeted coverage for the key races.
- Low risk to bash monitor matching itself: BackgroundProcessManager monitor detection and tool schemas are unchanged.

Pains
- The environment was headless, so UI screenshot/video dogfooding had to be replaced with terminal evidence plus generated summary media.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan: Prompt Bash Monitor Wake-ups at the Next Tool Boundary

## Goal

Make background Bash `monitor` wake messages useful during an active agent turn: when a monitored background Bash process prints a matching line, Mux should enqueue the synthetic monitor wake so the active stream is soft-stopped after the **next real tool-call end**, and the wake message is injected promptly as the next turn. It should no longer wait until the whole current turn naturally reaches idle.

## Current verified behavior

Evidence gathered from code inspection, focused tests, and an Explore cross-check:

- `src/node/services/backgroundProcessManager.ts`
  - `BackgroundProcessManager` tails background process output independently of `task_await` cursors.
  - `monitorTailLoop()` polls local runtimes every 100ms, filters complete lines, coalesces via `cooldownMs`, enforces `maxEvents`, and emits `monitor:match` through `emitMonitorMatch()`.
  - This lower-level monitor detection is already prompt.
- `src/node/services/workspaceService.ts`
  - `handleBashMonitorMatch()` persists matches with `BashMonitorWakeStore.enqueueOrMergePending()` and schedules `drainBashMonitorWakes()`.
  - `drainBashMonitorWakes()` currently returns early when `aiService.isStreaming(ownerWorkspaceId)` or session-backed busy state is true, and sends with internal `{ requireIdle: true }` when idle.
  - Result: matched monitor output is stored quickly, but the synthetic chat wake is held until the owner workspace becomes idle.
- `src/node/services/agentSession.ts` and `src/node/services/messageQueue.ts`
  - `MessageQueue` defaults to `queueDispatchMode: "tool-end"`.
  - `AgentSession.queueMessage()` records tool-end queued messages and sets the background manager's queued-message flag for `bash_output` early return.
  - On non-replayed `tool-call-end`, `AgentSession.requestQueuedToolEndDispatchAfterCurrentTool()` soft-stops the current stream with `{ soft: true, abortReason: "system" }`.
  - On the following system abort, `dispatchQueuedToolEndMessageAfterAbort()` sends the queued message.
- Focused tests already pass for the existing behavior:
  - `bun test src/node/services/backgroundProcessManager.test.ts --test-name-pattern "monitor"`
  - `bun test src/node/services/workspaceService.test.ts --test-name-pattern "monitor wakes|stream errors|owner stream"`
  - `bun test src/node/services/agentSession.queueDispatch.test.ts`

## Recommended approach

### Approach A — Use the existing `queueDispatchMode: "tool-end"` queue path for Bash monitor wakes

**Recommendation:** implement this.

**Net product-code LoC estimate:** approximately **+35 to +70 LoC** across `src/node/services/workspaceService.ts` and a small snapshot-safe cancellation helper in `src/node/services/bashMonitorWakeStore.ts`. Tests are additional and excluded from this estimate.

Why this is the right seam:

- It reuses the existing, tested stream-preemption semantics instead of inventing a monitor-specific interrupt path.
- It keeps monitor detection (`BackgroundProcessManager`) separate from chat dispatch policy (`WorkspaceService`/`AgentSession`).
- It preserves current durable pending wake storage and merge behavior in `BashMonitorWakeStore`.
- It automatically benefits from existing queue behavior:
  - tool-end sticky dispatch mode,
  - foreground `task_await` backgrounding via `taskService.backgroundForegroundWaitsForWorkspace()`,
  - soft system abort handling,
  - queue UI updates.

<details>
<summary>Rejected alternatives</summary>

### Alternative B — Directly stop the stream from `WorkspaceService` when a monitor matches

**Net product-code LoC estimate:** +40 to +80 LoC.

Not recommended. It would duplicate `AgentSession`'s queue/soft-stop state machine, increasing risk around replayed tool events, user aborts, queued edits, and stream phase transitions.

### Alternative C — Only remove `requireIdle` and mark wakes delivered immediately after `sendMessage()` returns

**Net product-code LoC estimate:** +5 to +15 LoC.

Not recommended. It is tempting but less crash-safe: when a busy session accepts the monitor prompt into the in-memory queue, `sendMessage()` returns `Ok` before the queued synthetic user message is persisted to history. Marking the wake delivered at that moment could lose the wake if the app crashes before queue dispatch.

</details>

## Implementation details

### 1. Update `WorkspaceService.drainBashMonitorWakes()`

File: `src/node/services/workspaceService.ts`

Change the drain behavior from “send only when idle” to “send immediately when idle, enqueue with tool-end preemption during an active session-backed stream, and defer safely for other busy states.”

Concrete changes:

1. Keep these existing guards unchanged:
   - Load pending records via `bashMonitorWakeStore.listPending(ownerWorkspaceId)`.
   - Supersede records if the owner workspace no longer exists.
   - Leave records pending if `getWorkflowContinuationSendOptions(ownerWorkspaceId)` returns `null`.
2. Replace the broad idle-only gate with explicit state classification:
   - **Idle owner:** send immediately.
   - **Session-backed active stream:** if `isBusyForMessage(ownerWorkspaceId)` and `aiService.isStreaming(ownerWorkspaceId)` are both true, and queue/preparing/retry state is clear, call `sendMessage()` and let it enqueue with `queueDispatchMode: "tool-end"`.
   - **Session-busy but not AIService-streaming:** defer after idle/no-queue. This avoids queuing during late `COMPLETING`, after the normal stream-end queue flush may already have run.
   - **Already queued, preparing, auto-retry pending, or another internal queued callback:** leave the wake pending and schedule a drain after idle/no-queue.
   - **`aiService.isStreaming(ownerWorkspaceId) === true` but no session-backed busy state:** leave the wake pending and rely on `stream-end` / `stream-abort` / `error` listeners to schedule the next drain. Do not call `sendMessage()` in this state, because it may start a concurrent stream instead of queueing.
3. Build the same wake prompt with `buildBashMonitorWakePrompt(pending)`.
4. Send through `WorkspaceService.sendMessage()` only for the idle or session-backed active-stream cases, with:
   - `options: { ...sendOptions, queueDispatchMode: "tool-end" }`
   - internal flags:
     - `skipAutoResumeReset: true`
     - `synthetic: true`
     - `agentInitiated: true`
     - **no `requireIdle: true`**
     - an `onAccepted` callback that marks exactly the dispatched pending snapshots as delivered.
5. Do **not** mark wake records delivered immediately after `sendMessage()` returns. Delivery should be marked only once `AgentSession.sendMessage()` accepts/persists the synthetic user message into history.

Suggested shape:

```ts
const hasSessionBusyTurn = this.isBusyForMessage(ownerWorkspaceId);
const aiServiceStreaming = this.aiService.isStreaming(ownerWorkspaceId);
const hasQueuedPreparingOrRetry = this.hasPendingQueuedOrPreparingTurn(ownerWorkspaceId);
const aiServiceOnlyStreaming = aiServiceStreaming && !hasSessionBusyTurn;
const sessionBusyWithoutAiStream = hasSessionBusyTurn && !aiServiceStreaming;

if (hasQueuedPreparingOrRetry || sessionBusyWithoutAiStream) {
  this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
  return;
}

if (aiServiceOnlyStreaming) {
  // Avoid starting a concurrent stream when only AIService still reports streaming.
  // Existing stream-end / stream-abort / error listeners reschedule the drain.
  return;
}

const retryAfterIdleIfBusy = (reason: string): void => {
  if (this.isBusyForMessage(ownerWorkspaceId) || this.hasPendingQueuedOrPreparingTurn(ownerWorkspaceId)) {
    this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
    return;
  }
  log.debug("Bash monitor wake left pending without immediate retry", { ownerWorkspaceId, reason });
};

const records = pending;
const prompt = buildBashMonitorWakePrompt(records);

const markDeliveredAfterAccepted = async (): Promise<void> => {
  let hasUndeliveredMergedMatches = false;
  for (const record of records) {
    const delivered = await this.bashMonitorWakeStore.markDeliveredSnapshot(
      ownerWorkspaceId,
      record
    );
    if (!delivered) {
      hasUndeliveredMergedMatches = true;
    }
  }

  if (hasUndeliveredMergedMatches) {
    this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
  }
};


const markSupersededAfterCanceled = async (): Promise<void> => {
  let hasNewMergedMatches = false;
  for (const record of records) {
    const superseded = await this.bashMonitorWakeStore.markSupersededSnapshot(
      ownerWorkspaceId,
      record
    );
    if (!superseded) {
      hasNewMergedMatches = true;
    }
  }

  if (hasNewMergedMatches) {
    this.scheduleBashMonitorWakeDrainAfterIdle(ownerWorkspaceId);
  }
};

const sendResult = await this.sendMessage(
  ownerWorkspaceId,
  prompt,
  { ...sendOptions, queueDispatchMode: "tool-end" },
  {
    skipAutoResumeReset: true,
    synthetic: true,
    agentInitiated: true,
    onAccepted: async () => {
      try {
        await markDeliveredAfterAccepted();
      } catch (error) {
        log.error("Failed to mark bash monitor wake delivered after accepted send", {
          ownerWorkspaceId,
          error,
        });
      }
    },
    onAcceptedPreStreamFailure: async (error) => {
      log.debug("Bash monitor wake accepted queue failed before stream start; leaving pending", {
        ownerWorkspaceId,
        error,
      });
      retryAfterIdleIfBusy("pre-stream failure");
    },
    onCanceled: async (reason) => {
      log.debug("Bash monitor wake queue was canceled; superseding canceled snapshot", {
        ownerWorkspaceId,
        reason,
      });
      try {
        await markSupersededAfterCanceled();
      } catch (error) {
        log.error("Failed to supersede canceled bash monitor wake snapshot", {
          ownerWorkspaceId,
          error,
        });
      }
    },
  }
);

if (!sendResult.success) {
  retryAfterIdleIfBusy("sendMessage rejected");
}
```

This is illustrative pseudocode. During implementation, keep names and helper placement consistent with surrounding `WorkspaceService` style and add assertions where a helper accepts a workspace id or records list.

Notes for the implementer:

- The callback must catch and log delivery-marker failures rather than throw. `AgentSession.sendMessage()` treats `onAccepted` errors as send failures, and a disk-marker failure should not prevent the accepted monitor wake from starting.
- If `sendMessage()` returns `Err`, leave records pending. Schedule an after-idle retry only when the workspace is currently session-busy, queued, preparing, or retrying; if the workspace is idle and still rejects the send, log and leave pending to avoid a tight retry loop.
- Use the guarded retry rule from `sendMessage()` `Err` and `onAcceptedPreStreamFailure`. Do not use it for `onCanceled`; cancellation should snapshot-supersede the canceled wake instead of requeueing the same wake after idle.
- If `markDeliveredSnapshot()` returns `false`, new monitor lines were merged while the snapshot was being delivered. Keep the existing retry-after-idle behavior so those new lines are delivered in a later synthetic turn.
- Keep `BashMonitorWakeStore`'s existing delivery behavior unchanged; add only the snapshot-safe supersede path needed for cancellation.

### 2. Add snapshot-safe cancellation support in `BashMonitorWakeStore`

File: `src/node/services/bashMonitorWakeStore.ts`

Add a small helper for cancellation/supersession that mirrors `markDeliveredSnapshot()` semantics but writes `status: "superseded"` for the exact canceled snapshot:

- Proposed public method: `markSupersededSnapshot(ownerWorkspaceId: string, snapshot: BashMonitorWakeRecord): Promise<boolean>`.
- If the current record still exactly matches the snapshot, mark it `superseded` and return `true`.
- If newer lines were merged into the same record after the snapshot was queued, remove only the canceled snapshot overlap and leave the newer lines pending, returning `false`.
- Prefer extracting the shared snapshot-overlap transition logic from `markDeliveredSnapshot()` rather than duplicating it, but keep the helper local and minimal.
- Add assertions for non-empty `ownerWorkspaceId` and snapshot id.

Use this helper from monitor wake `onCanceled` so a user-cleared monitor wake does not resurrect the same snapshot on the next stream-end/idle drain, while still preserving later merged monitor lines.

### 3. Preserve existing queue semantics

Do not change:

- `BackgroundProcessManager` monitor matching, polling, coalescing, `maxEvents`, or `monitor:match` payload shape.
- Bash tool schema or tool result shape.
- `AgentSession.requestQueuedToolEndDispatchAfterCurrentTool()`.
- `MessageQueue` dispatch-mode stickiness.
- `taskService.backgroundForegroundWaitsForWorkspace()` behavior.

The point of this change is to route monitor wakes into the existing queue path, not create a new queue/interrupt mechanism.

### 4. Tests

#### Unit tests: `src/node/services/workspaceService.test.ts`

Add or update behavior-focused tests. Avoid tautological prompt-text assertions except where needed to prove matched line inclusion already covered by existing tests.

1. **Idle monitor wake sends with tool-end options and marks delivered on acceptance**
   - Arrange a workspace and emit `monitor:match`.
   - Spy/mock `workspaceService.sendMessage()` so it calls `internal?.onAccepted?.()` before returning `Ok(undefined)`.
   - Assert:
     - `sendMessage` is called once.
     - Send options include `queueDispatchMode: "tool-end"`.
     - Internal options include `synthetic: true`, `agentInitiated: true`, `skipAutoResumeReset: true`.
     - Internal options do not include `requireIdle: true`.
     - Pending wake store is empty after `onAccepted` runs.

2. **Session-backed streaming owner queues immediately instead of waiting for natural turn end**
   - Create or mock an owner session whose `isBusy()` state is true and whose queue/preparing/retry state is clear.
   - Emit `monitor:match` while `aiService.isStreaming()` is true.
   - Assert:
     - `sendMessage` is called promptly.
     - The call uses `queueDispatchMode: "tool-end"` and no `requireIdle`.
     - The wake is not held until `stream-end`.

3. **AIService-only streaming state does not start a concurrent stream**
   - Preserve the spirit of the existing “does not spin idle waiters when only aiService reports an owner stream” test.
   - Set `aiService.isStreaming()` to return `true` while no session-backed busy state exists.
   - Emit `monitor:match`.
   - Assert:
     - `sendMessage` is not called.
     - `waitForIdleAndNoQueuedMessages` is not called just because `aiService.isStreaming()` is true.
     - The wake remains pending for the existing stream-end/abort/error listener to drain later.

4. **Session-busy but not AIService-streaming defers instead of queueing late**
   - Arrange session-backed busy state with `aiService.isStreaming()` false, representing late `COMPLETING` or another non-streaming busy phase.
   - Emit `monitor:match`.
   - Assert:
     - `sendMessage` is not called.
     - an after-idle/no-queue drain is scheduled.
     - the wake remains pending.

5. **Busy owner relies on queue path and backgrounds foreground waits**
   - Use the existing `WorkspaceService.sendMessage` fake-session tests as a model.
   - Call `workspaceService.sendMessage()` with `queueDispatchMode: "tool-end"` and synthetic/internal callback flags while `fakeSession.isBusy()` returns true.
   - Assert:
     - `fakeSession.queueMessage` is called.
     - `taskService.backgroundForegroundWaitsForWorkspace(workspaceId)` is called for effective `tool-end` dispatch.
     - `taskService.resetAutoResumeCount` is not called when `skipAutoResumeReset` is true.

6. **Rejected busy send leaves wake pending and schedules an idle retry**
   - Mock `sendMessage()` to return an `Err` representing a busy/interrupted/preparing state.
   - Assert the wake remains pending.
   - Assert `waitForIdleAndNoQueuedMessages()` or equivalent after-idle scheduling is engaged once.

7. **Rejected idle send leaves wake pending without a tight retry loop**
   - Mock the owner as idle but make `sendMessage()` return `Err`.
   - Assert the wake remains pending.
   - Assert no immediate idle-wait spin is scheduled.

8. **Merged matches during queued delivery remain pending**
   - Use `BashMonitorWakeStore.markDeliveredSnapshot()` behavior through the drain path if practical.
   - Simulate `onAccepted` after another `monitor:match` merged into the same process record.
   - Assert the original snapshot is considered delivered while the newer line remains pending and a retry is scheduled.

9. **Canceled queued monitor wake supersedes only the canceled snapshot**
   - Queue a monitor wake with `onCanceled` captured.
   - Before invoking `onCanceled`, merge another monitor line into the same process record.
   - Invoke `onCanceled`.
   - Assert the canceled snapshot does not reappear on later drains, while the newer merged line remains pending.

10. **Stream-abort drain race does not duplicate the wake**
   - Queue a monitor wake during a session-backed streaming turn.
   - Before `onAccepted` marks records delivered, simulate the `stream-abort` listener scheduling another drain.
   - Assert the second drain does not queue/send a duplicate prompt while the first internal monitor wake is already queued or being accepted.
   - Assert the pending record is eventually delivered exactly once after `onAccepted`.

11. **Existing queued human/internal message keeps monitor wake pending**
   - Arrange a workspace with an existing queued human message or an existing internal queued callback.
   - Emit `monitor:match`.
   - Assert the monitor wake does not merge into the human message, does not throw/drop, and remains pending for a later drain.
   - Assert an after-idle/no-queue retry is scheduled when appropriate.

#### Unit tests: `src/node/services/bashMonitorWakeStore.test.ts`

Add store-level tests for the new snapshot-safe cancellation helper:

1. `markSupersededSnapshot` marks an unchanged pending snapshot as `superseded` and removes it from `listPending()`.
2. `markSupersededSnapshot` preserves newer merged lines when the current record changed after the canceled snapshot.
3. `markSupersededSnapshot` is a no-op/success when the current record is already non-pending, matching `markDeliveredSnapshot()` tolerance.

#### Existing tests to keep green

Run at minimum:

```bash
run_and_report "monitor-manager-tests" bun test src/node/services/backgroundProcessManager.test.ts --test-name-pattern "monitor"
run_and_report "monitor-wake-store-tests" bun test src/node/services/bashMonitorWakeStore.test.ts
run_and_report "monitor-wake-workspace-tests" bun test src/node/services/workspaceService.test.ts --test-name-pattern "monitor|queue|wake"
run_and_report "queue-dispatch-tests" bun test src/node/services/agentSession.queueDispatch.test.ts
run_and_report "message-queue-tests" bun test src/node/services/messageQueue.test.ts
```

#### Broader validation gate

After targeted tests pass:

```bash
run_and_report "typecheck" make typecheck
run_and_report "lint" make lint
```

If the touched tests or dependencies are broader than expected, finish with:

```bash
run_and_report "static-check" make static-check
```

If ESLint OOMs in this workspace, retry with:

```bash
MUX_ESLINT_CONCURRENCY=1 run_and_report "static-check" make static-check
```

## Dogfooding plan

The dogfood must prove the user-visible timing, not just unit behavior.

### Dogfood scenario A: automated/local behavior proof

1. Start a Mux dev environment or test harness in an isolated `MUX_ROOT`.
2. Create/open a test workspace.
3. Start a background Bash command with a monitor, e.g. a command that prints a sentinel line after a short delay and keeps running:
   ```bash
   bash({
     script: "sleep 1; echo MUX_MONITOR_SENTINEL; sleep 30",
     run_in_background: true,
     display_name: "Monitor timing dogfood",
     timeout_secs: 60,
     monitor: { filter: "MUX_MONITOR_SENTINEL", cooldown_ms: 0, max_events: 1 }
   })
   ```
4. While the owner turn is still active, make the agent perform another real tool call that lasts long enough for the monitor to match.
5. Verify ordering:
   - monitor process emits the sentinel,
   - the active stream continues until its next real tool result finishes,
   - Mux soft-stops that stream with a system abort,
   - the synthetic monitor wake appears as the next user message before natural turn end,
   - the wake prompt includes the matched sentinel and task ID.
6. Capture evidence:
   - screenshot of the chat showing the monitor wake injected before the original turn naturally completed,
   - screenshot of the background process/banner or `task_await` output showing the monitor source,
   - a short screen recording of the sequence.

### Dogfood scenario B: idle fallback still works

1. With the owner workspace idle, start a monitored background Bash process that prints the sentinel.
2. Verify Mux starts a new synthetic monitor wake turn immediately.
3. Capture a screenshot and, if practical, include it in the same screen recording.

### Dogfood scenario C: no duplicate/lost wakes under repeated matches

1. Start a monitored background process that prints two sentinel lines separated by a short delay.
2. Use `max_events: 2` or no `max_events`, with a small cooldown.
3. Verify:
   - burst lines may coalesce into one wake when within cooldown,
   - later merged lines are not lost if they arrive while the first wake is being accepted,
   - no duplicate synthetic prompts are generated for the same delivered snapshot.
4. Capture terminal output or chat screenshots showing the final delivered line set.

### Screenshot/video tooling

- Prefer `agent-browser` or the Electron automation skill to capture screenshots and a short video of the Mux UI.
- If the environment is headless and Electron screenshots/video are blocked, document the blocker and capture terminal evidence with a timestamped transcript plus screenshots of the terminal/test output. Do not claim UI visual dogfooding passed without actual UI screenshots/video.

## Acceptance criteria

Functional:

- A background Bash `monitor:match` during a session-backed streaming owner turn causes a monitor wake message to be queued with effective `queueDispatchMode: "tool-end"`.
- The active stream is not interrupted immediately in the middle of arbitrary model text; it is soft-stopped after the next non-replayed `tool-call-end`.
- The synthetic monitor wake is sent as the next turn after that system soft abort.
- If the owner workspace is idle, the monitor wake still sends immediately.
- If only `aiService` reports streaming and no session-backed busy state is visible, no concurrent stream is started; the wake remains pending for the stream-end/abort/error drain.
- If the session is busy but `aiService` is no longer streaming, the wake defers until idle/no-queue instead of queueing during late completion.
- If the owner workspace already has a queued message, is preparing a turn, is waiting on auto-retry, or otherwise cannot accept another internal queued wake, the wake remains pending and is retried after idle/no-queue; it is not dropped or merged into human text.
- Delivered wake records are marked delivered only after the synthetic monitor user message is accepted/persisted.
- A user-canceled monitor wake queue supersedes only the canceled snapshot so it does not resurrect on later drains; newer merged monitor lines remain pending.
- New matching lines merged while a snapshot is being delivered remain pending for a later wake.
- No duplicate monitor wake prompt is emitted for an already delivered or already queued snapshot.

Non-functional:

- Keep changes minimal and localized; expected product-code touch is `src/node/services/workspaceService.ts` plus the snapshot-safe `markSupersededSnapshot()` helper in `src/node/services/bashMonitorWakeStore.ts`.
- Preserve current `BackgroundProcessManager` behavior and Bash tool schema.
- Preserve crash-safety better than the naïve `sendMessage() returned Ok` marker by using `onAccepted`.
- Avoid unbounded retry loops on persistent idle send failures.
- Preserve existing queue dispatch tests and message queue invariants.

## Quality gates

1. **After implementation:** run the targeted unit tests listed above.
2. **After fixing targeted failures:** run `make typecheck` and `make lint`.
3. **Before claiming done:** run `make static-check` unless there is a concrete environment blocker; if blocked, report the exact blocker and all passing targeted checks.
4. **Dogfood before final summary:** capture screenshots and a short video/recording demonstrating the next-tool-boundary wake behavior.

## Review focus for implementer

- Check that `onAccepted` cannot throw out of the callback.
- Check that `onAcceptedPreStreamFailure` leaves wake records pending without immediate idle resurrection loops, and `onCanceled` snapshot-supersedes the canceled wake while preserving newer merged lines.
- Check that monitor wakes do not get lost between queue acceptance and actual stream dispatch.
- Check that `aiService`-only streaming does not create a concurrent stream.
- Check that a stream-abort-triggered drain cannot duplicate an already queued monitor wake.
- Check that the `MessageQueue` callback restriction does not create an unacceptable UX regression; if a human message is already queued, leave monitor wakes pending rather than dropping them.
- Check that the tests verify behavior/timing, not exact prose.

## Advisor review status

Advisor approved after three review rounds. Non-blocking implementation cautions from final review:

- Keep `markSupersededSnapshot()` snapshot-safe exactly like `markDeliveredSnapshot()`; if newer lines remain, return `false` and leave them pending.
- Do not set `deliveredAt` for `superseded` records.
- Keep the state-classification order aligned with this plan: queued/preparing/retry → defer; session-busy-not-streaming → defer; AIService-only streaming → return; otherwise send.
- Treat the stream-abort duplicate race and canceled-snapshot-preserves-newer-lines tests as mandatory.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$38.06`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=38.06 -->



