### PR TITLE
ci: pin Node 22 in setup-mux to fix macOS E2E install hang

### DIFF
--- a/.github/actions/setup-mux/action.yml
+++ b/.github/actions/setup-mux/action.yml
@@ -30,14 +30,24 @@ runs:
       shell: bash
       run: echo "version=$(bun --version)" >> $GITHUB_OUTPUT
 
+    # Capture the Node version to key the node_modules cache below. Without it, changing
+    # the pinned Node (e.g. from the runner default to the version pinned above) would hit
+    # a cache built under the old Node and skip `bun install`, keeping modules whose
+    # postinstalls (Electron) ran — and whose native ABI was built — under the wrong Node,
+    # which defeats this pin. (Codex review, PR #3656.)
+    - name: Get Node version
+      id: node-version
+      shell: bash
+      run: echo "version=$(node --version)" >> $GITHUB_OUTPUT
+
     - name: Cache node_modules
       id: cache-node-modules
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: node_modules
-        key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.bun-version.outputs.version }}-node-modules-${{ hashFiles('**/bun.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.bun-version.outputs.version }}-node-${{ steps.node-version.outputs.version }}-node-modules-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
-          ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.bun-version.outputs.version }}-node-modules-
+          ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.bun-version.outputs.version }}-node-${{ steps.node-version.outputs.version }}-node-modules-
 
     - name: Check if node_modules exists
       id: check-node-modules

--- a/.github/actions/setup-mux/action.yml
+++ b/.github/actions/setup-mux/action.yml
@@ -8,6 +8,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Pin Node 22 (LTS) before anything installs deps. The GitHub runners now default
+    # to Node 24, whose extract-zip regression (nodejs/node#63487) hangs/corrupts zip
+    # extraction in dependency postinstalls — it breaks Electron's `node install.js`
+    # ("Electron failed to install correctly") and Playwright's browser install (stalls
+    # at 100%), which intermittently fails Test / E2E (macos) on a browser-cache miss.
+    # Node 22 is unaffected (microsoft/playwright#41092 workaround). Runs first so its
+    # `node` is on PATH for every subsequent `bun install` / `bun x` step.
+    - name: Setup Node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: "22"
+
     - name: Setup Bun
       uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
       with:


### PR DESCRIPTION
## Summary

Pins **Node 22** in the shared `setup-mux` composite action so every CI job installs dependencies under a known-good Node, fixing the intermittent `Test / E2E (macos)` failures.

## Background

GitHub runners now default to **Node 24**, which has an `extract-zip` regression ([nodejs/node#63487](https://github.com/nodejs/node/issues/63487)) that hangs/corrupts zip extraction in dependency postinstalls. On the macOS runner this surfaces two ways, both gated on a cache miss:

- **Electron**: `node install.js` postinstall fails → `electron.launch: Electron failed to install correctly` (triggered whenever `bun.lock` changes → node_modules cache miss → fresh install).
- **Playwright**: `playwright install` downloads Chromium to 100% then stalls forever → the `setup-playwright` step times out (triggered on a browser-cache miss).

That cache-miss dependency is exactly the "sometimes works, sometimes doesn't" behavior. Node 22 (LTS) is unaffected; this is the documented workaround in [microsoft/playwright#41092](https://github.com/microsoft/playwright/issues/41092).

## Implementation

Add `actions/setup-node@v4` (`node-version: 22`) as the **first** step of `.github/actions/setup-mux`, before Bun setup and `bun install`, so its `node` is on `PATH` for every subsequent `bun install` (Electron postinstall) and `bun x playwright install` step across all jobs that use `setup-mux`.

## Validation

This PR touches `.github/**` (→ the `config` path filter), so the full `Test / E2E (macos)` job runs here. Its node_modules cache hits but the Playwright browser cache misses, so this run exercises a real `playwright install` under Node 22 — i.e. the failing path is directly tested by this PR's own CI.

## Risks

Low. CI-only; no product code. The repo is Bun-based, so Node is used only for dependency postinstall scripts — pinning the LTS is strictly safer than the runner's rolling default. `_npm-publish.yml` independently pins Node (24) and is unaffected.
