### PR TITLE
🤖 fix: show workspace lifecycle display names

### DIFF
--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.stories.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.stories.tsx
@@ -46,9 +46,24 @@ export const ArchiveMultiple: Story = {
     defaultExpanded: true,
     result: {
       results: [
-        { status: "archived", action: "archive", workspaceId: "24e33167af" },
-        { status: "archived", action: "archive", workspaceId: "4a92f76fbf" },
-        { status: "archived", action: "archive", workspaceId: "0b71c40e21" },
+        {
+          status: "archived",
+          action: "archive",
+          workspaceId: "24e33167af",
+          displayName: "Fix streaming resume",
+        },
+        {
+          status: "archived",
+          action: "archive",
+          workspaceId: "4a92f76fbf",
+          displayName: "Review settings polish",
+        },
+        {
+          status: "archived",
+          action: "archive",
+          workspaceId: "0b71c40e21",
+          displayName: "Investigate sidebar jitter",
+        },
       ],
     },
   },
@@ -142,6 +157,7 @@ export const BlockedNeedsAction: Story = {
           status: "requires_confirmation",
           action: "archive",
           workspaceId: "feature-billing-webhooks-experiment-very-long-id-001",
+          displayName: "Billing webhooks experiment",
           paths: [
             "packages/server/src/very/deeply/nested/path/to/an/untracked/file/that/is/quite/long/scratch.local.ts",
             ".env.local",
@@ -151,6 +167,7 @@ export const BlockedNeedsAction: Story = {
           status: "active",
           action: "archive",
           workspaceId: "4a92f76fbf",
+          displayName: "Running cleanup follow-up",
           activeTaskIds: ["wst_4a92f76fbf01"],
         },
       ],

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.tsx
@@ -203,6 +203,11 @@ function targetIdLabel(target: { taskId?: string | null; workspaceId?: string | 
   return target.workspaceId ?? target.taskId ?? "workspace";
 }
 
+function trimToNonEmpty(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed != null && trimmed.length > 0 ? trimmed : null;
+}
+
 const Dot: React.FC<{ tone: Tone }> = (props) => (
   <span className={cn("inline-block h-1.5 w-1.5 shrink-0 rounded-full", TONE_DOT[props.tone])} />
 );
@@ -306,10 +311,16 @@ const WorkspaceRow: React.FC<{
   const row = props.row;
   const meta = STATUS_META[row.status];
   const Icon = meta.Icon;
-  const primary = targetIdLabel(row);
-  // Show the originating wst_… task id as a secondary line only when distinct from the
-  // primary (resolved) workspace id.
-  const secondary = row.taskId != null && row.taskId !== primary ? row.taskId : null;
+  const idLabel = targetIdLabel(row);
+  const displayName = trimToNonEmpty(row.displayName);
+  // Match the left-sidebar label when the backend captured one, while still keeping the
+  // stable workspace/task identifiers visible for copy/paste and debugging.
+  const primary = displayName != null && displayName !== idLabel ? displayName : idLabel;
+  const secondaryItems = [
+    primary !== idLabel ? idLabel : null,
+    row.taskId != null && row.taskId !== idLabel ? row.taskId : null,
+  ].filter((item): item is string => item != null);
+  const secondary = secondaryItems.length > 0 ? secondaryItems.join(" · ") : null;
   const hint = blockedHint(row.status, props.action);
 
   return (

--- a/src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx
+++ b/src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx
@@ -125,6 +125,31 @@ describe("WorkspaceLifecycleToolCall", () => {
     expect(view.queryByText("wst_running01")).not.toBeNull();
   });
 
+  test("renders captured workspace display name while keeping identifiers visible", () => {
+    const view = renderWithProviders(
+      <WorkspaceLifecycleToolCall
+        args={{ action: "archive", targets: [{ taskId: "wst_display" }] }}
+        status="completed"
+        defaultExpanded
+        result={{
+          results: [
+            {
+              status: "archived",
+              action: "archive",
+              taskId: "wst_display",
+              workspaceId: "ws-display",
+              displayName: "Archive cleanup",
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(view.queryByText("Archive cleanup")).not.toBeNull();
+    expect(view.queryByText(/ws-display/)).not.toBeNull();
+    expect(view.queryByText(/wst_display/)).not.toBeNull();
+  });
+
   test("self-heals a malformed result by falling back to the requested targets", () => {
     const view = renderWithProviders(
       <WorkspaceLifecycleToolCall

--- a/src/common/utils/tools/toolDefinitions.ts
+++ b/src/common/utils/tools/toolDefinitions.ts
@@ -1080,6 +1080,7 @@ const TaskWorkspaceLifecycleBaseResultSchema = z.object({
   action: TaskWorkspaceLifecycleActionSchema,
   taskId: z.string().optional(),
   workspaceId: z.string().optional(),
+  displayName: z.string().optional(),
   paths: z.array(z.string()).optional(),
   activeTaskIds: z.array(z.string()).optional(),
   note: z.string().optional(),

--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -652,6 +652,7 @@ describe("TaskService", () => {
         path: path.join(projectPath, "child"),
         id: "childworkspace",
         name: "child",
+        title: "Child workspace",
         createdAt: new Date().toISOString(),
         runtimeConfig: { type: "local" },
         ...(options.archived ? { archivedAt: new Date().toISOString() } : {}),
@@ -698,7 +699,12 @@ describe("TaskService", () => {
     );
 
     expect(archived).toEqual(
-      Ok({ status: "archived", action: "archive", workspaceId: "childworkspace" })
+      Ok({
+        status: "archived",
+        action: "archive",
+        workspaceId: "childworkspace",
+        displayName: "Child workspace",
+      })
     );
     expect(archive).toHaveBeenCalledWith("childworkspace", undefined);
 
@@ -742,6 +748,7 @@ describe("TaskService", () => {
         action: "archive",
         taskId: "wst_existing",
         workspaceId: "childworkspace",
+        displayName: "Child workspace",
       })
     );
     expect(archive).toHaveBeenCalledWith("childworkspace", undefined);
@@ -865,10 +872,20 @@ describe("TaskService", () => {
     );
 
     expect(deleteResult).toEqual(
-      Ok({ status: "requires_archive", action: "delete_worktree", workspaceId: "childworkspace" })
+      Ok({
+        status: "requires_archive",
+        action: "delete_worktree",
+        workspaceId: "childworkspace",
+        displayName: "Child workspace",
+      })
     );
     expect(removeResult).toEqual(
-      Ok({ status: "requires_archive", action: "remove", workspaceId: "childworkspace" })
+      Ok({
+        status: "requires_archive",
+        action: "remove",
+        workspaceId: "childworkspace",
+        displayName: "Child workspace",
+      })
     );
     expect(deleteWorktree).not.toHaveBeenCalled();
     expect(remove).not.toHaveBeenCalled();
@@ -923,6 +940,7 @@ describe("TaskService", () => {
         status: "requires_confirmation",
         action: "archive",
         workspaceId: "childworkspace",
+        displayName: "child",
         paths: ["scratch.txt"],
       })
     );
@@ -940,6 +958,7 @@ describe("TaskService", () => {
         action: "archive",
         taskId: "wst_created",
         workspaceId: "childworkspace",
+        displayName: "child",
         paths: ["scratch.txt"],
       })
     );
@@ -973,7 +992,12 @@ describe("TaskService", () => {
     );
 
     expect(alreadyArchived).toEqual(
-      Ok({ status: "already_archived", action: "archive", workspaceId: "childworkspace" })
+      Ok({
+        status: "already_archived",
+        action: "archive",
+        workspaceId: "childworkspace",
+        displayName: "child",
+      })
     );
     expect(confirmationArchive).toHaveBeenCalledTimes(2);
   });
@@ -1016,6 +1040,7 @@ describe("TaskService", () => {
         status: "active",
         action: "delete_worktree",
         workspaceId: "childworkspace",
+        displayName: "Child workspace",
         activeTaskIds: ["wst_running"],
       })
     );
@@ -1028,7 +1053,12 @@ describe("TaskService", () => {
     );
 
     expect(interrupted).toEqual(
-      Ok({ status: "deleted_worktree", action: "delete_worktree", workspaceId: "childworkspace" })
+      Ok({
+        status: "deleted_worktree",
+        action: "delete_worktree",
+        workspaceId: "childworkspace",
+        displayName: "Child workspace",
+      })
     );
     expect(deleteWorktree).toHaveBeenCalledWith("childworkspace");
     expect(archive).not.toHaveBeenCalled();
@@ -1046,7 +1076,12 @@ describe("TaskService", () => {
     );
 
     expect(removed).toEqual(
-      Ok({ status: "removed", action: "remove", workspaceId: "childworkspace" })
+      Ok({
+        status: "removed",
+        action: "remove",
+        workspaceId: "childworkspace",
+        displayName: "Child workspace",
+      })
     );
     expect(remove).toHaveBeenCalledWith("childworkspace", true);
 

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -192,6 +192,7 @@ interface WorkspaceLifecycleOptions {
 interface ResolvedWorkspaceLifecycleTarget {
   action: WorkspaceLifecycleAction;
   taskId?: string;
+  taskTitle?: string;
   workspaceId: string;
   metadata: WorkspaceMetadata | null;
 }
@@ -6007,6 +6008,7 @@ export class TaskService {
     assert(hasTaskId !== hasWorkspaceId, "workspace lifecycle target must have exactly one ID");
 
     let taskId: string | undefined;
+    let taskTitle: string | undefined;
     let workspaceId: string;
     if (hasTaskId) {
       taskId = target.taskId;
@@ -6018,6 +6020,7 @@ export class TaskService {
       if (record == null) {
         return { status: "invalid_scope", action, taskId };
       }
+      taskTitle = record.title;
       workspaceId = record.workspaceId;
     } else {
       assert(target.workspaceId != null, "workspace lifecycle workspaceId must be resolved");
@@ -6035,16 +6038,30 @@ export class TaskService {
     }
 
     const metadata = await this.findWorkspaceLifecycleMetadata(workspaceId);
-    return { action, ...(taskId != null ? { taskId } : {}), workspaceId, metadata };
+    return {
+      action,
+      ...(taskId != null ? { taskId } : {}),
+      ...(taskTitle != null ? { taskTitle } : {}),
+      workspaceId,
+      metadata,
+    };
   }
 
   private lifecycleTargetFields(resolved: ResolvedWorkspaceLifecycleTarget): {
     taskId?: string;
     workspaceId: string;
+    displayName?: string;
   } {
+    // Match the sidebar label so completed lifecycle tool rows remain understandable after
+    // archive/remove hides the child workspace from the active list.
+    const displayName =
+      coerceNonEmptyString(resolved.metadata?.title) ??
+      coerceNonEmptyString(resolved.metadata?.name) ??
+      coerceNonEmptyString(resolved.taskTitle);
     return {
       ...(resolved.taskId != null ? { taskId: resolved.taskId } : {}),
       workspaceId: resolved.workspaceId,
+      ...(displayName != null ? { displayName } : {}),
     };
   }
 


### PR DESCRIPTION
## Summary

Show the workspace display name in `task_workspace_lifecycle` transcript rows, while keeping the workspace ID and originating `wst_...` task ID visible as secondary identifiers.

## Background

Archived workspaces disappear from the active sidebar, but the lifecycle tool UI previously surfaced only stable IDs. That made it hard to map an archive result back to the workspace title the user saw in the sidebar.

## Implementation

- Add optional `displayName` support to workspace lifecycle tool result rows.
- Populate `displayName` from workspace metadata (`title` first, then `name`, then the task-turn title fallback).
- Render the display name as the primary row label and preserve copyable IDs on the secondary line.
- Extend UI and service tests plus Storybook fixture data for the new display shape.

## Validation

- `bun test src/browser/features/Tools/WorkspaceLifecycleToolCall.ui.test.tsx`
- `bun test src/node/services/tools/task_workspace_lifecycle.test.ts`
- `bun test src/node/services/taskService.test.ts --test-name-pattern "workspace lifecycle"`
- `make typecheck`
- `make fmt-check`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- Dogfooded with an `agent-browser` screenshot/video capture against a temporary Vite component harness at a narrow viewport.

## Risks

Low. Existing transcripts without `displayName` continue to render the prior ID-first fallback, and the schema field is optional.

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$21.03`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=21.03 -->
