### PR TITLE
🤖 feat: support workspace-staged ZIP attachments

### DIFF
--- a/src/browser/features/ChatInput/AttachFileButton.tsx
+++ b/src/browser/features/ChatInput/AttachFileButton.tsx
@@ -1,6 +1,6 @@
 /**
  * Attach file button - floats inside the chat input textarea next to the voice input button.
- * Opens a native file picker for images, SVGs, and PDFs.
+ * Opens a native file picker for images, SVGs, PDFs, and workspace-staged ZIPs.
  */
 
 import React, { useRef } from "react";
@@ -8,8 +8,8 @@ import { Paperclip } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/browser/components/Tooltip/Tooltip";
 import { cn } from "@/common/lib/utils";
 
-/** Accept filter for the file picker: images, SVGs, and PDFs */
-const FILE_ACCEPT = "image/*,.svg,.pdf";
+/** Accept filter for the file picker: provider attachments plus workspace-staged ZIPs. */
+const FILE_ACCEPT = "image/*,.svg,.pdf,.zip,application/zip,application/x-zip-compressed";
 
 interface AttachFileButtonProps {
   onFiles: (files: File[]) => void;
@@ -53,7 +53,7 @@ export const AttachFileButton: React.FC<AttachFileButtonProps> = (props) => {
           </button>
         </TooltipTrigger>
         <TooltipContent>
-          <strong>Attach file</strong> — images, SVGs, PDFs
+          <strong>Attach file</strong> — images, SVGs, PDFs, ZIPs
         </TooltipContent>
       </Tooltip>
       {/* Hidden file input — kept outside Tooltip to avoid stray DOM children */}

--- a/src/browser/features/ChatInput/ChatAttachments.tsx
+++ b/src/browser/features/ChatInput/ChatAttachments.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { FileText, X } from "lucide-react";
 
-export interface ChatAttachment {
+import { formatBytes } from "./stagedAttachments";
+
+export interface ProviderChatAttachment {
+  kind: "provider";
   id: string;
   url: string;
   mediaType: string;
@@ -14,6 +17,17 @@ export interface ChatAttachment {
     newHeight: number;
   };
 }
+
+export interface StagedChatAttachment {
+  kind: "staged";
+  id: string;
+  mediaType: string;
+  filename: string;
+  sizeBytes: number;
+  stagedPath: string;
+}
+
+export type ChatAttachment = ProviderChatAttachment | StagedChatAttachment;
 
 interface ChatAttachmentsProps {
   attachments: ChatAttachment[];
@@ -34,7 +48,7 @@ export const ChatAttachments: React.FC<ChatAttachmentsProps> = (props) => {
     <div className="flex flex-wrap gap-2 py-2">
       {props.attachments.map((attachment) => {
         const baseMediaType = getBaseMediaType(attachment.mediaType);
-        const isImage = baseMediaType.startsWith("image/");
+        const isImage = attachment.kind === "provider" && baseMediaType.startsWith("image/");
 
         if (isImage) {
           return (
@@ -68,6 +82,10 @@ export const ChatAttachments: React.FC<ChatAttachmentsProps> = (props) => {
 
         const label =
           attachment.filename ?? (baseMediaType === "application/pdf" ? "PDF" : baseMediaType);
+        const detail =
+          attachment.kind === "staged"
+            ? `workspace file • ${formatBytes(attachment.sizeBytes)}`
+            : null;
 
         return (
           <div
@@ -75,7 +93,12 @@ export const ChatAttachments: React.FC<ChatAttachmentsProps> = (props) => {
             className="border-border-light bg-dark flex max-w-[260px] items-center gap-2 rounded border px-2 py-1"
           >
             <FileText className="h-4 w-4 shrink-0 text-[var(--color-subtle)]" />
-            <span className="truncate text-xs text-[var(--color-subtle)]">{label}</span>
+            <span className="min-w-0 truncate text-xs text-[var(--color-subtle)]">
+              {label}
+              {detail ? (
+                <span className="ml-1 text-[var(--color-text-muted)]">{detail}</span>
+              ) : null}
+            </span>
             {handleRemove && (
               <button
                 onClick={() => handleRemove(attachment.id)}

--- a/src/browser/features/ChatInput/draftAttachmentsStorage.test.ts
+++ b/src/browser/features/ChatInput/draftAttachmentsStorage.test.ts
@@ -24,11 +24,69 @@ describe("draftAttachmentsStorage", () => {
       parsePersistedChatAttachments([
         { id: "img-1", url: "data:image/png;base64,AAA", mediaType: "image/png" },
       ])
-    ).toEqual([{ id: "img-1", url: "data:image/png;base64,AAA", mediaType: "image/png" }]);
+    ).toEqual([
+      { kind: "provider", id: "img-1", url: "data:image/png;base64,AAA", mediaType: "image/png" },
+    ]);
+  });
+
+  test("parsePersistedChatAttachments preserves legacy provider attachments", () => {
+    expect(
+      parsePersistedChatAttachments([
+        { id: "img-1", url: "data:image/png;base64,AAA", mediaType: "image/png" },
+      ])
+    ).toEqual([
+      { kind: "provider", id: "img-1", url: "data:image/png;base64,AAA", mediaType: "image/png" },
+    ]);
+  });
+
+  test("parsePersistedChatAttachments returns staged zip metadata without base64", () => {
+    expect(
+      parsePersistedChatAttachments([
+        {
+          kind: "staged",
+          id: "zip-1",
+          mediaType: "application/zip",
+          filename: "archive.zip",
+          sizeBytes: 123,
+          stagedPath: ".mux/user-attachments/id/archive.zip",
+        },
+      ])
+    ).toEqual([
+      {
+        kind: "staged",
+        id: "zip-1",
+        mediaType: "application/zip",
+        filename: "archive.zip",
+        sizeBytes: 123,
+        stagedPath: ".mux/user-attachments/id/archive.zip",
+      },
+    ]);
+  });
+
+  test("parsePersistedChatAttachments self-heals invalid staged records", () => {
+    expect(
+      parsePersistedChatAttachments([
+        {
+          kind: "staged",
+          id: "zip-1",
+          mediaType: "application/zip",
+          filename: "archive.zip",
+          sizeBytes: "123",
+          stagedPath: ".mux/user-attachments/id/archive.zip",
+        },
+      ])
+    ).toEqual([]);
   });
 
   test("estimatePersistedChatAttachmentsChars matches JSON length", () => {
-    const attachments = [{ id: "img-1", url: "data:image/png;base64,AAA", mediaType: "image/png" }];
+    const attachments = [
+      {
+        kind: "provider" as const,
+        id: "img-1",
+        url: "data:image/png;base64,AAA",
+        mediaType: "image/png",
+      },
+    ];
     expect(estimatePersistedChatAttachmentsChars(attachments)).toBe(
       JSON.stringify(attachments).length
     );

--- a/src/browser/features/ChatInput/draftAttachmentsStorage.ts
+++ b/src/browser/features/ChatInput/draftAttachmentsStorage.ts
@@ -5,13 +5,41 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isChatAttachment(value: unknown): value is ChatAttachment {
+function isProviderChatAttachment(value: unknown): value is {
+  kind?: "provider";
+  id: string;
+  url: string;
+  mediaType: string;
+  filename?: string;
+} {
   if (!isRecord(value)) return false;
   return (
+    (value.kind === undefined || value.kind === "provider") &&
     typeof value.id === "string" &&
     typeof value.url === "string" &&
     typeof value.mediaType === "string" &&
     (value.filename === undefined || typeof value.filename === "string")
+  );
+}
+
+function isStagedChatAttachment(value: unknown): value is {
+  kind: "staged";
+  id: string;
+  mediaType: string;
+  filename: string;
+  sizeBytes: number;
+  stagedPath: string;
+} {
+  if (!isRecord(value)) return false;
+  return (
+    value.kind === "staged" &&
+    typeof value.id === "string" &&
+    typeof value.mediaType === "string" &&
+    typeof value.filename === "string" &&
+    typeof value.sizeBytes === "number" &&
+    Number.isInteger(value.sizeBytes) &&
+    value.sizeBytes >= 0 &&
+    typeof value.stagedPath === "string"
   );
 }
 
@@ -22,16 +50,30 @@ export function parsePersistedChatAttachments(raw: unknown): ChatAttachment[] {
 
   const attachments: ChatAttachment[] = [];
   for (const item of raw) {
-    if (!isChatAttachment(item)) {
-      return [];
+    if (isProviderChatAttachment(item)) {
+      attachments.push({
+        kind: "provider",
+        id: item.id,
+        url: item.url,
+        mediaType: item.mediaType,
+        filename: item.filename,
+      });
+      continue;
     }
 
-    attachments.push({
-      id: item.id,
-      url: item.url,
-      mediaType: item.mediaType,
-      filename: item.filename,
-    });
+    if (isStagedChatAttachment(item)) {
+      attachments.push({
+        kind: "staged",
+        id: item.id,
+        mediaType: item.mediaType,
+        filename: item.filename,
+        sizeBytes: item.sizeBytes,
+        stagedPath: item.stagedPath,
+      });
+      continue;
+    }
+
+    return [];
   }
 
   return attachments;

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2553,7 +2553,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       // Regular message (or /<model-alias> one-shot override) - send directly via API
       const messageTextForSend = modelOneShot?.message ?? skillInvocation?.userText ?? messageText;
       const skillMuxMetadata = skillInvocation
-        ? buildSkillInvocationMetadata(messageText, skillInvocation.descriptor)
+        ? buildSkillInvocationMetadata(
+            appendStagedAttachmentNotice(messageText, attachments),
+            skillInvocation.descriptor
+          )
         : undefined;
 
       if (!api) {

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -1200,9 +1200,17 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   const applyDraftFromPending = useCallback(
     (pending: PendingUserMessage, attachmentKeyPrefix: string) => {
+      const providerAttachments = filePartsToChatAttachments(
+        pending.fileParts,
+        attachmentKeyPrefix
+      );
+      const stagedAttachments = pending.stagedAttachments.map((attachment, index) => ({
+        ...attachment,
+        id: `${attachmentKeyPrefix}-staged-${index}`,
+      }));
       setDraft({
         text: pending.content,
-        attachments: filePartsToChatAttachments(pending.fileParts, attachmentKeyPrefix),
+        attachments: [...providerAttachments, ...stagedAttachments],
       });
     },
     [setDraft]
@@ -1744,6 +1752,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           restoreDraft({
             content: text,
             fileParts: fileParts ?? [],
+            stagedAttachments: [],
             reviews: reviews ?? [],
           });
         } else {
@@ -1757,6 +1766,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           {
             content: nextText,
             fileParts: fileParts ?? [],
+            stagedAttachments: [],
             reviews: reviews ?? [],
           },
           `restored-${Date.now()}`

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -137,7 +137,10 @@ import {
   chatAttachmentsToFileParts,
   processAttachmentFiles,
 } from "@/browser/utils/attachmentsHandling";
-import type { PendingUserMessage } from "@/browser/utils/chatEditing";
+import {
+  buildPendingFromRestoredInput,
+  type PendingUserMessage,
+} from "@/browser/utils/chatEditing";
 
 import type { AgentSkillDescriptor } from "@/common/types/agentSkill";
 import type { AgentAiDefaults } from "@/common/types/agentAiDefaults";
@@ -1741,38 +1744,38 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       }>;
 
       const { text, mode = "append", fileParts, reviews } = customEvent.detail;
-      const hasFileParts = !!fileParts && fileParts.length > 0;
-      const hasReviews = !!reviews && reviews.length > 0;
+      const restoredIdPrefix = `restored-${Date.now()}`;
+      const restoredPending = buildPendingFromRestoredInput({
+        content: text,
+        fileParts: fileParts ?? [],
+        reviews: reviews ?? [],
+        idPrefix: restoredIdPrefix,
+      });
+      const hasFileParts = restoredPending.fileParts.length > 0;
+      const hasStagedAttachments = restoredPending.stagedAttachments.length > 0;
+      const hasReviews = restoredPending.reviews.length > 0;
 
       if (mode === "replace") {
         if (editingMessageForUi) {
           return;
         }
-        if (hasFileParts || hasReviews) {
-          restoreDraft({
-            content: text,
-            fileParts: fileParts ?? [],
-            stagedAttachments: [],
-            reviews: reviews ?? [],
-          });
+        if (hasFileParts || hasStagedAttachments || hasReviews) {
+          restoreDraft(restoredPending);
         } else {
-          restoreText(text);
+          restoreText(restoredPending.content);
         }
-      } else if (hasFileParts || hasReviews) {
+      } else if (hasFileParts || hasStagedAttachments || hasReviews) {
         const currentText = getDraft().text;
         const separator = currentText.trim() ? "\n\n" : "";
-        const nextText = currentText + separator + text;
         applyDraftFromPending(
           {
-            content: nextText,
-            fileParts: fileParts ?? [],
-            stagedAttachments: [],
-            reviews: reviews ?? [],
+            ...restoredPending,
+            content: currentText + separator + restoredPending.content,
           },
-          `restored-${Date.now()}`
+          restoredIdPrefix
         );
       } else {
-        appendText(text);
+        appendText(restoredPending.content);
       }
     };
     window.addEventListener(CUSTOM_EVENTS.UPDATE_CHAT_INPUT, handler as EventListener);

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -2694,19 +2694,22 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
               .slice(0, messageText.trim().length - modelOneShot.message.length)
               .trimEnd()
           : undefined;
+        const oneshotRawCommand = oneshotCommandPrefix
+          ? appendStagedAttachmentNotice(messageText.trim(), attachments)
+          : undefined;
         muxMetadata = muxMetadata
           ? {
               ...muxMetadata,
               requestedModel: effectiveModel,
-              ...(oneshotCommandPrefix
-                ? { rawCommand: messageText.trim(), commandPrefix: oneshotCommandPrefix }
+              ...(oneshotRawCommand
+                ? { rawCommand: oneshotRawCommand, commandPrefix: oneshotCommandPrefix }
                 : {}),
             }
           : {
               type: "normal",
               requestedModel: effectiveModel,
-              ...(oneshotCommandPrefix
-                ? { rawCommand: messageText.trim(), commandPrefix: oneshotCommandPrefix }
+              ...(oneshotRawCommand
+                ? { rawCommand: oneshotRawCommand, commandPrefix: oneshotCommandPrefix }
                 : {}),
             };
 

--- a/src/browser/features/ChatInput/index.tsx
+++ b/src/browser/features/ChatInput/index.tsx
@@ -195,6 +195,7 @@ import {
 } from "./utils";
 import { normalizeAgentId } from "@/common/utils/agentIds";
 import { isGoalRunning } from "@/common/types/goal";
+import { appendStagedAttachmentNotice, getStagedAttachments } from "./stagedAttachments";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 // localStorage quotas are environment-dependent and relatively small.
@@ -438,6 +439,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const [attachments, setAttachmentsState] = useState<ChatAttachment[]>(() => {
     return readPersistedChatAttachments(storageKeys.attachmentsKey);
   });
+  const [processingAttachmentCount, setProcessingAttachmentCount] = useState(0);
   // Reviews restored from edits/queued drafts override attached review state while active.
   const [draftReviews, setDraftReviews] = useState<ReviewNoteDataForDisplay[] | null>(null);
   const persistAttachments = useCallback(
@@ -1048,10 +1050,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
   const policyBlocksCreateSend = variant === "creation" && creationRuntimePolicyError != null;
   const coderPresetsLoading =
     coderState.enabled && !coderState.coderConfig?.existingWorkspace && coderState.loadingPresets;
+  const isProcessingAttachments = processingAttachmentCount > 0;
   const canSend =
     (hasTypedText || hasImages || hasReviews) &&
     !disabled &&
     !sendInFlightBlocksInput &&
+    !isProcessingAttachments &&
     !coderPresetsLoading &&
     !policyBlocksCreateSend;
   const runningGoalActive =
@@ -1949,7 +1953,10 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
   const showResizeToast = useCallback(
     (nextAttachments: ChatAttachment[]) => {
-      const resized = nextAttachments.filter((attachment) => attachment.resizeInfo);
+      const resized = nextAttachments.filter(
+        (attachment): attachment is Extract<ChatAttachment, { kind: "provider" }> =>
+          attachment.kind === "provider" && attachment.resizeInfo != null
+      );
       if (resized.length === 0) {
         return;
       }
@@ -1968,6 +1975,39 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       pushToast({ type: "info", message });
     },
     [pushToast]
+  );
+
+  const processAttachmentFilesForComposer = useCallback(
+    (files: File[]): Promise<ChatAttachment[]> => {
+      setProcessingAttachmentCount((count) => count + 1);
+      return processAttachmentFiles(files, {
+        stageAttachment:
+          variant === "workspace"
+            ? async (file, dataBase64) => {
+                if (!api) {
+                  throw new Error("Not connected to server");
+                }
+                if (workspaceId == null) {
+                  throw new Error("ZIP attachments can be added after opening a workspace.");
+                }
+                const result = await api.workspace.stageAttachment({
+                  workspaceId,
+                  filename: file.name,
+                  mediaType: file.type || null,
+                  sizeBytes: file.size,
+                  dataBase64,
+                });
+                if (!result.success) {
+                  throw new Error(result.error);
+                }
+                return result.data;
+              }
+            : undefined,
+      }).finally(() => {
+        setProcessingAttachmentCount((count) => Math.max(0, count - 1));
+      });
+    },
+    [api, variant, workspaceId]
   );
 
   // Handle paste events to extract attachments
@@ -1991,7 +2031,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
       e.preventDefault(); // Prevent default paste behavior for attachments
 
-      processAttachmentFiles(attachmentFiles)
+      processAttachmentFilesForComposer(attachmentFiles)
         .then((nextAttachments) => {
           setAttachments((prev) => [...prev, ...nextAttachments]);
           showResizeToast(nextAttachments);
@@ -2004,7 +2044,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           });
         });
     },
-    [editingMessageForUi, pushToast, setAttachments, showResizeToast]
+    [
+      editingMessageForUi,
+      processAttachmentFilesForComposer,
+      pushToast,
+      setAttachments,
+      showResizeToast,
+    ]
   );
 
   // Handle removing an attachment
@@ -2028,7 +2074,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       return;
     }
     const results = files.map((file) =>
-      processAttachmentFiles([file]).then(
+      processAttachmentFilesForComposer([file]).then(
         (attachments) => ({ ok: true as const, attachments }),
         (error: unknown) => ({ ok: false as const, error })
       )
@@ -2091,6 +2137,16 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       return true;
     }
 
+    if (getStagedAttachments(attachments).length > 0 && parsed.type !== "compact") {
+      setToast({
+        id: Date.now().toString(),
+        type: "error",
+        message:
+          "This command cannot include staged ZIP attachments. Remove the ZIP or send a normal message.",
+      });
+      return true;
+    }
+
     const reviewsData = reviewData;
     const dispatchMode = options?.queueDispatchMode ?? "tool-end";
     // Thread dispatch mode into send options so queued command sends stay in sync with normal sends.
@@ -2140,6 +2196,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
       editMessageId: editingMessageForUi?.id,
       onCancelEdit: commandOnCancelEdit,
       reviews: reviewsData,
+      attachments,
       fileParts: commandFileParts.length > 0 ? commandFileParts : undefined,
       onMessageSent: variant === "workspace" ? props.onMessageSent : undefined,
       onDetachAllReviews: variant === "workspace" ? props.onDetachAllReviews : undefined,
@@ -2206,7 +2263,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         return;
       }
 
-      processAttachmentFiles(attachmentFiles)
+      processAttachmentFilesForComposer(attachmentFiles)
         .then((nextAttachments) => {
           setAttachments((prev) => [...prev, ...nextAttachments]);
           showResizeToast(nextAttachments);
@@ -2219,7 +2276,13 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
           });
         });
     },
-    [editingMessageForUi, pushToast, setAttachments, showResizeToast]
+    [
+      editingMessageForUi,
+      processAttachmentFilesForComposer,
+      pushToast,
+      setAttachments,
+      showResizeToast,
+    ]
   );
 
   // Handle suggestion selection
@@ -2493,7 +2556,9 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
 
       // Preflight: if the message includes PDFs, ensure the selected model can accept them.
       const pdfAttachments = attachments.filter(
-        (attachment) => getBaseMediaType(attachment.mediaType) === PDF_MEDIA_TYPE
+        (attachment): attachment is Extract<ChatAttachment, { kind: "provider" }> =>
+          attachment.kind === "provider" &&
+          getBaseMediaType(attachment.mediaType) === PDF_MEDIA_TYPE
       );
       if (pdfAttachments.length > 0) {
         const caps = getModelCapabilitiesResolved(policyModel, providersConfig);
@@ -2560,6 +2625,7 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
         }
         let compactionOptions: Partial<SendMessageOptions> = {};
 
+        let appendStagedNoticeToUserMessage = true;
         if (editMessageForSend && actualMessageText.startsWith("/")) {
           const parsed = parseCommand(messageText);
           if (parsed?.type === "compact") {
@@ -2574,9 +2640,12 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
               // Include current attachments + reviews in followUpContent so they're queued
               // after compaction completes, not just attached to the compaction request.
               followUpContent:
-                parsed.continueMessage || sendFileParts?.length || reviewsData?.length
+                parsed.continueMessage ||
+                sendFileParts?.length ||
+                reviewsData?.length ||
+                getStagedAttachments(attachments).length
                   ? {
-                      text: parsed.continueMessage ?? "",
+                      text: appendStagedAttachmentNotice(parsed.continueMessage ?? "", attachments),
                       fileParts: sendFileParts,
                       reviews: reviewsData,
                     }
@@ -2584,14 +2653,18 @@ const ChatInputInner: React.FC<ChatInputProps> = (props) => {
               model: parsed.model,
               sendMessageOptions,
             });
+            appendStagedNoticeToUserMessage = false;
             actualMessageText = regeneratedText;
             muxMetadata = metadata;
             compactionOptions = sendOptions;
           }
         }
 
+        const userMessageText = appendStagedNoticeToUserMessage
+          ? appendStagedAttachmentNotice(actualMessageText, attachments)
+          : actualMessageText;
         const { finalText: finalMessageText, metadata: reviewMetadata } = prepareUserMessageForSend(
-          { text: actualMessageText, reviews: reviewsData },
+          { text: userMessageText, reviews: reviewsData },
           muxMetadata
         );
         // When editing /compact, compactionOptions already includes the base sendMessageOptions.

--- a/src/browser/features/ChatInput/stagedAttachments.test.ts
+++ b/src/browser/features/ChatInput/stagedAttachments.test.ts
@@ -64,4 +64,13 @@ describe("stagedAttachments", () => {
       ],
     });
   });
+
+  test("preserves user-authored attached-files XML that is not a staged notice", () => {
+    const userText = "Please edit this XML:\n<attached-files><file>keep me</file></attached-files>";
+
+    expect(parseStagedAttachmentNotice(userText)).toEqual({
+      text: userText,
+      attachments: [],
+    });
+  });
 });

--- a/src/browser/features/ChatInput/stagedAttachments.test.ts
+++ b/src/browser/features/ChatInput/stagedAttachments.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  appendStagedAttachmentNotice,
+  buildStagedAttachmentNotice,
+  parseStagedAttachmentNotice,
+} from "./stagedAttachments";
+
+describe("stagedAttachments", () => {
+  test("builds a staged-file notice with filename, type, size, and path", () => {
+    const notice = buildStagedAttachmentNotice([
+      {
+        kind: "staged",
+        id: "zip-1",
+        filename: "archive.zip",
+        mediaType: "application/zip",
+        sizeBytes: 12_345,
+        stagedPath: ".mux/user-attachments/id/archive.zip",
+      },
+    ]);
+
+    expect(notice).toContain("<attached-files>");
+    expect(notice).toContain("`archive.zip` (`application/zip`, 12.1 KB)");
+    expect(notice).toContain("`.mux/user-attachments/id/archive.zip`");
+  });
+
+  test("allows zip-only sends by returning the notice as message text", () => {
+    const message = appendStagedAttachmentNotice("", [
+      {
+        kind: "staged",
+        id: "zip-1",
+        filename: "archive.zip",
+        mediaType: "application/zip",
+        sizeBytes: 1,
+        stagedPath: ".mux/user-attachments/id/archive.zip",
+      },
+    ]);
+
+    expect(message.trim()).toStartWith("<attached-files>");
+  });
+
+  test("parses staged notices into display attachments and visible text", () => {
+    const message = appendStagedAttachmentNotice("Inspect this archive.", [
+      {
+        kind: "staged",
+        id: "zip-1",
+        filename: "archive.zip",
+        mediaType: "application/zip",
+        sizeBytes: 12_345,
+        stagedPath: ".mux/user-attachments/id/archive.zip",
+      },
+    ]);
+
+    expect(parseStagedAttachmentNotice(message)).toEqual({
+      text: "Inspect this archive.",
+      attachments: [
+        {
+          filename: "archive.zip",
+          mediaType: "application/zip",
+          sizeLabel: "12.1 KB",
+          stagedPath: ".mux/user-attachments/id/archive.zip",
+        },
+      ],
+    });
+  });
+});

--- a/src/browser/features/ChatInput/stagedAttachments.test.ts
+++ b/src/browser/features/ChatInput/stagedAttachments.test.ts
@@ -58,6 +58,7 @@ describe("stagedAttachments", () => {
           filename: "archive.zip",
           mediaType: "application/zip",
           sizeLabel: "12.1 KB",
+          sizeBytes: 12_390,
           stagedPath: ".mux/user-attachments/id/archive.zip",
         },
       ],

--- a/src/browser/features/ChatInput/stagedAttachments.ts
+++ b/src/browser/features/ChatInput/stagedAttachments.ts
@@ -1,0 +1,83 @@
+import type { ChatAttachment, StagedChatAttachment } from "./ChatAttachments";
+
+const ATTACHED_FILES_OPEN_TAG = "<attached-files>";
+const ATTACHED_FILES_CLOSE_TAG = "</attached-files>";
+const ATTACHED_FILES_BLOCK_PATTERN = /\n?<attached-files>[\s\S]*?<\/attached-files>/gu;
+const ATTACHED_FILE_LINE_PATTERN =
+  /^- `(?<filename>[^`]+)` \(`(?<mediaType>[^`]+)`, (?<sizeLabel>[^)]+)\): `(?<stagedPath>[^`]+)`$/u;
+
+export interface DisplayStagedAttachment {
+  filename: string;
+  mediaType: string;
+  sizeLabel: string;
+  stagedPath: string;
+}
+
+export function getStagedAttachments(attachments: ChatAttachment[]): StagedChatAttachment[] {
+  return attachments.filter((attachment) => attachment.kind === "staged");
+}
+
+export function appendStagedAttachmentNotice(text: string, attachments: ChatAttachment[]): string {
+  const notice = buildStagedAttachmentNotice(getStagedAttachments(attachments));
+  if (notice.length === 0) {
+    return text;
+  }
+  return text.trim().length > 0 ? `${text}\n${notice}` : notice.trimStart();
+}
+
+export function parseStagedAttachmentNotice(text: string): {
+  text: string;
+  attachments: DisplayStagedAttachment[];
+} {
+  const attachments: DisplayStagedAttachment[] = [];
+  const visibleText = text.replace(ATTACHED_FILES_BLOCK_PATTERN, (block) => {
+    attachments.push(...parseStagedAttachmentBlock(block));
+    return "";
+  });
+
+  return { text: visibleText.trimEnd(), attachments };
+}
+
+export function stripStagedAttachmentNotice(text: string): string {
+  return parseStagedAttachmentNotice(text).text;
+}
+
+export function buildStagedAttachmentNotice(attachments: StagedChatAttachment[]): string {
+  if (attachments.length === 0) {
+    return "";
+  }
+
+  const lines = attachments.map(
+    (attachment) =>
+      `- \`${attachment.filename}\` (\`${attachment.mediaType}\`, ${formatBytes(attachment.sizeBytes)}): \`${attachment.stagedPath}\``
+  );
+
+  return `\n${ATTACHED_FILES_OPEN_TAG}\nThe user attached file(s) that were saved into the workspace filesystem. These are not native model attachments; use filesystem tools such as \`bash\`, \`file_read\`, or archive tools to inspect them if needed.\n\n${lines.join("\n")}\n${ATTACHED_FILES_CLOSE_TAG}`;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function parseStagedAttachmentBlock(block: string): DisplayStagedAttachment[] {
+  const parsed: DisplayStagedAttachment[] = [];
+  for (const line of block.split(/\r?\n/u)) {
+    const match = ATTACHED_FILE_LINE_PATTERN.exec(line.trim());
+    if (!match?.groups) {
+      continue;
+    }
+    parsed.push({
+      filename: match.groups.filename,
+      mediaType: match.groups.mediaType,
+      sizeLabel: match.groups.sizeLabel,
+      stagedPath: match.groups.stagedPath,
+    });
+  }
+  return parsed;
+}

--- a/src/browser/features/ChatInput/stagedAttachments.ts
+++ b/src/browser/features/ChatInput/stagedAttachments.ts
@@ -10,11 +10,26 @@ export interface DisplayStagedAttachment {
   filename: string;
   mediaType: string;
   sizeLabel: string;
+  sizeBytes: number;
   stagedPath: string;
 }
 
 export function getStagedAttachments(attachments: ChatAttachment[]): StagedChatAttachment[] {
   return attachments.filter((attachment) => attachment.kind === "staged");
+}
+
+export function displayStagedAttachmentsToChatAttachments(
+  attachments: DisplayStagedAttachment[],
+  idPrefix: string
+): StagedChatAttachment[] {
+  return attachments.map((attachment, index) => ({
+    kind: "staged",
+    id: `${idPrefix}-staged-${index}`,
+    mediaType: attachment.mediaType,
+    filename: attachment.filename,
+    sizeBytes: attachment.sizeBytes,
+    stagedPath: attachment.stagedPath,
+  }));
 }
 
 export function appendStagedAttachmentNotice(text: string, attachments: ChatAttachment[]): string {
@@ -65,6 +80,26 @@ export function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function parseSizeLabelBytes(sizeLabel: string): number {
+  const match = /^(?<amount>\d+(?:\.\d+)?) (?<unit>B|KB|MB)$/u.exec(sizeLabel.trim());
+  if (!match?.groups) {
+    return 0;
+  }
+
+  const amount = Number(match.groups.amount);
+  if (!Number.isFinite(amount)) {
+    return 0;
+  }
+
+  if (match.groups.unit === "B") {
+    return Math.round(amount);
+  }
+  if (match.groups.unit === "KB") {
+    return Math.round(amount * 1024);
+  }
+  return Math.round(amount * 1024 * 1024);
+}
+
 function parseStagedAttachmentBlock(block: string): DisplayStagedAttachment[] {
   const parsed: DisplayStagedAttachment[] = [];
   for (const line of block.split(/\r?\n/u)) {
@@ -72,10 +107,12 @@ function parseStagedAttachmentBlock(block: string): DisplayStagedAttachment[] {
     if (!match?.groups) {
       continue;
     }
+    const sizeLabel = match.groups.sizeLabel;
     parsed.push({
       filename: match.groups.filename,
       mediaType: match.groups.mediaType,
-      sizeLabel: match.groups.sizeLabel,
+      sizeLabel,
+      sizeBytes: parseSizeLabelBytes(sizeLabel),
       stagedPath: match.groups.stagedPath,
     });
   }

--- a/src/browser/features/ChatInput/stagedAttachments.ts
+++ b/src/browser/features/ChatInput/stagedAttachments.ts
@@ -2,6 +2,8 @@ import type { ChatAttachment, StagedChatAttachment } from "./ChatAttachments";
 
 const ATTACHED_FILES_OPEN_TAG = "<attached-files>";
 const ATTACHED_FILES_CLOSE_TAG = "</attached-files>";
+const STAGED_ATTACHMENT_NOTICE_TEXT =
+  "The user attached file(s) that were saved into the workspace filesystem. These are not native model attachments; use filesystem tools such as `bash`, `file_read`, or archive tools to inspect them if needed.";
 const ATTACHED_FILES_BLOCK_PATTERN = /\n?<attached-files>[\s\S]*?<\/attached-files>/gu;
 const ATTACHED_FILE_LINE_PATTERN =
   /^- `(?<filename>[^`]+)` \(`(?<mediaType>[^`]+)`, (?<sizeLabel>[^)]+)\): `(?<stagedPath>[^`]+)`$/u;
@@ -46,7 +48,11 @@ export function parseStagedAttachmentNotice(text: string): {
 } {
   const attachments: DisplayStagedAttachment[] = [];
   const visibleText = text.replace(ATTACHED_FILES_BLOCK_PATTERN, (block) => {
-    attachments.push(...parseStagedAttachmentBlock(block));
+    const parsedBlock = parseStagedAttachmentBlock(block);
+    if (!isGeneratedStagedAttachmentBlock(block) || parsedBlock.length === 0) {
+      return block;
+    }
+    attachments.push(...parsedBlock);
     return "";
   });
 
@@ -67,7 +73,7 @@ export function buildStagedAttachmentNotice(attachments: StagedChatAttachment[])
       `- \`${attachment.filename}\` (\`${attachment.mediaType}\`, ${formatBytes(attachment.sizeBytes)}): \`${attachment.stagedPath}\``
   );
 
-  return `\n${ATTACHED_FILES_OPEN_TAG}\nThe user attached file(s) that were saved into the workspace filesystem. These are not native model attachments; use filesystem tools such as \`bash\`, \`file_read\`, or archive tools to inspect them if needed.\n\n${lines.join("\n")}\n${ATTACHED_FILES_CLOSE_TAG}`;
+  return `\n${ATTACHED_FILES_OPEN_TAG}\n${STAGED_ATTACHMENT_NOTICE_TEXT}\n\n${lines.join("\n")}\n${ATTACHED_FILES_CLOSE_TAG}`;
 }
 
 export function formatBytes(bytes: number): string {
@@ -78,6 +84,13 @@ export function formatBytes(bytes: number): string {
     return `${(bytes / 1024).toFixed(1)} KB`;
   }
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function isGeneratedStagedAttachmentBlock(block: string): boolean {
+  const normalizedBlock = block.replace(/\r\n/gu, "\n").trimStart();
+  return normalizedBlock.startsWith(
+    `${ATTACHED_FILES_OPEN_TAG}\n${STAGED_ATTACHMENT_NOTICE_TEXT}\n\n`
+  );
 }
 
 function parseSizeLabelBytes(sizeLabel: string): number {

--- a/src/browser/features/ChatInput/utils.ts
+++ b/src/browser/features/ChatInput/utils.ts
@@ -220,6 +220,7 @@ export function filePartsToChatAttachments(
   idPrefix: string
 ): ChatAttachment[] {
   return fileParts.map((part, index) => ({
+    kind: "provider",
     id: `${idPrefix}-${index}`,
     url: part.url,
     mediaType: part.mediaType,

--- a/src/browser/features/Messages/UserMessage.tsx
+++ b/src/browser/features/Messages/UserMessage.tsx
@@ -1,6 +1,12 @@
 import React from "react";
+import { APIContext } from "@/browser/contexts/API";
+import { useOptionalWorkspaceContext } from "@/browser/contexts/WorkspaceContext";
 import { cn } from "@/common/lib/utils";
 import type { DisplayedMessage } from "@/common/types/message";
+import {
+  stripStagedAttachmentNotice,
+  type DisplayStagedAttachment,
+} from "@/browser/features/ChatInput/stagedAttachments";
 import type { ButtonConfig } from "./MessageWindow";
 import { MessageWindow } from "./MessageWindow";
 import { UserMessageContent } from "./UserMessageContent";
@@ -30,6 +36,26 @@ import {
   SIDE_QUESTION_MESSAGE_WINDOW_CLASS,
   SIDE_QUESTION_USER_BLOCK_CLASS,
 } from "./sideQuestionStyles";
+
+function base64ToBlob(dataBase64: string, mediaType: string): Blob {
+  const binary = atob(dataBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Blob([bytes], { type: mediaType });
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const blobUrl = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(blobUrl), 1000);
+}
 
 /** Navigation info for navigating between user messages */
 export interface UserMessageNavigation {
@@ -63,10 +89,37 @@ export const UserMessage: React.FC<UserMessageProps> = ({
   const isGoalContinuation = message.isGoalContinuation === true;
   const isBudgetLimitWrapup = message.isBudgetLimitWrapup === true;
   const content = message.content;
+  const visibleContent = stripStagedAttachmentNotice(content);
   const [vimEnabled] = usePersistedState<boolean>(VIM_ENABLED_KEY, false, { listener: true });
   const isMobileTouch =
     typeof window !== "undefined" &&
     window.matchMedia("(max-width: 768px) and (pointer: coarse)").matches;
+
+  const apiState = React.useContext(APIContext);
+  const api = apiState?.api ?? null;
+  const workspaceContext = useOptionalWorkspaceContext();
+  const workspaceId = workspaceContext?.selectedWorkspace?.workspaceId ?? null;
+
+  const handleDownloadStagedAttachment = async (attachment: DisplayStagedAttachment) => {
+    if (api == null || workspaceId == null) {
+      console.warn("Cannot download staged attachment without an active workspace connection.");
+      return;
+    }
+
+    const result = await api.workspace.downloadStagedAttachment({
+      workspaceId,
+      stagedPath: attachment.stagedPath,
+    });
+    if (!result.success) {
+      console.error("Failed to download staged attachment:", result.error);
+      return;
+    }
+
+    downloadBlob(
+      base64ToBlob(result.data.dataBase64, result.data.mediaType),
+      result.data.filename || attachment.filename
+    );
+  };
 
   console.assert(
     typeof clipboardWriteText === "function",
@@ -148,7 +201,7 @@ export const UserMessage: React.FC<UserMessageProps> = ({
       : []),
     {
       label: copied ? "Copied" : "Copy",
-      onClick: () => void copyToClipboard(content),
+      onClick: () => void copyToClipboard(visibleContent),
       icon: copied ? <ClipboardCheck /> : <Clipboard />,
     },
   ];
@@ -206,6 +259,7 @@ export const UserMessage: React.FC<UserMessageProps> = ({
         inlineSkillSnapshots={message.inlineSkillSnapshots}
         reviews={message.reviews}
         fileParts={message.fileParts}
+        onDownloadStagedAttachment={(attachment) => void handleDownloadStagedAttachment(attachment)}
         variant="sent"
       />
     );

--- a/src/browser/features/Messages/UserMessageContent.staged.test.tsx
+++ b/src/browser/features/Messages/UserMessageContent.staged.test.tsx
@@ -1,0 +1,63 @@
+import "../../../../tests/ui/dom";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
+import type { StagedChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
+import { installDom } from "../../../../tests/ui/dom";
+import { UserMessageContent } from "./UserMessageContent";
+
+const STAGED_ATTACHMENT: StagedChatAttachment = {
+  kind: "staged",
+  id: "zip-1",
+  filename: "archive.zip",
+  mediaType: "application/zip",
+  sizeBytes: 12_345,
+  stagedPath: ".mux/user-attachments/id/archive.zip",
+};
+
+describe("UserMessageContent staged attachment rendering", () => {
+  let cleanupDom: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanupDom = installDom();
+  });
+
+  afterEach(() => {
+    cleanup();
+    cleanupDom?.();
+    cleanupDom = null;
+  });
+
+  test("hides the model-only staged attachment notice and renders a download chip", () => {
+    const downloads: unknown[] = [];
+    const content = appendStagedAttachmentNotice("Inspect this archive.", [STAGED_ATTACHMENT]);
+
+    const view = render(
+      <UserMessageContent
+        content={content}
+        variant="sent"
+        onDownloadStagedAttachment={(attachment) => downloads.push(attachment)}
+      />
+    );
+
+    expect(view.queryByText(/<attached-files>/)).toBeNull();
+    expect(view.queryByText(/workspace filesystem/)).toBeNull();
+    expect(view.getByText("Inspect this archive.")).toBeTruthy();
+
+    const chip = view.getByRole("button", { name: /download archive\.zip/i });
+    expect(chip.textContent).toContain("archive.zip");
+    expect(chip.textContent).toContain("12.1 KB");
+
+    fireEvent.click(chip);
+    expect(downloads).toEqual([
+      {
+        filename: "archive.zip",
+        mediaType: "application/zip",
+        sizeLabel: "12.1 KB",
+        stagedPath: ".mux/user-attachments/id/archive.zip",
+      },
+    ]);
+  });
+});

--- a/src/browser/features/Messages/UserMessageContent.staged.test.tsx
+++ b/src/browser/features/Messages/UserMessageContent.staged.test.tsx
@@ -56,6 +56,7 @@ describe("UserMessageContent staged attachment rendering", () => {
         filename: "archive.zip",
         mediaType: "application/zip",
         sizeLabel: "12.1 KB",
+        sizeBytes: 12_390,
         stagedPath: ".mux/user-attachments/id/archive.zip",
       },
     ]);

--- a/src/browser/features/Messages/UserMessageContent.tsx
+++ b/src/browser/features/Messages/UserMessageContent.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { FileText } from "lucide-react";
 import type { InlineSkillSnapshotMap, ReviewNoteDataForDisplay } from "@/common/types/message";
 import type { FilePart } from "@/common/orpc/schemas";
+import {
+  parseStagedAttachmentNotice,
+  type DisplayStagedAttachment,
+} from "@/browser/features/ChatInput/stagedAttachments";
 import { ReviewBlockFromData } from "../Shared/ReviewBlock";
 import {
   HoverCard,
@@ -25,6 +29,7 @@ interface UserMessageContentProps {
   inlineSkillSnapshots?: InlineSkillSnapshotMap;
   reviews?: ReviewNoteDataForDisplay[];
   fileParts?: FilePart[];
+  onDownloadStagedAttachment?: (attachment: DisplayStagedAttachment) => void;
   /** Controls styling: "sent" for full styling, "queued" for muted preview */
   variant: "sent" | "queued";
 }
@@ -98,13 +103,15 @@ const imageStyles = {
 export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => {
   const reviews = props.reviews ?? [];
   const fileParts = props.fileParts ?? [];
+  const parsedStagedNotice = parseStagedAttachmentNotice(props.content);
+  const stagedAttachments = parsedStagedNotice.attachments;
 
   const hasReviews = reviews.length > 0;
 
-  // Strip review tags from text when displaying alongside review blocks
+  // Strip model-only attachment/review tags from text when displaying alongside rich UI blocks.
   const textContent = hasReviews
-    ? props.content.replace(/<review>[\s\S]*?<\/review>\s*/g, "").trim()
-    : props.content;
+    ? parsedStagedNotice.text.replace(/<review>[\s\S]*?<\/review>\s*/g, "").trim()
+    : parsedStagedNotice.text;
 
   // Check if content starts with the command prefix
   const shouldHighlightPrefix =
@@ -263,6 +270,28 @@ export const UserMessageContent: React.FC<UserMessageContentProps> = (props) => 
               </a>
             );
           })}
+        </div>
+      )}
+      {stagedAttachments.length > 0 && (
+        <div className={imageContainerStyles[props.variant]}>
+          {stagedAttachments.map((attachment) => (
+            <button
+              key={attachment.stagedPath}
+              type="button"
+              aria-label={`Download ${attachment.filename}`}
+              disabled={!props.onDownloadStagedAttachment}
+              className={`${fileAttachmentStyles[props.variant]} ${
+                props.onDownloadStagedAttachment
+                  ? "cursor-pointer hover:bg-[var(--color-hover)]"
+                  : "cursor-default opacity-70"
+              }`}
+              onClick={() => props.onDownloadStagedAttachment?.(attachment)}
+            >
+              <FileText className="h-4 w-4 shrink-0" />
+              <span className="truncate">{attachment.filename}</span>
+              <span className="text-[var(--color-text-muted)]">{attachment.sizeLabel}</span>
+            </button>
+          ))}
         </div>
       )}
     </>

--- a/src/browser/utils/attachmentsHandling.test.ts
+++ b/src/browser/utils/attachmentsHandling.test.ts
@@ -7,6 +7,7 @@ import {
   extractAttachmentsFromClipboard,
   extractAttachmentsFromDrop,
   processAttachmentFiles,
+  chatAttachmentsToFileParts,
 } from "./attachmentsHandling";
 
 // Mock FileReader for Node.js environment
@@ -102,6 +103,8 @@ describe("attachmentsHandling", () => {
 
       const attachment = await fileToChatAttachment(file);
 
+      expect(attachment.kind).toBe("provider");
+      if (attachment.kind !== "provider") throw new Error("Expected provider attachment");
       expect(attachment.mediaType).toBe("image/jpeg");
       expect(attachment.url).toContain("data:image/jpeg;base64,");
     });
@@ -219,6 +222,50 @@ describe("attachmentsHandling", () => {
     });
   });
 
+  describe("staged attachments", () => {
+    test("stages zip files through the provided callback", async () => {
+      const file = new File(["zip bytes"], "archive.zip", { type: "" });
+
+      const attachments = await processAttachmentFiles([file], {
+        stageAttachment: (zipFile, dataBase64) => {
+          expect(dataBase64).toBe("emlwIGJ5dGVz");
+          return Promise.resolve({
+            filename: zipFile.name,
+            mediaType: "application/zip",
+            sizeBytes: zipFile.size,
+            stagedPath: `.mux/user-attachments/id/${zipFile.name}`,
+          });
+        },
+      });
+
+      expect(attachments).toEqual([
+        {
+          kind: "staged",
+          id: expect.stringMatching(/^\d+-[a-z0-9]+$/),
+          filename: "archive.zip",
+          mediaType: "application/zip",
+          sizeBytes: 9,
+          stagedPath: ".mux/user-attachments/id/archive.zip",
+        },
+      ]);
+    });
+
+    test("does not convert staged zip attachments to provider file parts", () => {
+      expect(
+        chatAttachmentsToFileParts([
+          {
+            kind: "staged",
+            id: "zip-1",
+            filename: "archive.zip",
+            mediaType: "application/zip",
+            sizeBytes: 1,
+            stagedPath: ".mux/user-attachments/id/archive.zip",
+          },
+        ])
+      ).toEqual([]);
+    });
+  });
+
   describe("processAttachmentFiles", () => {
     test("converts multiple files to attachments", async () => {
       const file1 = new File(["image 1"], "test1.png", { type: "image/png" });
@@ -227,6 +274,9 @@ describe("attachmentsHandling", () => {
       const attachments = await processAttachmentFiles([file1, file2]);
 
       expect(attachments).toHaveLength(2);
+      if (attachments[0].kind !== "provider" || attachments[1].kind !== "provider") {
+        throw new Error("Expected provider attachments");
+      }
       expect(attachments[0].mediaType).toBe("image/png");
       expect(attachments[1].mediaType).toBe("image/jpeg");
       expect(attachments[0].url).toContain("data:image/png;base64,");

--- a/src/browser/utils/attachmentsHandling.ts
+++ b/src/browser/utils/attachmentsHandling.ts
@@ -1,6 +1,10 @@
 import type { FilePart } from "@/common/orpc/types";
 import { MAX_SVG_TEXT_CHARS, SVG_MEDIA_TYPE } from "@/common/constants/imageAttachments";
-import { getSupportedAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+import { MAX_STAGED_ATTACHMENT_SIZE_BYTES } from "@/common/constants/stagedAttachments";
+import {
+  getSupportedAttachmentMediaType,
+  getSupportedStagedAttachmentMediaType,
+} from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import type { ChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
 import { resizeImageIfNeeded } from "@/browser/utils/imageResize";
 
@@ -9,6 +13,17 @@ import { resizeImageIfNeeded } from "@/browser/utils/imageResize";
  */
 export function generateAttachmentId(): string {
   return `${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+export interface StageAttachmentResult {
+  filename: string;
+  mediaType: string;
+  sizeBytes: number;
+  stagedPath: string;
+}
+
+export interface ProcessAttachmentOptions {
+  stageAttachment?: (file: File, dataBase64: string) => Promise<StageAttachmentResult>;
 }
 
 function getSupportedMediaType(file: File): string | null {
@@ -27,7 +42,12 @@ export function chatAttachmentsToFileParts(
 ): FilePart[] {
   const validate = options?.validate ?? false;
 
-  return attachments.map((attachment, index) => {
+  return attachments.flatMap((attachment, index) => {
+    if (attachment.kind === "staged") {
+      // Staged ZIPs live in the workspace filesystem and must never be sent as provider file parts.
+      return [];
+    }
+
     if (validate) {
       if (!attachment.url || typeof attachment.url !== "string") {
         console.error(
@@ -48,12 +68,56 @@ export function chatAttachmentsToFileParts(
       }
     }
 
-    return {
-      url: attachment.url,
-      mediaType: attachment.mediaType,
-      filename: attachment.filename,
-    };
+    return [
+      {
+        url: attachment.url,
+        mediaType: attachment.mediaType,
+        filename: attachment.filename,
+      },
+    ];
   });
+}
+
+function getSupportedStagedMediaType(file: File): string | null {
+  return getSupportedStagedAttachmentMediaType({
+    mediaType: file.type !== "" ? file.type : null,
+    filename: file.name,
+  });
+}
+
+function fileBytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+async function fileToStagedChatAttachment(
+  file: File,
+  stageAttachment: (file: File, dataBase64: string) => Promise<StageAttachmentResult>
+): Promise<ChatAttachment> {
+  const mediaType = getSupportedStagedMediaType(file);
+  if (mediaType == null) {
+    throw new Error(`Unsupported attachment type: ${file.type || file.name}`);
+  }
+  if (file.size > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
+    throw new Error(
+      `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+    );
+  }
+
+  const dataBase64 = fileBytesToBase64(new Uint8Array(await file.arrayBuffer()));
+  const staged = await stageAttachment(file, dataBase64);
+  return {
+    kind: "staged",
+    id: generateAttachmentId(),
+    filename: staged.filename,
+    mediaType: staged.mediaType,
+    sizeBytes: staged.sizeBytes,
+    stagedPath: staged.stagedPath,
+  };
 }
 
 /**
@@ -76,6 +140,7 @@ export async function fileToChatAttachment(file: File): Promise<ChatAttachment> 
     }
 
     return {
+      kind: "provider",
       id: generateAttachmentId(),
       url: `data:${SVG_MEDIA_TYPE},${encodeURIComponent(svgText)}`,
       mediaType,
@@ -103,6 +168,7 @@ export async function fileToChatAttachment(file: File): Promise<ChatAttachment> 
     const resizeResult = await resizeImageIfNeeded(dataUrl, mediaType);
 
     return {
+      kind: "provider",
       id: generateAttachmentId(),
       url: resizeResult.dataUrl,
       mediaType: resizeResult.mediaType,
@@ -121,6 +187,7 @@ export async function fileToChatAttachment(file: File): Promise<ChatAttachment> 
   }
 
   return {
+    kind: "provider",
     id: generateAttachmentId(),
     url: dataUrl,
     mediaType,
@@ -138,7 +205,7 @@ export function extractAttachmentsFromClipboard(items: DataTransferItemList): Fi
     const file = item?.getAsFile();
     if (!file) continue;
 
-    if (getSupportedMediaType(file)) {
+    if (getSupportedMediaType(file) || getSupportedStagedMediaType(file)) {
       files.push(file);
     }
   }
@@ -153,7 +220,7 @@ export function extractAttachmentsFromDrop(dataTransfer: DataTransfer): File[] {
   const files: File[] = [];
 
   for (const file of Array.from(dataTransfer.files)) {
-    if (getSupportedMediaType(file)) {
+    if (getSupportedMediaType(file) || getSupportedStagedMediaType(file)) {
       files.push(file);
     }
   }
@@ -164,6 +231,19 @@ export function extractAttachmentsFromDrop(dataTransfer: DataTransfer): File[] {
 /**
  * Processes multiple attachment files and converts them to chat attachments.
  */
-export async function processAttachmentFiles(files: File[]): Promise<ChatAttachment[]> {
-  return await Promise.all(files.map(fileToChatAttachment));
+export async function processAttachmentFiles(
+  files: File[],
+  options: ProcessAttachmentOptions = {}
+): Promise<ChatAttachment[]> {
+  return await Promise.all(
+    files.map((file) => {
+      if (getSupportedStagedMediaType(file) != null) {
+        if (!options.stageAttachment) {
+          throw new Error("ZIP attachments can be added after opening a workspace.");
+        }
+        return fileToStagedChatAttachment(file, options.stageAttachment);
+      }
+      return fileToChatAttachment(file);
+    })
+  );
 }

--- a/src/browser/utils/chatCommands.ts
+++ b/src/browser/utils/chatCommands.ts
@@ -68,6 +68,10 @@ import { getProviderModelEntryId } from "@/common/utils/providers/modelEntries";
 import { isCustomOpenAICompatibleProviderConfig } from "@/common/utils/providers/customProviders";
 import { isValidProvider } from "@/common/constants/providers";
 import { openInEditor } from "@/browser/utils/openInEditor";
+import {
+  appendStagedAttachmentNotice,
+  getStagedAttachments,
+} from "@/browser/features/ChatInput/stagedAttachments";
 import { WORKSPACE_DEFAULTS } from "@/constants/workspaceDefaults";
 
 // ============================================================================
@@ -1635,6 +1639,7 @@ export interface CommandHandlerContext {
   workspaceId: string;
   currentModel?: string | null;
   sendMessageOptions: SendMessageOptions;
+  attachments?: ChatAttachment[];
   fileParts?: FilePart[];
   /** Reviews attached to the message (from code review panel) */
   reviews?: ReviewNoteData[];
@@ -1772,12 +1777,16 @@ export async function handleCompactCommand(
   setSendingState(true);
 
   try {
-    // Build followUpContent directly from parsed command + context
+    // Build followUpContent directly from parsed command + context.
+    const stagedAttachments = context.attachments ? getStagedAttachments(context.attachments) : [];
     const hasContent =
-      parsed.continueMessage ?? context.fileParts?.length ?? context.reviews?.length;
+      parsed.continueMessage ??
+      context.fileParts?.length ??
+      context.reviews?.length ??
+      stagedAttachments.length;
     const followUpContent: CompactionFollowUpInput | undefined = hasContent
       ? {
-          text: parsed.continueMessage ?? "",
+          text: appendStagedAttachmentNotice(parsed.continueMessage ?? "", stagedAttachments),
           fileParts: context.fileParts,
           reviews: context.reviews,
         }

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import type { DisplayedUserMessage } from "@/common/types/message";
-import { buildEditingStateFromDisplayed, canEditDisplayedUserMessage } from "./chatEditing";
+import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
+import type { DisplayedUserMessage, QueuedMessage } from "@/common/types/message";
+import {
+  buildEditingStateFromDisplayed,
+  buildPendingFromDisplayed,
+  canEditDisplayedUserMessage,
+  normalizeQueuedMessage,
+} from "./chatEditing";
 
 function userMessage(overrides: Partial<DisplayedUserMessage> = {}): DisplayedUserMessage {
   return {
@@ -12,6 +18,15 @@ function userMessage(overrides: Partial<DisplayedUserMessage> = {}): DisplayedUs
     ...overrides,
   };
 }
+
+const STAGED_ATTACHMENT = {
+  kind: "staged" as const,
+  id: "zip-1",
+  filename: "archive.zip",
+  mediaType: "application/zip",
+  sizeBytes: 199,
+  stagedPath: ".mux/user-attachments/id/archive.zip",
+};
 
 describe("canEditDisplayedUserMessage", () => {
   test("excludes goal-synthetic messages from all edit paths", () => {
@@ -42,6 +57,38 @@ describe("canEditDisplayedUserMessage", () => {
 
   test("excludes side-question rows from edit paths", () => {
     expect(canEditDisplayedUserMessage(userMessage({ isSideQuestion: true }))).toBe(false);
+  });
+
+  test("restores staged ZIPs as attachments when editing sent messages", () => {
+    const content = appendStagedAttachmentNotice("Inspect this archive.", [STAGED_ATTACHMENT]);
+
+    const pending = buildPendingFromDisplayed(userMessage({ content, historyId: "history-1" }));
+
+    expect(pending.content).toBe("Inspect this archive.");
+    expect(pending.fileParts).toEqual([]);
+    expect(pending.stagedAttachments).toEqual([
+      {
+        ...STAGED_ATTACHMENT,
+        id: "edited-history-1-staged-0",
+      },
+    ]);
+  });
+
+  test("restores staged ZIPs as attachments when normalizing queued messages", () => {
+    const queued: QueuedMessage = {
+      id: "queued-1",
+      content: appendStagedAttachmentNotice("Queued archive.", [STAGED_ATTACHMENT]),
+    };
+
+    const pending = normalizeQueuedMessage(queued);
+
+    expect(pending.content).toBe("Queued archive.");
+    expect(pending.stagedAttachments).toEqual([
+      {
+        ...STAGED_ATTACHMENT,
+        id: "queued-queued-1-staged-0",
+      },
+    ]);
   });
 
   test("allows normal user messages", () => {

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -9,6 +9,7 @@ import {
   buildEditingStateFromCompaction,
   buildEditingStateFromDisplayed,
   buildPendingFromDisplayed,
+  buildPendingFromRestoredInput,
   canEditDisplayedUserMessage,
   normalizeQueuedMessage,
 } from "./chatEditing";
@@ -94,6 +95,39 @@ describe("canEditDisplayedUserMessage", () => {
         id: "queued-queued-1-staged-0",
       },
     ]);
+  });
+
+  test("restores staged ZIPs from restore-to-input payloads with attachments", () => {
+    const filePart = {
+      url: "data:text/plain;base64,ZGF0YQ==",
+      mediaType: "text/plain",
+      filename: "context.txt",
+    };
+    const review = {
+      filePath: "src/app.ts",
+      lineRange: "+1",
+      selectedCode: "const value = 1;",
+      userNote: "Review this",
+    };
+
+    const pending = buildPendingFromRestoredInput({
+      content: appendStagedAttachmentNotice("Restore queued work.", [STAGED_ATTACHMENT]),
+      fileParts: [filePart],
+      reviews: [review],
+      idPrefix: "restored-queue",
+    });
+
+    expect(pending).toEqual({
+      content: "Restore queued work.",
+      fileParts: [filePart],
+      stagedAttachments: [
+        {
+          ...STAGED_ATTACHMENT,
+          id: "restored-queue-staged-0",
+        },
+      ],
+      reviews: [review],
+    });
   });
 
   test("restores staged ZIPs from compaction follow-up content", () => {

--- a/src/browser/utils/chatEditing.test.ts
+++ b/src/browser/utils/chatEditing.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
-import type { DisplayedUserMessage, QueuedMessage } from "@/common/types/message";
+import type {
+  CompactionFollowUpRequest,
+  DisplayedUserMessage,
+  QueuedMessage,
+} from "@/common/types/message";
 import {
+  buildEditingStateFromCompaction,
   buildEditingStateFromDisplayed,
   buildPendingFromDisplayed,
   canEditDisplayedUserMessage,
@@ -87,6 +92,24 @@ describe("canEditDisplayedUserMessage", () => {
       {
         ...STAGED_ATTACHMENT,
         id: "queued-queued-1-staged-0",
+      },
+    ]);
+  });
+
+  test("restores staged ZIPs from compaction follow-up content", () => {
+    const followUp: CompactionFollowUpRequest = {
+      text: appendStagedAttachmentNotice("Continue after compaction.", [STAGED_ATTACHMENT]),
+      model: "claude-sonnet-4-5",
+      agentId: "exec",
+    };
+
+    const editingState = buildEditingStateFromCompaction("compact-message", "/compact", followUp);
+
+    expect(editingState.pending.content).toBe("/compact");
+    expect(editingState.pending.stagedAttachments).toEqual([
+      {
+        ...STAGED_ATTACHMENT,
+        id: "compaction-compact-message-staged-0",
       },
     ]);
   });

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -1,11 +1,16 @@
 import type { FilePart } from "@/common/orpc/types";
+import type { StagedChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
+import {
+  displayStagedAttachmentsToChatAttachments,
+  parseStagedAttachmentNotice,
+} from "@/browser/features/ChatInput/stagedAttachments";
 import type {
   CompactionFollowUpRequest,
   DisplayedUserMessage,
   QueuedMessage,
   ReviewNoteDataForDisplay,
 } from "@/common/types/message";
-import { getEditableUserMessageText } from "@/browser/utils/messages/messageUtils";
+import { getEditableUserMessageDraftContent } from "@/browser/utils/messages/messageUtils";
 
 // Keep pending edit data normalized with required arrays so edits can't drop attachments/reviews.
 export interface PendingUserMessage extends Omit<
@@ -13,6 +18,7 @@ export interface PendingUserMessage extends Omit<
   "id" | "hasCompactionRequest" | "queueDispatchMode"
 > {
   fileParts: FilePart[];
+  stagedAttachments: StagedChatAttachment[];
   reviews: ReviewNoteDataForDisplay[];
 }
 
@@ -26,11 +32,18 @@ export interface EditingMessageState {
   isBeforeLatestContextBoundary?: boolean;
 }
 
-export const normalizeQueuedMessage = (queued: QueuedMessage): PendingUserMessage => ({
-  content: queued.content,
-  fileParts: queued.fileParts ?? [],
-  reviews: queued.reviews ?? [],
-});
+export const normalizeQueuedMessage = (queued: QueuedMessage): PendingUserMessage => {
+  const parsed = parseStagedAttachmentNotice(queued.content);
+  return {
+    content: parsed.text,
+    fileParts: queued.fileParts ?? [],
+    stagedAttachments: displayStagedAttachmentsToChatAttachments(
+      parsed.attachments,
+      `queued-${queued.id}`
+    ),
+    reviews: queued.reviews ?? [],
+  };
+};
 
 const LOCAL_COMMAND_STDOUT_OPEN_TAG = "<local-command-stdout>";
 const LOCAL_COMMAND_STDOUT_CLOSE_TAG = "</local-command-stdout>";
@@ -47,11 +60,15 @@ export const canEditDisplayedUserMessage = (message: DisplayedUserMessage): bool
   return true;
 };
 
-export const buildPendingFromDisplayed = (message: DisplayedUserMessage): PendingUserMessage => ({
-  content: getEditableUserMessageText(message),
-  fileParts: message.fileParts ?? [],
-  reviews: message.reviews ?? [],
-});
+export const buildPendingFromDisplayed = (message: DisplayedUserMessage): PendingUserMessage => {
+  const draft = getEditableUserMessageDraftContent(message);
+  return {
+    content: draft.text,
+    fileParts: message.fileParts ?? [],
+    stagedAttachments: draft.stagedAttachments,
+    reviews: message.reviews ?? [],
+  };
+};
 
 export const buildEditingStateFromDisplayed = (
   message: DisplayedUserMessage
@@ -76,6 +93,7 @@ export const buildEditingStateFromCompaction = (
   pending: {
     content: command,
     fileParts: followUp?.fileParts ?? [],
+    stagedAttachments: [],
     reviews: followUp?.reviews ?? [],
   },
 });

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -43,18 +43,31 @@ function stagedAttachmentsFromText(
   return displayStagedAttachmentsToChatAttachments(parsed.attachments, idPrefix);
 }
 
-export const normalizeQueuedMessage = (queued: QueuedMessage): PendingUserMessage => {
-  const parsed = parseStagedAttachmentNotice(queued.content);
+export const normalizeQueuedMessage = (queued: QueuedMessage): PendingUserMessage =>
+  buildPendingFromRestoredInput({
+    content: queued.content,
+    fileParts: queued.fileParts ?? [],
+    reviews: queued.reviews ?? [],
+    idPrefix: `queued-${queued.id}`,
+  });
+
+export function buildPendingFromRestoredInput(params: {
+  content: string;
+  fileParts: FilePart[];
+  reviews: ReviewNoteDataForDisplay[];
+  idPrefix: string;
+}): PendingUserMessage {
+  const parsed = parseStagedAttachmentNotice(params.content);
   return {
     content: parsed.text,
-    fileParts: queued.fileParts ?? [],
+    fileParts: params.fileParts,
     stagedAttachments: displayStagedAttachmentsToChatAttachments(
       parsed.attachments,
-      `queued-${queued.id}`
+      params.idPrefix
     ),
-    reviews: queued.reviews ?? [],
+    reviews: params.reviews,
   };
-};
+}
 
 const LOCAL_COMMAND_STDOUT_OPEN_TAG = "<local-command-stdout>";
 const LOCAL_COMMAND_STDOUT_CLOSE_TAG = "</local-command-stdout>";

--- a/src/browser/utils/chatEditing.ts
+++ b/src/browser/utils/chatEditing.ts
@@ -32,6 +32,17 @@ export interface EditingMessageState {
   isBeforeLatestContextBoundary?: boolean;
 }
 
+function stagedAttachmentsFromText(
+  text: string | undefined,
+  idPrefix: string
+): StagedChatAttachment[] {
+  if (!text) {
+    return [];
+  }
+  const parsed = parseStagedAttachmentNotice(text);
+  return displayStagedAttachmentsToChatAttachments(parsed.attachments, idPrefix);
+}
+
 export const normalizeQueuedMessage = (queued: QueuedMessage): PendingUserMessage => {
   const parsed = parseStagedAttachmentNotice(queued.content);
   return {
@@ -93,7 +104,7 @@ export const buildEditingStateFromCompaction = (
   pending: {
     content: command,
     fileParts: followUp?.fileParts ?? [],
-    stagedAttachments: [],
+    stagedAttachments: stagedAttachmentsFromText(followUp?.text, `compaction-${messageId}`),
     reviews: followUp?.reviews ?? [],
   },
 });

--- a/src/browser/utils/compaction/format.ts
+++ b/src/browser/utils/compaction/format.ts
@@ -1,3 +1,4 @@
+import { stripStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
 import type { CompactionRequestData } from "@/common/types/message";
 import { isDefaultSourceContent } from "@/common/types/message";
 
@@ -27,8 +28,12 @@ export function getFollowUpContentText(
 ): string | null {
   if (!followUpContent) return null;
   if (isDefaultSourceContent(followUpContent)) return null;
-  const text = followUpContent.text;
-  if (typeof text !== "string" || text.trim().length === 0) {
+  const rawText = followUpContent.text;
+  if (typeof rawText !== "string") {
+    return null;
+  }
+  const text = stripStagedAttachmentNotice(rawText);
+  if (text.trim().length === 0) {
     return null;
   }
   return text;

--- a/src/browser/utils/compaction/format.ts
+++ b/src/browser/utils/compaction/format.ts
@@ -24,7 +24,8 @@ export function formatCompactionCommandLine(options: {
  * Hides the default resume sentinel ("Continue") and empty text.
  */
 export function getFollowUpContentText(
-  followUpContent?: CompactionRequestData["followUpContent"]
+  followUpContent?: CompactionRequestData["followUpContent"],
+  options?: { stripStagedAttachmentNotice?: boolean }
 ): string | null {
   if (!followUpContent) return null;
   if (isDefaultSourceContent(followUpContent)) return null;
@@ -32,7 +33,8 @@ export function getFollowUpContentText(
   if (typeof rawText !== "string") {
     return null;
   }
-  const text = stripStagedAttachmentNotice(rawText);
+  const text =
+    options?.stripStagedAttachmentNotice === true ? stripStagedAttachmentNotice(rawText) : rawText;
   if (text.trim().length === 0) {
     return null;
   }

--- a/src/browser/utils/compaction/handler.test.ts
+++ b/src/browser/utils/compaction/handler.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test, mock } from "bun:test";
 import type { APIClient } from "@/browser/contexts/API";
+import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
 import { cancelCompaction } from "./handler";
+
+const STAGED_ATTACHMENT = {
+  kind: "staged" as const,
+  id: "zip-1",
+  filename: "archive.zip",
+  mediaType: "application/zip",
+  sizeBytes: 199,
+  stagedPath: ".mux/user-attachments/id/archive.zip",
+};
 
 describe("cancelCompaction", () => {
   test("enters edit mode with full text before interrupting", async () => {
@@ -46,6 +56,7 @@ describe("cancelCompaction", () => {
       pending: {
         content: "/compact -t 100\nDo the thing",
         fileParts: [],
+        stagedAttachments: [],
         reviews: [],
       },
     });
@@ -113,9 +124,59 @@ describe("cancelCompaction", () => {
       pending: {
         content: "/compact\nContinue work",
         fileParts: [mockFilePart],
+        stagedAttachments: [],
         reviews: [mockReview],
       },
     });
     expect(calls).toEqual(["edit", "interrupt"]);
+  });
+
+  test("restores staged follow-up attachments without exposing the hidden notice", async () => {
+    const interruptStream = mock(() => Promise.resolve({ success: true }));
+    const client = {
+      workspace: {
+        interruptStream,
+      },
+    } as unknown as APIClient;
+
+    const aggregator = {
+      getAllMessages: () => [
+        {
+          id: "user-3",
+          role: "user",
+          metadata: {
+            muxMetadata: {
+              type: "compaction-request",
+              rawCommand: "/compact",
+              parsed: {
+                followUpContent: {
+                  text: appendStagedAttachmentNotice("Continue work", [STAGED_ATTACHMENT]),
+                },
+              },
+            },
+          },
+        },
+      ],
+    } as unknown as Parameters<typeof cancelCompaction>[2];
+
+    const startEditingMessage = mock(() => undefined);
+
+    const result = await cancelCompaction(client, "ws-3", aggregator, startEditingMessage);
+
+    expect(result).toBe(true);
+    expect(startEditingMessage).toHaveBeenCalledWith({
+      id: "user-3",
+      pending: {
+        content: "/compact\nContinue work",
+        fileParts: [],
+        stagedAttachments: [
+          {
+            ...STAGED_ATTACHMENT,
+            id: "compaction-user-3-staged-0",
+          },
+        ],
+        reviews: [],
+      },
+    });
   });
 });

--- a/src/browser/utils/compaction/handler.test.ts
+++ b/src/browser/utils/compaction/handler.test.ts
@@ -67,6 +67,55 @@ describe("cancelCompaction", () => {
     expect(calls).toEqual(["edit", "interrupt"]);
   });
 
+  test("strips generated staged notices from raw compaction commands", async () => {
+    const interruptStream = mock(() => Promise.resolve({ success: true }));
+    const client = {
+      workspace: {
+        interruptStream,
+      },
+    } as unknown as APIClient;
+
+    const aggregator = {
+      getAllMessages: () => [
+        {
+          id: "user-raw-staged",
+          role: "user",
+          metadata: {
+            muxMetadata: {
+              type: "compaction-request",
+              rawCommand: appendStagedAttachmentNotice("/compact", [STAGED_ATTACHMENT]),
+              parsed: {
+                followUpContent: {
+                  text: appendStagedAttachmentNotice("", [STAGED_ATTACHMENT]),
+                },
+              },
+            },
+          },
+        },
+      ],
+    } as unknown as Parameters<typeof cancelCompaction>[2];
+
+    const startEditingMessage = mock(() => undefined);
+
+    const result = await cancelCompaction(client, "ws-raw-staged", aggregator, startEditingMessage);
+
+    expect(result).toBe(true);
+    expect(startEditingMessage).toHaveBeenCalledWith({
+      id: "user-raw-staged",
+      pending: {
+        content: "/compact",
+        fileParts: [],
+        stagedAttachments: [
+          {
+            ...STAGED_ATTACHMENT,
+            id: "compaction-user-raw-staged-staged-0",
+          },
+        ],
+        reviews: [],
+      },
+    });
+  });
+
   test("preserves follow-up attachments and reviews on cancel", async () => {
     const calls: string[] = [];
 

--- a/src/browser/utils/compaction/handler.ts
+++ b/src/browser/utils/compaction/handler.ts
@@ -8,6 +8,7 @@
 import type { StreamingMessageAggregator } from "@/browser/utils/messages/StreamingMessageAggregator";
 import { getCompactionFollowUpContent } from "@/common/types/message";
 import type { APIClient } from "@/browser/contexts/API";
+import { stripStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
 import {
   buildEditingStateFromCompaction,
   type EditingMessageState,
@@ -53,7 +54,7 @@ export function getCompactionCommand(aggregator: StreamingMessageAggregator): st
   if (followUpText && !muxMeta.rawCommand.includes("\n")) {
     return `${muxMeta.rawCommand}\n${followUpText}`;
   }
-  return muxMeta.rawCommand;
+  return stripStagedAttachmentNotice(muxMeta.rawCommand);
 }
 
 /**

--- a/src/browser/utils/compaction/handler.ts
+++ b/src/browser/utils/compaction/handler.ts
@@ -47,7 +47,9 @@ export function getCompactionCommand(aggregator: StreamingMessageAggregator): st
   const muxMeta = compactionMsg.metadata?.muxMetadata;
   if (muxMeta?.type !== "compaction-request") return null;
 
-  const followUpText = getFollowUpContentText(getCompactionFollowUpContent(muxMeta));
+  const followUpText = getFollowUpContentText(getCompactionFollowUpContent(muxMeta), {
+    stripStagedAttachmentNotice: true,
+  });
   if (followUpText && !muxMeta.rawCommand.includes("\n")) {
     return `${muxMeta.rawCommand}\n${followUpText}`;
   }

--- a/src/browser/utils/messages/displayedMessageBuilder.staged.test.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.staged.test.ts
@@ -71,4 +71,31 @@ describe("buildDisplayedMessagesForMessage staged attachments", () => {
     expect(userMessage.content).toContain("<attached-files>");
     expect(userMessage.content).toContain(".mux/user-attachments/id/archive.zip");
   });
+
+  test("preserves staged notices in skill raw commands for chip rendering", () => {
+    const rawCommand = appendStagedAttachmentNotice("/review inspect this", [STAGED_ATTACHMENT]);
+    const message = createMuxMessage("msg-3", "user", "Using skill review: inspect this", {
+      historySequence: 3,
+      muxMetadata: {
+        type: "agent-skill",
+        rawCommand,
+        skillName: "review",
+        scope: "project",
+      },
+    });
+
+    const displayed = buildDisplayedMessagesForMessage({
+      message,
+      hasActiveStream: false,
+      isContextBoundaryMessage: () => false,
+    });
+
+    expect(displayed).toHaveLength(1);
+    const userMessage = displayed[0];
+    expect(userMessage?.type).toBe("user");
+    if (userMessage?.type !== "user") return;
+    expect(userMessage.content).toContain("/review inspect this");
+    expect(userMessage.content).toContain("<attached-files>");
+    expect(userMessage.content).toContain(".mux/user-attachments/id/archive.zip");
+  });
 });

--- a/src/browser/utils/messages/displayedMessageBuilder.staged.test.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.staged.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import { appendStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
+import { createMuxMessage } from "@/common/types/message";
+import { buildDisplayedMessagesForMessage } from "./displayedMessageBuilder";
+
+const STAGED_ATTACHMENT = {
+  kind: "staged" as const,
+  id: "zip-1",
+  filename: "archive.zip",
+  mediaType: "application/zip",
+  sizeBytes: 199,
+  stagedPath: ".mux/user-attachments/id/archive.zip",
+};
+
+describe("buildDisplayedMessagesForMessage staged attachments", () => {
+  test("preserves staged notices in compaction previews for chip rendering", () => {
+    const followUpText = appendStagedAttachmentNotice("Continue work", [STAGED_ATTACHMENT]);
+    const message = createMuxMessage("msg-1", "user", "/compact", {
+      historySequence: 1,
+      muxMetadata: {
+        type: "compaction-request",
+        rawCommand: "/compact",
+        parsed: {
+          followUpContent: {
+            text: followUpText,
+            model: "claude-sonnet-4-5",
+            agentId: "exec",
+          },
+        },
+      },
+    });
+
+    const displayed = buildDisplayedMessagesForMessage({
+      message,
+      hasActiveStream: false,
+      isContextBoundaryMessage: () => false,
+    });
+
+    expect(displayed).toHaveLength(1);
+    const userMessage = displayed[0];
+    expect(userMessage?.type).toBe("user");
+    if (userMessage?.type !== "user") return;
+    expect(userMessage.content).toContain("Continue work");
+    expect(userMessage.content).toContain("<attached-files>");
+    expect(userMessage.content).toContain(".mux/user-attachments/id/archive.zip");
+  });
+});

--- a/src/browser/utils/messages/displayedMessageBuilder.staged.test.ts
+++ b/src/browser/utils/messages/displayedMessageBuilder.staged.test.ts
@@ -45,4 +45,30 @@ describe("buildDisplayedMessagesForMessage staged attachments", () => {
     expect(userMessage.content).toContain("<attached-files>");
     expect(userMessage.content).toContain(".mux/user-attachments/id/archive.zip");
   });
+
+  test("preserves staged notices in one-shot raw commands for chip rendering", () => {
+    const rawCommand = appendStagedAttachmentNotice("/opus inspect this", [STAGED_ATTACHMENT]);
+    const message = createMuxMessage("msg-2", "user", "inspect this", {
+      historySequence: 2,
+      muxMetadata: {
+        type: "normal",
+        rawCommand,
+        commandPrefix: "/opus",
+      },
+    });
+
+    const displayed = buildDisplayedMessagesForMessage({
+      message,
+      hasActiveStream: false,
+      isContextBoundaryMessage: () => false,
+    });
+
+    expect(displayed).toHaveLength(1);
+    const userMessage = displayed[0];
+    expect(userMessage?.type).toBe("user");
+    if (userMessage?.type !== "user") return;
+    expect(userMessage.content).toContain("/opus inspect this");
+    expect(userMessage.content).toContain("<attached-files>");
+    expect(userMessage.content).toContain(".mux/user-attachments/id/archive.zip");
+  });
 });

--- a/src/browser/utils/messages/messageUtils.ts
+++ b/src/browser/utils/messages/messageUtils.ts
@@ -1,3 +1,4 @@
+import { stripStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
 import type { DisplayedMessage } from "@/common/types/message";
 import { formatReviewForModel } from "@/common/types/review";
 import type { BashOutputToolArgs } from "@/common/types/tools";
@@ -9,17 +10,18 @@ export function getEditableUserMessageText(
   message: Extract<DisplayedMessage, { type: "user" }>
 ): string {
   const reviews = message.reviews;
+  const content = stripStagedAttachmentNotice(message.content);
   if (!reviews || reviews.length === 0) {
-    return message.content;
+    return content;
   }
 
   // Reviews are already stored in metadata; strip their rendered tags to avoid duplication on edit.
   const reviewText = reviews.map(formatReviewForModel).join("\n\n");
-  if (!message.content.startsWith(reviewText)) {
-    return message.content;
+  if (!content.startsWith(reviewText)) {
+    return content;
   }
 
-  const remainder = message.content.slice(reviewText.length);
+  const remainder = content.slice(reviewText.length);
   if (remainder.startsWith("\n\n")) {
     return remainder.slice(2);
   }

--- a/src/browser/utils/messages/messageUtils.ts
+++ b/src/browser/utils/messages/messageUtils.ts
@@ -1,7 +1,32 @@
-import { stripStagedAttachmentNotice } from "@/browser/features/ChatInput/stagedAttachments";
-import type { DisplayedMessage } from "@/common/types/message";
+import {
+  displayStagedAttachmentsToChatAttachments,
+  parseStagedAttachmentNotice,
+} from "@/browser/features/ChatInput/stagedAttachments";
+import type { StagedChatAttachment } from "@/browser/features/ChatInput/ChatAttachments";
+import type { DisplayedMessage, ReviewNoteDataForDisplay } from "@/common/types/message";
 import { formatReviewForModel } from "@/common/types/review";
 import type { BashOutputToolArgs } from "@/common/types/tools";
+
+export interface EditableUserMessageDraftContent {
+  text: string;
+  stagedAttachments: StagedChatAttachment[];
+}
+
+/**
+ * Returns the text and staged attachments that should be placed into ChatInput when editing.
+ */
+export function getEditableUserMessageDraftContent(
+  message: Extract<DisplayedMessage, { type: "user" }>
+): EditableUserMessageDraftContent {
+  const parsed = parseStagedAttachmentNotice(message.content);
+  return {
+    text: stripRenderedReviews(parsed.text, message.reviews),
+    stagedAttachments: displayStagedAttachmentsToChatAttachments(
+      parsed.attachments,
+      `edited-${message.historyId}`
+    ),
+  };
+}
 
 /**
  * Returns the text that should be placed into the ChatInput when editing a user message.
@@ -9,8 +34,10 @@ import type { BashOutputToolArgs } from "@/common/types/tools";
 export function getEditableUserMessageText(
   message: Extract<DisplayedMessage, { type: "user" }>
 ): string {
-  const reviews = message.reviews;
-  const content = stripStagedAttachmentNotice(message.content);
+  return getEditableUserMessageDraftContent(message).text;
+}
+
+function stripRenderedReviews(content: string, reviews?: ReviewNoteDataForDisplay[]): string {
   if (!reviews || reviews.length === 0) {
     return content;
   }

--- a/src/common/constants/stagedAttachments.ts
+++ b/src/common/constants/stagedAttachments.ts
@@ -1,0 +1,7 @@
+export const STAGED_ATTACHMENT_DIR = ".mux/user-attachments";
+export const MAX_STAGED_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
+export const MAX_STAGED_ATTACHMENT_BASE64_CHARS =
+  Math.ceil(MAX_STAGED_ATTACHMENT_SIZE_BYTES / 3) * 4 + 8;
+
+export const ZIP_MEDIA_TYPE = "application/zip";
+export const ZIP_MEDIA_TYPES = [ZIP_MEDIA_TYPE, "application/x-zip-compressed"] as const;

--- a/src/common/constants/storage.test.ts
+++ b/src/common/constants/storage.test.ts
@@ -87,6 +87,33 @@ describe("storage workspace-scoped keys", () => {
     expect(localStorage.getItem(destKey)).toBe(value);
   });
 
+  test("copyWorkspaceStorage drops staged draft attachments", () => {
+    const source = "ws-source";
+    const dest = "ws-dest";
+
+    const sourceKey = getInputAttachmentsKey(source);
+    const destKey = getInputAttachmentsKey(dest);
+    const providerAttachment = {
+      kind: "provider",
+      id: "img-1",
+      url: "data:image/png;base64,AAA",
+      mediaType: "image/png",
+    };
+    const stagedAttachment = {
+      kind: "staged",
+      id: "zip-1",
+      filename: "archive.zip",
+      mediaType: "application/zip",
+      sizeBytes: 128,
+      stagedPath: ".mux/user-attachments/id/archive.zip",
+    };
+    localStorage.setItem(sourceKey, JSON.stringify([providerAttachment, stagedAttachment]));
+
+    copyWorkspaceStorage(source, dest);
+
+    expect(JSON.parse(localStorage.getItem(destKey) ?? "null")).toEqual([providerAttachment]);
+  });
+
   test("deleteWorkspaceStorage removes inputAttachments key", () => {
     const workspaceId = "ws-delete";
     const key = getInputAttachmentsKey(workspaceId);

--- a/src/common/constants/storage.ts
+++ b/src/common/constants/storage.ts
@@ -785,6 +785,26 @@ const EPHEMERAL_WORKSPACE_KEY_FUNCTIONS: Array<(workspaceId: string) => string> 
   getPostCompactionStateKey, // Cache only, no need to preserve on fork
 ];
 
+function isStagedPersistedAttachment(value: unknown): boolean {
+  return (
+    typeof value === "object" && value !== null && (value as { kind?: unknown }).kind === "staged"
+  );
+}
+
+function stripStagedDraftAttachments(value: string): string {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!Array.isArray(parsed)) {
+      return value;
+    }
+    // Forked worktrees do not share staged draft files. Keep provider attachments, but drop
+    // workspace-local staged ZIP chips so the fork cannot point at missing source-worktree paths.
+    return JSON.stringify(parsed.filter((attachment) => !isStagedPersistedAttachment(attachment)));
+  } catch {
+    return value;
+  }
+}
+
 /**
  * Copy all workspace-specific localStorage keys from source to destination workspace.
  * Includes keys listed in PERSISTENT_WORKSPACE_KEY_FUNCTIONS (model, draft input text/attachments, etc).
@@ -795,7 +815,10 @@ export function copyWorkspaceStorage(sourceWorkspaceId: string, destWorkspaceId:
     const destKey = getKey(destWorkspaceId);
     const value = localStorage.getItem(sourceKey);
     if (value !== null) {
-      localStorage.setItem(destKey, value);
+      localStorage.setItem(
+        destKey,
+        getKey === getInputAttachmentsKey ? stripStagedDraftAttachments(value) : value
+      );
     }
   }
 }

--- a/src/common/orpc/schemas/api.ts
+++ b/src/common/orpc/schemas/api.ts
@@ -6,6 +6,10 @@ import { WORKTREE_ARCHIVE_BEHAVIORS } from "@/common/config/worktreeArchiveBehav
 import { HEARTBEAT_MAX_INTERVAL_MS, HEARTBEAT_MIN_INTERVAL_MS } from "@/constants/heartbeat";
 import { DEFAULT_GOAL_DEFAULTS } from "@/constants/goals";
 import { EXPERIMENT_IDS } from "@/common/constants/experiments";
+import {
+  MAX_STAGED_ATTACHMENT_BASE64_CHARS,
+  MAX_STAGED_ATTACHMENT_SIZE_BYTES,
+} from "@/common/constants/stagedAttachments";
 import { ChatStatsSchema, SessionUsageFileSchema } from "./chatStats";
 import { AdditionalSystemContextSchema, WorkspaceInstructionsSchema } from "./instructions";
 import {
@@ -1248,6 +1252,39 @@ export const workspace = {
       }),
       z.object({ success: z.literal(false), error: z.string() }),
     ]),
+  },
+  stageAttachment: {
+    input: z.object({
+      workspaceId: z.string(),
+      filename: z.string(),
+      mediaType: z.string().nullish(),
+      sizeBytes: z.number().int().nonnegative().max(MAX_STAGED_ATTACHMENT_SIZE_BYTES),
+      dataBase64: z.string().max(MAX_STAGED_ATTACHMENT_BASE64_CHARS),
+    }),
+    output: ResultSchema(
+      z.object({
+        filename: z.string(),
+        mediaType: z.string(),
+        sizeBytes: z.number().int().nonnegative(),
+        stagedPath: z.string(),
+      }),
+      z.string()
+    ),
+  },
+  downloadStagedAttachment: {
+    input: z.object({
+      workspaceId: z.string(),
+      stagedPath: z.string(),
+    }),
+    output: ResultSchema(
+      z.object({
+        filename: z.string(),
+        mediaType: z.string(),
+        sizeBytes: z.number().int().nonnegative().max(MAX_STAGED_ATTACHMENT_SIZE_BYTES),
+        dataBase64: z.string().max(MAX_STAGED_ATTACHMENT_BASE64_CHARS),
+      }),
+      z.string()
+    ),
   },
   sendMessage: {
     input: z.object({

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getSupportedAttachmentMediaType,
+  getSupportedStagedAttachmentMediaType,
+} from "./supportedAttachmentMediaTypes";
+
+describe("supportedAttachmentMediaTypes", () => {
+  test("classifies zip files as staged attachments without making them provider attachments", () => {
+    expect(getSupportedAttachmentMediaType({ mediaType: "", filename: "archive.zip" })).toBeNull();
+    expect(getSupportedStagedAttachmentMediaType({ mediaType: "", filename: "archive.zip" })).toBe(
+      "application/zip"
+    );
+    expect(
+      getSupportedStagedAttachmentMediaType({
+        mediaType: "application/x-zip-compressed",
+        filename: "archive",
+      })
+    ).toBe("application/zip");
+  });
+});

--- a/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
+++ b/src/common/utils/attachments/supportedAttachmentMediaTypes.ts
@@ -1,4 +1,5 @@
 import { SVG_MEDIA_TYPE } from "@/common/constants/imageAttachments";
+import { ZIP_MEDIA_TYPE, ZIP_MEDIA_TYPES } from "@/common/constants/stagedAttachments";
 
 export const PDF_MEDIA_TYPE = "application/pdf";
 export const MARKDOWN_MEDIA_TYPE = "text/markdown";
@@ -46,4 +47,27 @@ export function getSupportedAttachmentMediaType(args: {
 
   const normalized = normalizeAttachmentMediaType(rawMediaType);
   return isSupportedAttachmentMediaType(normalized) ? normalized : null;
+}
+
+export function isSupportedStagedAttachmentMediaType(mediaType: string): boolean {
+  const normalized = normalizeAttachmentMediaType(mediaType);
+  return ZIP_MEDIA_TYPES.includes(normalized as (typeof ZIP_MEDIA_TYPES)[number]);
+}
+
+export function getSupportedStagedAttachmentMediaType(args: {
+  mediaType?: string | null;
+  filename?: string | null;
+}): string | null {
+  const trimmedMediaType = args.mediaType?.trim();
+  const mediaType =
+    trimmedMediaType != null && trimmedMediaType.length > 0 ? trimmedMediaType : null;
+  if (mediaType != null && isSupportedStagedAttachmentMediaType(mediaType)) {
+    return ZIP_MEDIA_TYPE;
+  }
+
+  if (args.filename?.toLowerCase().endsWith(".zip") === true) {
+    return ZIP_MEDIA_TYPE;
+  }
+
+  return null;
 }

--- a/src/node/orpc/router.ts
+++ b/src/node/orpc/router.ts
@@ -4179,6 +4179,18 @@ export const router = (authToken?: string) => {
             projectPath: result.data.projectPath,
           };
         }),
+      stageAttachment: t
+        .input(schemas.workspace.stageAttachment.input)
+        .output(schemas.workspace.stageAttachment.output)
+        .handler(async ({ context, input }) => {
+          return context.workspaceService.stageAttachment(input);
+        }),
+      downloadStagedAttachment: t
+        .input(schemas.workspace.downloadStagedAttachment.input)
+        .output(schemas.workspace.downloadStagedAttachment.output)
+        .handler(async ({ context, input }) => {
+          return context.workspaceService.downloadStagedAttachment(input);
+        }),
       sendMessage: t
         .input(schemas.workspace.sendMessage.input)
         .output(schemas.workspace.sendMessage.output)

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -6620,17 +6620,6 @@ export class WorkspaceService extends EventEmitter {
         workspaceName: sourceMetadata.name,
         workspacePath: sourceWorkspace?.workspacePath,
       });
-      const sourceWorkspacePath = resolveWorkspaceExecutionPath(sourceMetadata, freshSourceRuntime);
-      const targetWorkspacePath = resolveWorkspaceExecutionPath(
-        {
-          ...sourceMetadata,
-          name: resolvedName,
-          namedWorkspacePath: workspacePath,
-          projectPath: foundProjectPath,
-          runtimeConfig: forkedRuntimeConfig,
-        },
-        targetRuntime
-      );
 
       const sourceSessionDir = this.config.getSessionDir(sourceWorkspaceId);
       const newSessionDir = this.config.getSessionDir(newWorkspaceId);
@@ -6687,15 +6676,31 @@ export class WorkspaceService extends EventEmitter {
 
         const referencedStagedAttachmentPaths =
           await collectReferencedStagedAttachmentPaths(newSessionDir);
-        const copyStagedAttachmentsResult = await copyStagedWorkspaceAttachments({
-          sourceRuntime: freshSourceRuntime,
-          targetRuntime,
-          sourceWorkspacePath,
-          stagedPaths: referencedStagedAttachmentPaths,
-          targetWorkspacePath,
-        });
-        if (!copyStagedAttachmentsResult.success) {
-          throw new Error(copyStagedAttachmentsResult.error);
+        if (referencedStagedAttachmentPaths.length > 0) {
+          const sourceWorkspacePath = resolveWorkspaceExecutionPath(
+            sourceMetadata,
+            freshSourceRuntime
+          );
+          const targetWorkspacePath = resolveWorkspaceExecutionPath(
+            {
+              ...sourceMetadata,
+              name: resolvedName,
+              namedWorkspacePath: workspacePath,
+              projectPath: foundProjectPath,
+              runtimeConfig: forkedRuntimeConfig,
+            },
+            targetRuntime
+          );
+          const copyStagedAttachmentsResult = await copyStagedWorkspaceAttachments({
+            sourceRuntime: freshSourceRuntime,
+            targetRuntime,
+            sourceWorkspacePath,
+            stagedPaths: referencedStagedAttachmentPaths,
+            targetWorkspacePath,
+          });
+          if (!copyStagedAttachmentsResult.success) {
+            throw new Error(copyStagedAttachmentsResult.error);
+          }
         }
 
         // Forks inherit chat history, but their cost ledger must start fresh.

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -91,6 +91,7 @@ import { expandTilde, expandTildeForSSH } from "@/node/runtime/tildeExpansion";
 import { removeManagedGitWorktree } from "@/node/worktree/removeManagedGitWorktree";
 
 import {
+  copyStagedWorkspaceAttachments,
   readStagedWorkspaceAttachment,
   stageWorkspaceAttachment,
   type DownloadedStagedWorkspaceAttachment,
@@ -6594,6 +6595,25 @@ export class WorkspaceService extends EventEmitter {
         log
       );
 
+      // Create a fresh source runtime handle because DockerRuntime.forkWorkspace() can
+      // mutate the original runtime's container identity to target the new workspace.
+      const freshSourceRuntime = createRuntime(sourceRuntimeConfig, {
+        projectPath: foundProjectPath,
+        workspaceName: sourceMetadata.name,
+        workspacePath: sourceWorkspace?.workspacePath,
+      });
+      const sourceWorkspacePath = resolveWorkspaceExecutionPath(sourceMetadata, freshSourceRuntime);
+      const targetWorkspacePath = resolveWorkspaceExecutionPath(
+        {
+          ...sourceMetadata,
+          name: resolvedName,
+          namedWorkspacePath: workspacePath,
+          projectPath: foundProjectPath,
+          runtimeConfig: forkedRuntimeConfig,
+        },
+        targetRuntime
+      );
+
       const sourceSessionDir = this.config.getSessionDir(sourceWorkspaceId);
       const newSessionDir = this.config.getSessionDir(newWorkspaceId);
 
@@ -6647,6 +6667,16 @@ export class WorkspaceService extends EventEmitter {
           targetWorkspaceId: newWorkspaceId,
         });
 
+        const copyStagedAttachmentsResult = await copyStagedWorkspaceAttachments({
+          sourceRuntime: freshSourceRuntime,
+          targetRuntime,
+          sourceWorkspacePath,
+          targetWorkspacePath,
+        });
+        if (!copyStagedAttachmentsResult.success) {
+          throw new Error(copyStagedAttachmentsResult.error);
+        }
+
         // Forks inherit chat history, but their cost ledger must start fresh.
         // Persist an explicit empty usage file so later reads do not rebuild
         // historical costs from the copied messages.
@@ -6667,17 +6697,10 @@ export class WorkspaceService extends EventEmitter {
         }
         initLogger.logComplete(-1);
         const message = getErrorMessage(copyError);
-        return Err(`Failed to copy chat history: ${message}`);
+        return Err(`Failed to copy fork state: ${message}`);
       }
 
       // Copy plan file using explicit source/target runtimes for cross-runtime safety.
-      // Create a fresh source runtime handle because DockerRuntime.forkWorkspace() can
-      // mutate the original runtime's container identity to target the new workspace.
-      const freshSourceRuntime = createRuntime(sourceRuntimeConfig, {
-        projectPath: foundProjectPath,
-        workspaceName: sourceMetadata.name,
-        workspacePath: sourceWorkspace?.workspacePath,
-      });
       await copyPlanFileAcrossRuntimes(
         freshSourceRuntime,
         targetRuntime,

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -90,6 +90,12 @@ import { isWorktreeRuntime } from "@/node/runtime/worktreeLifecycleHooks";
 import { expandTilde, expandTildeForSSH } from "@/node/runtime/tildeExpansion";
 import { removeManagedGitWorktree } from "@/node/worktree/removeManagedGitWorktree";
 
+import {
+  readStagedWorkspaceAttachment,
+  stageWorkspaceAttachment,
+  type DownloadedStagedWorkspaceAttachment,
+  type StagedWorkspaceAttachment,
+} from "@/node/utils/attachments/stageWorkspaceAttachment";
 import { ContainerManager } from "@/node/multiProject/containerManager";
 
 import type { PostCompactionExclusions } from "@/common/types/attachment";
@@ -6904,6 +6910,46 @@ export class WorkspaceService extends EventEmitter {
     }
 
     return foundDecision && current;
+  }
+
+  async stageAttachment(input: {
+    workspaceId: string;
+    filename: string;
+    mediaType?: string | null;
+    sizeBytes: number;
+    dataBase64: string;
+  }): Promise<Result<StagedWorkspaceAttachment, string>> {
+    const metadata = await this.getInfo(input.workspaceId);
+    if (metadata == null) {
+      return Err("Workspace not found");
+    }
+
+    const { runtime, workspacePath } = createRuntimeContextForWorkspace(metadata);
+    return stageWorkspaceAttachment({
+      runtime,
+      workspacePath,
+      filename: input.filename,
+      mediaType: input.mediaType,
+      sizeBytes: input.sizeBytes,
+      dataBase64: input.dataBase64,
+    });
+  }
+
+  async downloadStagedAttachment(input: {
+    workspaceId: string;
+    stagedPath: string;
+  }): Promise<Result<DownloadedStagedWorkspaceAttachment, string>> {
+    const metadata = await this.getInfo(input.workspaceId);
+    if (metadata == null) {
+      return Err("Workspace not found");
+    }
+
+    const { runtime, workspacePath } = createRuntimeContextForWorkspace(metadata);
+    return readStagedWorkspaceAttachment({
+      runtime,
+      workspacePath,
+      stagedPath: input.stagedPath,
+    });
   }
 
   async sendMessage(

--- a/src/node/services/workspaceService.ts
+++ b/src/node/services/workspaceService.ts
@@ -92,6 +92,7 @@ import { removeManagedGitWorktree } from "@/node/worktree/removeManagedGitWorktr
 
 import {
   copyStagedWorkspaceAttachments,
+  extractStagedAttachmentPathsFromText,
   readStagedWorkspaceAttachment,
   stageWorkspaceAttachment,
   type DownloadedStagedWorkspaceAttachment,
@@ -1072,6 +1073,23 @@ function rollUpAncestorWorkspaceIds(params: {
     params.newParentWorkspaceId,
     ...filtered.filter((id) => id !== params.newParentWorkspaceId),
   ];
+}
+
+async function collectReferencedStagedAttachmentPaths(sessionDir: string): Promise<string[]> {
+  const paths = new Set<string>();
+  for (const fileName of [CHAT_ARCHIVE_FILE_NAME, CHAT_FILE_NAME, "partial.json"] as const) {
+    try {
+      const content = await fsPromises.readFile(path.join(sessionDir, fileName), "utf8");
+      for (const stagedPath of extractStagedAttachmentPathsFromText(content)) {
+        paths.add(stagedPath);
+      }
+    } catch (error) {
+      if (!isErrnoWithCode(error, "ENOENT")) {
+        throw error;
+      }
+    }
+  }
+  return [...paths];
 }
 
 async function archiveChildSessionArtifactsIntoParentSessionDir(params: {
@@ -6667,10 +6685,13 @@ export class WorkspaceService extends EventEmitter {
           targetWorkspaceId: newWorkspaceId,
         });
 
+        const referencedStagedAttachmentPaths =
+          await collectReferencedStagedAttachmentPaths(newSessionDir);
         const copyStagedAttachmentsResult = await copyStagedWorkspaceAttachments({
           sourceRuntime: freshSourceRuntime,
           targetRuntime,
           sourceWorkspacePath,
+          stagedPaths: referencedStagedAttachmentPaths,
           targetWorkspacePath,
         });
         if (!copyStagedAttachmentsResult.success) {

--- a/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { STAGED_ATTACHMENT_DIR } from "@/common/constants/stagedAttachments";
+import { LocalRuntime } from "@/node/runtime/LocalRuntime";
+
+import {
+  readStagedWorkspaceAttachment,
+  stageWorkspaceAttachment,
+} from "./stageWorkspaceAttachment";
+
+let tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs = [];
+});
+
+describe("stageWorkspaceAttachment", () => {
+  test("writes zip bytes under the staged attachment directory and keeps git clean", async () => {
+    const repo = await makeTempDir("mux-stage-attachment-");
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    const runtime = new LocalRuntime(repo);
+    const bytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 1, 2, 3]);
+
+    const result = await stageWorkspaceAttachment({
+      runtime,
+      workspacePath: repo,
+      filename: "../../archive.zip",
+      mediaType: "application/zip",
+      sizeBytes: bytes.byteLength,
+      dataBase64: Buffer.from(bytes).toString("base64"),
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.filename).toBe("archive.zip");
+    expect(result.data.stagedPath).toStartWith(`${STAGED_ATTACHMENT_DIR}/`);
+    expect(await readFile(path.join(repo, result.data.stagedPath))).toEqual(Buffer.from(bytes));
+    const status = execFileSync("git", ["status", "--porcelain"], { cwd: repo, encoding: "utf8" });
+    expect(status).toBe("");
+  });
+
+  test("reads staged zip bytes for download and rejects paths outside staging", async () => {
+    const repo = await makeTempDir("mux-stage-attachment-download-");
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    const runtime = new LocalRuntime(repo);
+    const bytes = Buffer.from("zip bytes");
+
+    const staged = await stageWorkspaceAttachment({
+      runtime,
+      workspacePath: repo,
+      filename: "archive.zip",
+      mediaType: "application/zip",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    if (!staged.success) return;
+
+    const invalidDownload = await readStagedWorkspaceAttachment({
+      runtime,
+      workspacePath: repo,
+      stagedPath: "../README.md",
+    });
+    expect(invalidDownload).toEqual({ success: false, error: "Invalid staged attachment path." });
+
+    const downloaded = await readStagedWorkspaceAttachment({
+      runtime,
+      workspacePath: repo,
+      stagedPath: staged.data.stagedPath,
+    });
+
+    expect(downloaded).toEqual({
+      success: true,
+      data: {
+        filename: "archive.zip",
+        mediaType: "application/zip",
+        sizeBytes: bytes.byteLength,
+        dataBase64: bytes.toString("base64"),
+      },
+    });
+  });
+
+  test("stages zip files in non-git workspaces", async () => {
+    const dir = await makeTempDir("mux-stage-attachment-nongit-");
+    const runtime = new LocalRuntime(dir);
+    const bytes = Buffer.from("zip");
+
+    const result = await stageWorkspaceAttachment({
+      runtime,
+      workspacePath: dir,
+      filename: "archive.zip",
+      mediaType: "",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(await readFile(path.join(dir, result.data.stagedPath), "utf8")).toBe("zip");
+  });
+
+  test("rejects invalid base64 before writing", async () => {
+    const repo = await makeTempDir("mux-stage-attachment-bad-base64-");
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    const runtime = new LocalRuntime(repo);
+
+    const result = await stageWorkspaceAttachment({
+      runtime,
+      workspacePath: repo,
+      filename: "archive.zip",
+      mediaType: "application/zip",
+      sizeBytes: 0,
+      dataBase64: "not base64!",
+    });
+
+    expect(result.success).toBe(false);
+    expect(
+      await Array.fromAsync(new Bun.Glob(`${STAGED_ATTACHMENT_DIR}/**`).scan({ cwd: repo }))
+    ).toEqual([]);
+  });
+
+  test("rejects invalid payloads before writing", async () => {
+    const repo = await makeTempDir("mux-stage-attachment-invalid-");
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    const runtime = new LocalRuntime(repo);
+
+    const result = await stageWorkspaceAttachment({
+      runtime,
+      workspacePath: repo,
+      filename: "archive.txt",
+      mediaType: "text/plain",
+      sizeBytes: 3,
+      dataBase64: Buffer.from("zip").toString("base64"),
+    });
+
+    expect(result.success).toBe(false);
+    expect(
+      await Array.fromAsync(new Bun.Glob(`${STAGED_ATTACHMENT_DIR}/**`).scan({ cwd: repo }))
+    ).toEqual([]);
+  });
+});

--- a/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
@@ -8,6 +8,7 @@ import { STAGED_ATTACHMENT_DIR } from "@/common/constants/stagedAttachments";
 import { LocalRuntime } from "@/node/runtime/LocalRuntime";
 
 import {
+  copyStagedWorkspaceAttachments,
   readStagedWorkspaceAttachment,
   stageWorkspaceAttachment,
 } from "./stageWorkspaceAttachment";
@@ -108,6 +109,42 @@ describe("stageWorkspaceAttachment", () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(await readFile(path.join(dir, result.data.stagedPath), "utf8")).toBe("zip");
+  });
+
+  test("copies staged zip attachments into a fork target and keeps git clean", async () => {
+    const sourceRepo = await makeTempDir("mux-stage-attachment-copy-source-");
+    const targetRepo = await makeTempDir("mux-stage-attachment-copy-target-");
+    execFileSync("git", ["init", "-b", "main"], { cwd: sourceRepo, stdio: "ignore" });
+    execFileSync("git", ["init", "-b", "main"], { cwd: targetRepo, stdio: "ignore" });
+    const sourceRuntime = new LocalRuntime(sourceRepo);
+    const targetRuntime = new LocalRuntime(targetRepo);
+    const bytes = Buffer.from("forked zip bytes");
+
+    const staged = await stageWorkspaceAttachment({
+      runtime: sourceRuntime,
+      workspacePath: sourceRepo,
+      filename: "archive.zip",
+      mediaType: "application/zip",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    if (!staged.success) return;
+
+    const copied = await copyStagedWorkspaceAttachments({
+      sourceRuntime,
+      targetRuntime,
+      sourceWorkspacePath: sourceRepo,
+      targetWorkspacePath: targetRepo,
+    });
+
+    expect(copied).toEqual({ success: true, data: undefined });
+    expect(await readFile(path.join(targetRepo, staged.data.stagedPath))).toEqual(bytes);
+    const status = execFileSync("git", ["status", "--porcelain"], {
+      cwd: targetRepo,
+      encoding: "utf8",
+    });
+    expect(status).toBe("");
   });
 
   test("rejects invalid base64 before writing", async () => {

--- a/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
@@ -9,6 +9,7 @@ import { LocalRuntime } from "@/node/runtime/LocalRuntime";
 
 import {
   copyStagedWorkspaceAttachments,
+  extractStagedAttachmentPathsFromText,
   readStagedWorkspaceAttachment,
   stageWorkspaceAttachment,
 } from "./stageWorkspaceAttachment";
@@ -131,20 +132,49 @@ describe("stageWorkspaceAttachment", () => {
     expect(staged.success).toBe(true);
     if (!staged.success) return;
 
+    const futureStaged = await stageWorkspaceAttachment({
+      runtime: sourceRuntime,
+      workspacePath: sourceRepo,
+      filename: "future.zip",
+      mediaType: "application/zip",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(futureStaged.success).toBe(true);
+    if (!futureStaged.success) return;
+
     const copied = await copyStagedWorkspaceAttachments({
       sourceRuntime,
       targetRuntime,
       sourceWorkspacePath: sourceRepo,
       targetWorkspacePath: targetRepo,
+      stagedPaths: [staged.data.stagedPath],
     });
 
     expect(copied).toEqual({ success: true, data: undefined });
     expect(await readFile(path.join(targetRepo, staged.data.stagedPath))).toEqual(bytes);
+    let futureAttachmentExists = true;
+    try {
+      await readFile(path.join(targetRepo, futureStaged.data.stagedPath));
+    } catch {
+      futureAttachmentExists = false;
+    }
+    expect(futureAttachmentExists).toBe(false);
     const status = execFileSync("git", ["status", "--porcelain"], {
       cwd: targetRepo,
       encoding: "utf8",
     });
     expect(status).toBe("");
+  });
+
+  test("extracts referenced staged attachment paths from persisted text", () => {
+    const text =
+      "before `.mux/user-attachments/one/ARCHIVE.ZIP` middle `.mux/user-attachments/two/future.zip` after";
+
+    expect(extractStagedAttachmentPathsFromText(text)).toEqual([
+      ".mux/user-attachments/one/ARCHIVE.ZIP",
+      ".mux/user-attachments/two/future.zip",
+    ]);
   });
 
   test("rejects invalid base64 before writing", async () => {

--- a/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
@@ -123,7 +123,7 @@ describe("stageWorkspaceAttachment", () => {
     const staged = await stageWorkspaceAttachment({
       runtime: sourceRuntime,
       workspacePath: sourceRepo,
-      filename: "archive.zip",
+      filename: "ARCHIVE.ZIP",
       mediaType: "application/zip",
       sizeBytes: bytes.byteLength,
       dataBase64: bytes.toString("base64"),

--- a/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.test.ts
@@ -167,6 +167,38 @@ describe("stageWorkspaceAttachment", () => {
     expect(status).toBe("");
   });
 
+  test("skips stale referenced staged zip attachments during fork copy", async () => {
+    const sourceRepo = await makeTempDir("mux-stage-attachment-stale-source-");
+    const targetRepo = await makeTempDir("mux-stage-attachment-stale-target-");
+    execFileSync("git", ["init", "-b", "main"], { cwd: sourceRepo, stdio: "ignore" });
+    execFileSync("git", ["init", "-b", "main"], { cwd: targetRepo, stdio: "ignore" });
+    const sourceRuntime = new LocalRuntime(sourceRepo);
+    const targetRuntime = new LocalRuntime(targetRepo);
+    const bytes = Buffer.from("still present");
+
+    const staged = await stageWorkspaceAttachment({
+      runtime: sourceRuntime,
+      workspacePath: sourceRepo,
+      filename: "present.zip",
+      mediaType: "application/zip",
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+    expect(staged.success).toBe(true);
+    if (!staged.success) return;
+
+    const copied = await copyStagedWorkspaceAttachments({
+      sourceRuntime,
+      targetRuntime,
+      sourceWorkspacePath: sourceRepo,
+      targetWorkspacePath: targetRepo,
+      stagedPaths: [staged.data.stagedPath, ".mux/user-attachments/missing/deleted.zip"],
+    });
+
+    expect(copied).toEqual({ success: true, data: undefined });
+    expect(await readFile(path.join(targetRepo, staged.data.stagedPath))).toEqual(bytes);
+  });
+
   test("extracts referenced staged attachment paths from persisted text", () => {
     const text =
       "before `.mux/user-attachments/one/ARCHIVE.ZIP` middle `.mux/user-attachments/two/future.zip` after";

--- a/src/node/utils/attachments/stageWorkspaceAttachment.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.ts
@@ -211,7 +211,7 @@ async function listStagedAttachmentPaths(
 ): Promise<Result<string[], string>> {
   const result = await execBuffered(
     runtime,
-    `if [ ! -d ${shellQuote(STAGED_ATTACHMENT_DIR)} ]; then exit 0; fi; find ${shellQuote(STAGED_ATTACHMENT_DIR)} -type f -name '*.zip' -print`,
+    `if [ ! -d ${shellQuote(STAGED_ATTACHMENT_DIR)} ]; then exit 0; fi; find ${shellQuote(STAGED_ATTACHMENT_DIR)} -type f -iname '*.zip' -print`,
     { cwd: workspacePath, timeout: 30 }
   );
   if (result.exitCode !== 0) {

--- a/src/node/utils/attachments/stageWorkspaceAttachment.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.ts
@@ -10,7 +10,9 @@ import type { Result } from "@/common/types/result";
 import { Err, Ok } from "@/common/types/result";
 import { getSupportedStagedAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
 import { getErrorMessage } from "@/common/utils/errors";
+import { shellQuote } from "@/common/utils/shell";
 import type { Runtime } from "@/node/runtime/Runtime";
+import { execBuffered } from "@/node/utils/runtime/helpers";
 import { ensureGitInfoExclude } from "@/node/utils/git/ensureGitInfoExclude";
 
 export interface StagedWorkspaceAttachment {
@@ -116,6 +118,57 @@ export async function readStagedWorkspaceAttachment(input: {
   }
 }
 
+export async function copyStagedWorkspaceAttachments(input: {
+  sourceRuntime: Runtime;
+  targetRuntime: Runtime;
+  sourceWorkspacePath: string;
+  targetWorkspacePath: string;
+}): Promise<Result<void, string>> {
+  try {
+    assert(input.sourceWorkspacePath.trim().length > 0, "sourceWorkspacePath is required");
+    assert(input.targetWorkspacePath.trim().length > 0, "targetWorkspacePath is required");
+
+    const stagedPaths = await listStagedAttachmentPaths(
+      input.sourceRuntime,
+      input.sourceWorkspacePath
+    );
+    if (!stagedPaths.success) {
+      return stagedPaths;
+    }
+    if (stagedPaths.data.length === 0) {
+      return Ok(undefined);
+    }
+
+    const excludeResult = await ensureGitInfoExclude({
+      runtime: input.targetRuntime,
+      workspacePath: input.targetWorkspacePath,
+      relativeDir: STAGED_ATTACHMENT_DIR,
+    });
+    if (excludeResult.status === "failed") {
+      return Err(`Could not mark staged attachments as ignored: ${excludeResult.error}`);
+    }
+
+    for (const stagedPath of stagedPaths.data) {
+      const bytes = await readStreamToBuffer(
+        input.sourceRuntime.readFile(`${input.sourceWorkspacePath}/${stagedPath}`)
+      );
+      if (bytes.byteLength > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
+        return Err(
+          `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+        );
+      }
+      await input.targetRuntime.ensureDir(
+        `${input.targetWorkspacePath}/${stagedPath.split("/").slice(0, -1).join("/")}`
+      );
+      await writeBytes(input.targetRuntime, `${input.targetWorkspacePath}/${stagedPath}`, bytes);
+    }
+
+    return Ok(undefined);
+  } catch (error) {
+    return Err(getErrorMessage(error));
+  }
+}
+
 export function sanitizeZipFilename(filename: string): string {
   const rawBase = filename.split(/[\\/]/u).pop()?.trim() ?? "";
   const withoutControls = Array.from(rawBase)
@@ -150,6 +203,29 @@ function normalizeReadableStagedPath(stagedPath: string): string | null {
     return null;
   }
   return normalized;
+}
+
+async function listStagedAttachmentPaths(
+  runtime: Runtime,
+  workspacePath: string
+): Promise<Result<string[], string>> {
+  const result = await execBuffered(
+    runtime,
+    `if [ ! -d ${shellQuote(STAGED_ATTACHMENT_DIR)} ]; then exit 0; fi; find ${shellQuote(STAGED_ATTACHMENT_DIR)} -type f -name '*.zip' -print`,
+    { cwd: workspacePath, timeout: 30 }
+  );
+  if (result.exitCode !== 0) {
+    return Err(result.stderr.trim() || "Failed to list staged attachments.");
+  }
+
+  const stagedPaths: string[] = [];
+  for (const line of result.stdout.split("\n")) {
+    const stagedPath = normalizeReadableStagedPath(line.trim());
+    if (stagedPath != null) {
+      stagedPaths.push(stagedPath);
+    }
+  }
+  return Ok(stagedPaths);
 }
 
 async function readStreamToBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer> {

--- a/src/node/utils/attachments/stageWorkspaceAttachment.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.ts
@@ -148,10 +148,21 @@ export async function copyStagedWorkspaceAttachments(input: {
       return Err(`Could not mark staged attachments as ignored: ${excludeResult.error}`);
     }
 
+    const shouldSkipUnreadableSource = input.stagedPaths != null;
     for (const stagedPath of stagedPaths.data) {
-      const bytes = await readStreamToBuffer(
-        input.sourceRuntime.readFile(`${input.sourceWorkspacePath}/${stagedPath}`)
-      );
+      let bytes: Buffer;
+      try {
+        bytes = await readStreamToBuffer(
+          input.sourceRuntime.readFile(`${input.sourceWorkspacePath}/${stagedPath}`)
+        );
+      } catch (error) {
+        // Fork history can contain stale generated attachment notices after users clean up
+        // staged files manually. Preserve the fork rather than failing the whole workspace copy.
+        if (shouldSkipUnreadableSource) {
+          continue;
+        }
+        throw error;
+      }
       if (bytes.byteLength > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
         return Err(
           `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`

--- a/src/node/utils/attachments/stageWorkspaceAttachment.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+
+import {
+  MAX_STAGED_ATTACHMENT_SIZE_BYTES,
+  STAGED_ATTACHMENT_DIR,
+  ZIP_MEDIA_TYPE,
+} from "@/common/constants/stagedAttachments";
+import type { Result } from "@/common/types/result";
+import { Err, Ok } from "@/common/types/result";
+import { getSupportedStagedAttachmentMediaType } from "@/common/utils/attachments/supportedAttachmentMediaTypes";
+import { getErrorMessage } from "@/common/utils/errors";
+import type { Runtime } from "@/node/runtime/Runtime";
+import { ensureGitInfoExclude } from "@/node/utils/git/ensureGitInfoExclude";
+
+export interface StagedWorkspaceAttachment {
+  filename: string;
+  mediaType: string;
+  sizeBytes: number;
+  stagedPath: string;
+}
+
+export interface DownloadedStagedWorkspaceAttachment {
+  filename: string;
+  mediaType: string;
+  sizeBytes: number;
+  dataBase64: string;
+}
+
+export async function stageWorkspaceAttachment(input: {
+  runtime: Runtime;
+  workspacePath: string;
+  filename: string;
+  mediaType?: string | null;
+  sizeBytes: number;
+  dataBase64: string;
+}): Promise<Result<StagedWorkspaceAttachment, string>> {
+  try {
+    assert(input.workspacePath.trim().length > 0, "workspacePath is required");
+    const mediaType = getSupportedStagedAttachmentMediaType({
+      mediaType: input.mediaType,
+      filename: input.filename,
+    });
+    if (mediaType == null) {
+      return Err("Only .zip attachments can be staged.");
+    }
+    if (!Number.isInteger(input.sizeBytes) || input.sizeBytes < 0) {
+      return Err("Attachment size is invalid.");
+    }
+    if (input.sizeBytes > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
+      return Err(
+        `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+      );
+    }
+
+    const bytes = Buffer.from(input.dataBase64, "base64");
+    if (bytes.byteLength !== input.sizeBytes) {
+      return Err("Attachment size did not match the uploaded data.");
+    }
+    if (bytes.byteLength > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
+      return Err(
+        `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+      );
+    }
+
+    const filename = sanitizeZipFilename(input.filename);
+    const excludeResult = await ensureGitInfoExclude({
+      runtime: input.runtime,
+      workspacePath: input.workspacePath,
+      relativeDir: STAGED_ATTACHMENT_DIR,
+    });
+    if (excludeResult.status === "failed") {
+      return Err(`Could not mark staged attachments as ignored: ${excludeResult.error}`);
+    }
+
+    const stagedDir = `${STAGED_ATTACHMENT_DIR}/${randomUUID()}`;
+    const stagedPath = `${stagedDir}/${filename}`;
+    await input.runtime.ensureDir(`${input.workspacePath}/${stagedDir}`);
+    await writeBytes(input.runtime, `${input.workspacePath}/${stagedPath}`, bytes);
+
+    return Ok({ filename, mediaType: ZIP_MEDIA_TYPE, sizeBytes: bytes.byteLength, stagedPath });
+  } catch (error) {
+    return Err(getErrorMessage(error));
+  }
+}
+
+export async function readStagedWorkspaceAttachment(input: {
+  runtime: Runtime;
+  workspacePath: string;
+  stagedPath: string;
+}): Promise<Result<DownloadedStagedWorkspaceAttachment, string>> {
+  try {
+    assert(input.workspacePath.trim().length > 0, "workspacePath is required");
+    const stagedPath = normalizeReadableStagedPath(input.stagedPath);
+    if (stagedPath == null) {
+      return Err("Invalid staged attachment path.");
+    }
+
+    const bytes = await readStreamToBuffer(
+      input.runtime.readFile(`${input.workspacePath}/${stagedPath}`)
+    );
+    if (bytes.byteLength > MAX_STAGED_ATTACHMENT_SIZE_BYTES) {
+      return Err(
+        `ZIP attachments must be ${MAX_STAGED_ATTACHMENT_SIZE_BYTES.toLocaleString()} bytes or less.`
+      );
+    }
+
+    return Ok({
+      filename: stagedPath.split("/").pop() ?? "attachment.zip",
+      mediaType: ZIP_MEDIA_TYPE,
+      sizeBytes: bytes.byteLength,
+      dataBase64: bytes.toString("base64"),
+    });
+  } catch (error) {
+    return Err(getErrorMessage(error));
+  }
+}
+
+export function sanitizeZipFilename(filename: string): string {
+  const rawBase = filename.split(/[\\/]/u).pop()?.trim() ?? "";
+  const withoutControls = Array.from(rawBase)
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      return code > 0x1f && code !== 0x7f;
+    })
+    .join("");
+  const safeChars = withoutControls.replace(/[^A-Za-z0-9._ -]/gu, "-").replace(/^\.+/u, "");
+  const withExtension = safeChars.toLowerCase().endsWith(".zip") ? safeChars : `${safeChars}.zip`;
+  const fallback =
+    withExtension === ".zip" || withExtension.trim().length === 0
+      ? "attachment.zip"
+      : withExtension;
+  if (fallback.length <= 120) {
+    return fallback;
+  }
+  const stem = fallback.slice(0, 116).replace(/\.+$/u, "") || "attachment";
+  return `${stem}.zip`;
+}
+
+function normalizeReadableStagedPath(stagedPath: string): string | null {
+  const normalized = stagedPath.replace(/\\/gu, "/").replace(/^\/+/, "");
+  if (
+    normalized.length === 0 ||
+    normalized.includes("\0") ||
+    normalized.includes("//") ||
+    normalized.split("/").includes("..") ||
+    !normalized.startsWith(`${STAGED_ATTACHMENT_DIR}/`) ||
+    !normalized.toLowerCase().endsWith(".zip")
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+async function readStreamToBuffer(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks);
+}
+
+async function writeBytes(runtime: Runtime, path: string, bytes: Uint8Array): Promise<void> {
+  const writer = runtime.writeFile(path).getWriter();
+  try {
+    await writer.write(bytes);
+    await writer.close();
+  } catch (error) {
+    writer.releaseLock();
+    throw error;
+  }
+}

--- a/src/node/utils/attachments/stageWorkspaceAttachment.ts
+++ b/src/node/utils/attachments/stageWorkspaceAttachment.ts
@@ -123,15 +123,15 @@ export async function copyStagedWorkspaceAttachments(input: {
   targetRuntime: Runtime;
   sourceWorkspacePath: string;
   targetWorkspacePath: string;
+  stagedPaths?: readonly string[];
 }): Promise<Result<void, string>> {
   try {
     assert(input.sourceWorkspacePath.trim().length > 0, "sourceWorkspacePath is required");
     assert(input.targetWorkspacePath.trim().length > 0, "targetWorkspacePath is required");
 
-    const stagedPaths = await listStagedAttachmentPaths(
-      input.sourceRuntime,
-      input.sourceWorkspacePath
-    );
+    const stagedPaths = input.stagedPaths
+      ? Ok(normalizeStagedAttachmentPaths(input.stagedPaths))
+      : await listStagedAttachmentPaths(input.sourceRuntime, input.sourceWorkspacePath);
     if (!stagedPaths.success) {
       return stagedPaths;
     }
@@ -169,6 +169,18 @@ export async function copyStagedWorkspaceAttachments(input: {
   }
 }
 
+export function extractStagedAttachmentPathsFromText(text: string): string[] {
+  const paths = new Set<string>();
+  const pattern = /`(?<path>\.mux\/user-attachments\/[^`]+?\.zip)`/giu;
+  for (const match of text.matchAll(pattern)) {
+    const stagedPath = match.groups?.path ? normalizeReadableStagedPath(match.groups.path) : null;
+    if (stagedPath != null) {
+      paths.add(stagedPath);
+    }
+  }
+  return [...paths];
+}
+
 export function sanitizeZipFilename(filename: string): string {
   const rawBase = filename.split(/[\\/]/u).pop()?.trim() ?? "";
   const withoutControls = Array.from(rawBase)
@@ -203,6 +215,17 @@ function normalizeReadableStagedPath(stagedPath: string): string | null {
     return null;
   }
   return normalized;
+}
+
+function normalizeStagedAttachmentPaths(stagedPaths: readonly string[]): string[] {
+  const normalized = new Set<string>();
+  for (const stagedPath of stagedPaths) {
+    const readablePath = normalizeReadableStagedPath(stagedPath);
+    if (readablePath != null) {
+      normalized.add(readablePath);
+    }
+  }
+  return [...normalized];
 }
 
 async function listStagedAttachmentPaths(

--- a/src/node/utils/git/ensureGitInfoExclude.test.ts
+++ b/src/node/utils/git/ensureGitInfoExclude.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { STAGED_ATTACHMENT_DIR } from "@/common/constants/stagedAttachments";
+import { LocalRuntime } from "@/node/runtime/LocalRuntime";
+
+import { ensureGitInfoExclude } from "./ensureGitInfoExclude";
+
+let tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs = [];
+});
+
+describe("ensureGitInfoExclude", () => {
+  test("adds the staged attachment directory to a git repo exclude file once", async () => {
+    const repo = await makeTempDir("mux-git-exclude-");
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    const runtime = new LocalRuntime(repo);
+
+    const first = await ensureGitInfoExclude({
+      runtime,
+      workspacePath: repo,
+      relativeDir: STAGED_ATTACHMENT_DIR,
+    });
+    const second = await ensureGitInfoExclude({
+      runtime,
+      workspacePath: repo,
+      relativeDir: STAGED_ATTACHMENT_DIR,
+    });
+
+    expect(first.status).toBe("ensured");
+    expect(second.status).toBe("ensured");
+    const excludePath = execFileSync("git", ["rev-parse", "--git-path", "info/exclude"], {
+      cwd: repo,
+      encoding: "utf8",
+    }).trim();
+    const exclude = await readFile(path.join(repo, excludePath), "utf8");
+    expect(exclude.match(/^\/\.mux\/user-attachments\/$/gm)).toHaveLength(1);
+  });
+
+  test("uses a git-root-relative pattern for subdirectory workspaces", async () => {
+    const repo = await makeTempDir("mux-git-exclude-subdir-");
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    const workspacePath = path.join(repo, "packages", "app");
+    await mkdir(workspacePath, { recursive: true });
+    await writeFile(path.join(workspacePath, ".keep"), "");
+    const runtime = new LocalRuntime(repo);
+
+    const result = await ensureGitInfoExclude({
+      runtime,
+      workspacePath,
+      relativeDir: STAGED_ATTACHMENT_DIR,
+    });
+
+    expect(result.status).toBe("ensured");
+    const excludePath = execFileSync("git", ["rev-parse", "--git-path", "info/exclude"], {
+      cwd: repo,
+      encoding: "utf8",
+    }).trim();
+    const exclude = await readFile(path.join(repo, excludePath), "utf8");
+    expect(exclude).toContain("/packages/app/.mux/user-attachments/");
+  });
+
+  test("reports non-git directories without writing an exclude file", async () => {
+    const dir = await makeTempDir("mux-git-exclude-nongit-");
+    const runtime = new LocalRuntime(dir);
+
+    const result = await ensureGitInfoExclude({
+      runtime,
+      workspacePath: dir,
+      relativeDir: STAGED_ATTACHMENT_DIR,
+    });
+    expect(result).toEqual({ status: "notGit" });
+  });
+});

--- a/src/node/utils/git/ensureGitInfoExclude.ts
+++ b/src/node/utils/git/ensureGitInfoExclude.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import type { Runtime } from "@/node/runtime/Runtime";
+import { execBuffered, readFileString, writeFileString } from "@/node/utils/runtime/helpers";
+
+export type EnsureGitInfoExcludeResult =
+  | { status: "notGit" }
+  | { status: "ensured"; pattern: string; excludePath: string }
+  | { status: "failed"; error: string };
+
+export async function ensureGitInfoExclude(input: {
+  runtime: Runtime;
+  workspacePath: string;
+  relativeDir: string;
+}): Promise<EnsureGitInfoExcludeResult> {
+  const { runtime, workspacePath, relativeDir } = input;
+  assert(workspacePath.trim().length > 0, "workspacePath is required");
+  assert(relativeDir.trim().length > 0, "relativeDir is required");
+
+  const inside = await execBuffered(runtime, "git rev-parse --is-inside-work-tree", {
+    cwd: workspacePath,
+    timeout: 5,
+  });
+  if (inside.exitCode !== 0) {
+    const message = `${inside.stderr}\n${inside.stdout}`;
+    if (/not a git repository/i.test(message)) {
+      return { status: "notGit" };
+    }
+    return { status: "failed", error: message.trim() || "Could not determine Git workspace" };
+  }
+
+  const [prefixResult, excludeResult] = await Promise.all([
+    execBuffered(runtime, "git rev-parse --show-prefix", { cwd: workspacePath, timeout: 5 }),
+    execBuffered(runtime, "git rev-parse --git-path info/exclude", {
+      cwd: workspacePath,
+      timeout: 5,
+    }),
+  ]);
+  if (prefixResult.exitCode !== 0) {
+    return {
+      status: "failed",
+      error: prefixResult.stderr.trim() || "Could not resolve Git prefix",
+    };
+  }
+  if (excludeResult.exitCode !== 0) {
+    return {
+      status: "failed",
+      error: excludeResult.stderr.trim() || "Could not resolve Git exclude path",
+    };
+  }
+
+  const prefix = prefixResult.stdout
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\/+|\/+$/g, "");
+  const relative = relativeDir.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+  const pattern = `/${[prefix, relative].filter(Boolean).join("/")}/`;
+  const excludePath = resolveRuntimePath(workspacePath, excludeResult.stdout.trim());
+
+  let existing = "";
+  try {
+    existing = await readFileString(runtime, excludePath);
+  } catch {
+    existing = "";
+  }
+
+  const existingLines = existing
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (!existingLines.includes(pattern)) {
+    const separator = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+    await writeFileString(runtime, excludePath, `${existing}${separator}${pattern}\n`);
+  }
+
+  return { status: "ensured", pattern, excludePath };
+}
+
+function resolveRuntimePath(workspacePath: string, gitPath: string): string {
+  assert(gitPath.trim().length > 0, "git exclude path is required");
+  if (path.isAbsolute(gitPath) || /^[/~]/u.test(gitPath) || /^[A-Za-z]:[\\/]/u.test(gitPath)) {
+    return gitPath;
+  }
+  return `${workspacePath.replace(/[\\/]+$/u, "")}/${gitPath}`;
+}


### PR DESCRIPTION
## Summary

Adds workspace-staged ZIP attachments for workspace chat prompts. ZIP files are written into the workspace filesystem instead of being sent as provider-native file parts, and sent messages render a native file chip rather than exposing the hidden model-facing attachment notice.

## Background

Providers do not accept arbitrary ZIP binaries through the existing image/PDF attachment path. This change keeps provider attachments unchanged while adding a staged attachment path for ZIPs so agents can inspect archives through filesystem tools.

## Implementation

- Adds a staged composer attachment kind with draft persistence for ZIP metadata only.
- Stages ZIP bytes through workspace oRPC APIs into `.mux/user-attachments/...` with shared size/type constraints.
- Ensures the staging directory is added to local Git excludes via `git rev-parse --git-path info/exclude`.
- Copies referenced staged ZIP files into forked workspaces so forked transcripts and download chips still resolve their staged paths, including uppercase `.ZIP` names, without copying attachments that were truncated out of fork history.
- Appends a hidden generated `<attached-files>` notice to model-facing user text while stripping only that exact notice from rendering, copy, and editable text so user-authored XML is preserved.
- Restores staged ZIP metadata as draft chips when sent, queued, one-shot, skill, or compaction follow-up messages are displayed/edited/canceled so resubmits preserve the staged paths without duplicating hidden notices.
- Preserves staged notices in compaction preview, one-shot raw command, and skill raw command display content so the message renderer can continue showing attachment chips.
- Renders staged ZIPs as clickable/downloadable message chips backed by a secure staged-attachment download endpoint.

## Validation

- `MUX_ESLINT_CONCURRENCY=1 make static-check`
- `bun test src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts src/browser/utils/attachmentsHandling.test.ts src/browser/features/ChatInput/draftAttachmentsStorage.test.ts src/browser/features/ChatInput/stagedAttachments.test.ts src/browser/features/Messages/UserMessageContent.staged.test.tsx src/browser/utils/chatEditing.test.ts src/browser/utils/compaction/handler.test.ts src/browser/utils/messages/displayedMessageBuilder.staged.test.ts src/node/utils/git/ensureGitInfoExclude.test.ts src/node/utils/attachments/stageWorkspaceAttachment.test.ts`

## Dogfooding

- Started an isolated dev-server sandbox.
- Uploaded a ZIP through the workspace composer and verified the draft chip renders with workspace-file metadata.
- Sent a ZIP-backed prompt and verified the chat message renders a downloadable file chip while hiding the raw `<attached-files>` block.
- Captured screenshots in the Mux workspace thread for both draft and sent-message states.

## Risks

Moderate surface area across the composer, message rendering, edit/compaction restoration, fork handling, oRPC schemas, and workspace filesystem writes. The staged path is intentionally limited to ZIPs, capped at 10MB, validated on upload/download, copied across forks only when referenced by retained history, and excluded from provider `fileParts` to avoid API validation regressions.

---

<details>
<summary>📋 Implementation Plan</summary>

# Implementation Plan: Workspace-Staged ZIP Prompt Attachments

## Goal

Let users attach `.zip` files in a Mux workspace prompt via drag/drop or the paperclip picker. ZIP bytes should **not** be sent to the model as provider-native attachments. Instead, Mux should write each ZIP into a workspace-local staging directory, automatically add that directory to the workspace's local Git exclude file, and append a clear note to the outgoing user message so the agent knows where the file is and can inspect it with filesystem tools.

## Recommendation

Implement **workspace-staged attachments as a separate attachment kind** from existing model attachments.

- Existing images/SVG/PDFs remain provider attachments (`FilePart` data URLs) and keep current behavior.
- ZIPs become staged workspace files with lightweight metadata (`filename`, `mediaType`, `sizeBytes`, `stagedPath`) stored in composer state and draft persistence.
- Sending a prompt with staged ZIPs appends a markdown attachment notice to the text and does **not** include the ZIP in `options.fileParts`.
- The backend staging endpoint writes bytes through the workspace `Runtime`, so local, SSH, devcontainer, and Coder runtimes place the file where agent tools can see it.
- The backend staging endpoint updates `.git/info/exclude` via `git rev-parse --git-path info/exclude` and treats failure as blocking in Git workspaces, so ZIPs are not left as accidentally committable files.
- The UI tracks staging-in-progress state and blocks send until all staged uploads have either succeeded or failed.

**Recommended approach net product LoC estimate:** ~750–1,050 LoC.

<details>
<summary>Why this approach instead of native ZIP file parts or staging on send?</summary>

- Provider-native `FilePart` is intentionally provider-sendable content today; `AgentSession.sendMessage()` asserts file-part URLs are `data:` URLs and model compatibility checks are PDF/image oriented. Overloading that path for ZIPs risks sending unsupported binary data to providers.
- Staging on attach keeps draft persistence lightweight. The current composer persists `ChatAttachment[]` into localStorage; storing ZIP data URLs there would quickly hit localStorage limits.
- Staging on attach also supports queued sends and app restarts before send: the file already exists in the workspace and the draft stores only the staged path.
- A separate staged kind keeps edit/history semantics simple: the sent message contains a plain-text staged-path note, so editing a previous message naturally edits the path note without re-uploading binary data.
</details>

## Evidence gathered

Repo exploration found these relevant facts:

- `src/browser/features/ChatInput/AttachFileButton.tsx` currently filters picker files with `image/*,.svg,.pdf` and describes “images, SVGs, PDFs”.
- `src/browser/utils/attachmentsHandling.ts` accepts files only when `getSupportedAttachmentMediaType()` returns a provider-supported media type, then converts them to `ChatAttachment` data URLs.
- `src/common/utils/attachments/supportedAttachmentMediaTypes.ts` currently maps image extensions and `.pdf`; `isSupportedAttachmentMediaType()` returns true for `image/*` and `application/pdf` only.
- `src/browser/features/ChatInput/index.tsx` converts all composer attachments through `chatAttachmentsToFileParts()` and sends them as `options.fileParts` in `api.workspace.sendMessage()`.
- `src/node/services/agentSession.ts` validates `fileParts` as `data:` URLs and persists them as message file parts, so staged ZIP paths should not enter that field.
- The `Runtime` abstraction already supports `writeFile()`, `readFile()`, `ensureDir()`, `exec()`, and runtime-aware path handling for local/remote workspaces.
- Worktree-safe local Git excludes must be resolved with `git rev-parse --git-path info/exclude`; manually joining `.git/info/exclude` is unsafe for worktrees.

## Scope

### In scope

- `.zip` files only for the first implementation.
- Workspace chat composer only (`variant === "workspace"`) because staging requires an existing workspace path.
- Drag/drop and paperclip picker support for `.zip`.
- Optional paste support only if browsers expose a ZIP as a file in clipboard data; no extra clipboard UX beyond existing file extraction.
- A workspace oRPC endpoint to stage file bytes into `.mux/user-attachments/<uuid>/<safe-filename>.zip`.
- Automatic, idempotent insertion of the staged attachment directory into `.git/info/exclude` for Git workspaces; staging fails if Mux cannot ensure this for a Git workspace.
- A prompt notice appended to outgoing text for staged ZIPs.
- Tests for frontend filtering/rendering/send payload, backend staging/exclude behavior, and integration-level git cleanliness.

### Out of scope for this slice

- Native model ingestion of ZIP bytes.
- Auto-unzipping ZIPs on attach or send.
- Recursive archive safety scanning beyond size/type validation.
- Chunked uploads for very large ZIPs.
- Non-ZIP staged binary attachments.
- Creation-view initial prompts before a workspace exists; show a clear unsupported toast for ZIPs there, then revisit as a follow-up if needed.
- Automatic cleanup of staged files when a composer chip is removed. The files are small, ignored, and cleaned up with the workspace. Optional delete-on-remove can be a follow-up if disk churn becomes a concern.

## Architecture

### 0. Shared constants

Add a small shared constants module, for example `src/common/constants/stagedAttachments.ts`:

```ts
export const STAGED_ATTACHMENT_DIR = ".mux/user-attachments";
export const MAX_STAGED_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
export const MAX_STAGED_ATTACHMENT_BASE64_CHARS = Math.ceil(MAX_STAGED_ATTACHMENT_SIZE_BYTES / 3) * 4 + 8;
```

Use this constant set in both browser and backend code:

- Frontend blocks over-cap ZIPs before reading/uploading.
- oRPC schema can cap `dataBase64` length.
- Backend decodes and verifies actual bytes are within cap.
- Tests import the same cap instead of duplicating magic values.

### 1. Attachment model

Introduce a discriminated composer attachment shape in `src/browser/features/ChatInput/ChatAttachments.tsx` or a nearby shared type file:

```ts
type ProviderChatAttachment = {
  kind: "provider";
  id: string;
  url: string;
  mediaType: string;
  filename?: string;
  resizeInfo?: { /* existing image resize fields */ };
};

type StagedChatAttachment = {
  kind: "staged";
  id: string;
  mediaType: "application/zip" | "application/x-zip-compressed";
  filename: string;
  sizeBytes: number;
  stagedPath: string; // workspace-relative path used by bash/file tools
};

type ChatAttachment = ProviderChatAttachment | StagedChatAttachment;
```

Compatibility rule: while migrating, parse legacy persisted attachments that do not have `kind` as `kind: "provider"` so existing image/PDF drafts do not disappear.

### 2. Supported file classification

Do **not** simply make `application/zip` a provider-supported attachment media type. Instead split classification:

- Provider-supported media: current images/SVG/PDF.
- Staged-supported media: ZIP MIME types and/or `.zip` extension.

Recommended additions:

- `src/common/utils/attachments/supportedAttachmentMediaTypes.ts`
  - Keep `isSupportedAttachmentMediaType()` provider-only if other code depends on that meaning.
  - Add `ZIP_MEDIA_TYPES`, `ZIP_MEDIA_TYPE`, `getSupportedStagedAttachmentMediaType(args)`, or a combined classifier such as `getAttachmentSupport(args): { kind: "provider" | "staged"; mediaType: string } | null`.
  - Match `.zip`, `application/zip`, `application/x-zip-compressed`, and empty MIME type with `.zip` filename.

### 3. Frontend staging flow

Files:

- `src/browser/utils/attachmentsHandling.ts`
- `src/browser/features/ChatInput/index.tsx`
- `src/browser/features/ChatInput/AttachFileButton.tsx`
- `src/browser/features/ChatInput/ChatAttachments.tsx`
- `src/browser/features/ChatInput/draftAttachmentsStorage.ts`

Plan:

1. Extend the paperclip accept filter to include `.zip` and update tooltip copy.
2. Update drag/drop extraction to accept provider files and ZIP staged files.
3. Keep paste behavior as-is except that ZIP files exposed by the clipboard file APIs can be classified as staged.
4. Add a small frontend helper to read a `File` into base64 for upload. Keep this separate from provider `FileReader.readAsDataURL()` logic so staged attachments never use `url: data:...` in state.
5. Enforce a shared size cap before reading the file. Show a clear toast for over-cap ZIPs and do not start an upload.
6. In `ChatInput/index.tsx`, when `variant !== "workspace"` and a ZIP is attached, reject it with a clear toast like: “ZIP attachments can be added after opening a workspace.”
7. For workspace variant, call `api.workspace.stageAttachment()` immediately when a ZIP is selected/dropped.
8. Track `isProcessingAttachments` / pending staging count while ZIP uploads are in flight. Disable Send, or make Send show a blocking toast, until staging resolves. This prevents a user from dropping a ZIP and immediately sending a prompt that omits it.
9. Store only the returned staged metadata in `attachments` state/localStorage.
10. Render staged ZIPs as normal file chips with filename, size, and a subtle “staged” or “workspace file” label. Avoid native `title` attributes; use shared tooltip components if extra detail is needed.
11. `chatAttachmentsToFileParts()` must include only `kind: "provider"` attachments and defensively assert that staged attachments are not converted to provider file parts.
12. Use a shared `buildStagedAttachmentNotice(stagedAttachments)` helper for every send-like path, not ad-hoc string concatenation in one branch.
13. On normal send, derive `stagedAttachments = attachments.filter(kind === "staged")`, append the attachment notice to the text before `prepareUserMessageForSend()`, and send provider attachments as `fileParts` exactly as today.
14. For slash-command paths, either pass staged attachment metadata into command handlers that produce a user follow-up (`/compact` continue text, model one-shot normal sends, etc.) and append the same notice, or explicitly block staged ZIPs for commands that cannot preserve them. Silent omission is not acceptable.

Prompt notice format:

```md

<attached-files>
The user attached file(s) that were saved into the workspace filesystem. These are not native model attachments; use filesystem tools such as `bash`, `file_read`, or archive tools to inspect them if needed.

- `archive.zip` (`application/zip`, 12.3 KB): `.mux/user-attachments/550e8400-e29b-41d4-a716-446655440000/archive.zip`
</attached-files>
```

This XML-ish wrapper makes the injected context easy to spot without being confused with user prose. Keep the path workspace-relative so `bash` can run `unzip -l .mux/user-attachments/...` from the workspace root.

### 4. Backend oRPC staging endpoint

Files:

- `src/common/orpc/schemas/api.ts`
- `src/common/orpc/types.ts` if generated/exported types require updates
- `src/node/orpc/router.ts`
- `src/node/services/workspaceService.ts` or a new focused helper service under `src/node/services/`
- New helper module, e.g. `src/node/utils/attachments/stageWorkspaceAttachment.ts`
- New helper module for Git excludes, e.g. `src/node/utils/git/ensureGitInfoExclude.ts`

Endpoint shape:

```ts
workspace.stageAttachment.input = z.object({
  workspaceId: z.string(),
  filename: z.string(),
  mediaType: z.string().nullish(),
  sizeBytes: z.number().int().nonnegative().max(MAX_STAGED_ATTACHMENT_SIZE_BYTES),
  dataBase64: z.string().max(MAX_STAGED_ATTACHMENT_BASE64_CHARS),
});

workspace.stageAttachment.output = ResultSchema(
  z.object({
    filename: z.string(),
    mediaType: z.string(),
    sizeBytes: z.number().int().nonnegative(),
    stagedPath: z.string(),
  }),
  z.string()
);
```

Implementation details:

1. Resolve workspace metadata and runtime with existing workspace runtime helpers (`createRuntimeContextForWorkspace(metadata)` or the same runtime context path used by workspace services). Do not use process cwd or `metadata.projectPath` as a staging identity.
2. Stage relative to the runtime `workspacePath` that agent tools use as their effective workspace root / primary cwd. The returned `stagedPath` must be directly usable from agent `bash` and `file_read` tools without needing an absolute host path.
3. Validate ZIP support on the backend independently from the frontend:
   - Require `.zip` extension or known ZIP MIME type.
   - Reject missing/empty filenames after sanitization.
   - Decode base64 and assert decoded length equals `sizeBytes`.
   - Enforce `MAX_STAGED_ATTACHMENT_SIZE_BYTES` after decoding, even though the schema and frontend also check it.
4. Sanitize filename:
   - Remove path separators, control characters, leading dots that create hidden/tricky names, and shell-hostile surprises.
   - Preserve `.zip` extension when possible.
   - Cap length to avoid filesystem/path issues.
   - Fallback to `attachment.zip`.
5. Generate a UUID subdirectory per staged attachment.
6. Before writing bytes in a Git workspace, ensure the matching local exclude pattern exists. If the helper returns `failed`, abort staging and do not write the ZIP.
7. Write bytes through `runtime.writeFile()` to `<workspacePath>/.mux/user-attachments/<uuid>/<safeFilename>`.
8. Return `stagedPath` as `.mux/user-attachments/<uuid>/<safeFilename>`.
9. Non-Git workspaces may stage without an exclude entry, but unknown Git/exclude failures in a Git workspace must surface an error rather than leaving an unignored ZIP behind.

### 5. Worktree-safe `.git/info/exclude` update

Helper responsibilities:

1. Return a structured result: `{ status: "notGit" } | { status: "ensured"; pattern: string; excludePath: string } | { status: "failed"; error: string }`.
2. Run `git rev-parse --is-inside-work-tree` with `cwd: workspacePath`.
   - If Git explicitly reports “not a git repository”, return `notGit`.
   - If the command fails for an ambiguous reason, return `failed` so staging does not risk an unignored file.
3. Run `git rev-parse --show-prefix` with `cwd: workspacePath` to compute the path from Git top-level to the runtime workspace path. This matters if the runtime workspace path is a subdirectory of a repo.
4. Run `git rev-parse --git-path info/exclude` with `cwd: workspacePath`.
5. Resolve the returned exclude path correctly:
   - If absolute in this runtime, use it directly.
   - If relative, resolve against `workspacePath`.
6. Compute the exclude pattern for the exact staged directory relative to the Git top-level, for example:
   ```txt
   /.mux/user-attachments/
   /packages/app/.mux/user-attachments/
   ```
   Use the second form when `git rev-parse --show-prefix` returns `packages/app/`.
7. Read existing exclude file if present; treat missing file as empty only after Git path resolution succeeds.
8. Append the computed pattern once, preserving existing content and newline conventions well enough.
9. Avoid duplicates by comparing trimmed non-empty lines.
10. Write through `runtime.writeFile()`.
11. Keep this helper reusable and tested; do not scatter Git exclude writes in UI or service code.

### 6. Send-message behavior

Keep backend `sendMessage` mostly unchanged. The frontend should append staged notices to `message` for normal sends and any slash-command path that creates a user follow-up, while excluding staged ZIPs from `options.fileParts`.

Why frontend injection is acceptable here:

- The user-visible chat message should include the file path the agent saw.
- Edits, retries, compaction, and queued sends already operate on message text and existing provider `fileParts`.
- No provider-message transformation needs to understand ZIPs.

Slash-command rule:

- Add `buildStagedAttachmentNotice()` in a shared ChatInput helper and use it in both normal send and command preparation paths.
- Model one-shot commands that fall through to normal send should preserve staged notices automatically.
- `/compact` with follow-up text must include the staged notice in the queued follow-up content, not in the compaction instruction itself unless the ZIP is intended for the compaction agent.
- Commands that do not create a user-visible follow-up should either leave staged attachments in the draft or show a blocking toast explaining that the command cannot include staged files.

Important edge cases:

- **Only ZIP, no text:** allowed. The final message text becomes just the staged attachment notice, satisfying `sendMessage()` non-empty validation.
- **Queued send while workspace busy:** staged file already exists; queued message text contains path notice.
- **Auto-compaction before send:** appended notice becomes part of follow-up text and remains lightweight.
- **Editing sent message:** user edits normal text containing the staged path; no binary re-upload.
- **Send failure:** current draft restoration should restore staged attachment metadata, not base64. The staged file remains on disk and ignored.
- **Remove chip before send:** remove only from composer state. Leave the staged file on disk; it is ignored and harmless. Optional cleanup RPC can follow later.

## Implementation phases

### Phase 1 — Shared classification and types

Files/symbols:

- `src/common/constants/stagedAttachments.ts`
- `src/common/utils/attachments/supportedAttachmentMediaTypes.ts`
- `src/browser/features/ChatInput/ChatAttachments.tsx` or a new local `types.ts`
- `src/browser/features/ChatInput/draftAttachmentsStorage.ts`

Tasks:

1. Add shared staged attachment constants and ZIP/staged classification helpers without changing provider attachment classification semantics.
2. Convert `ChatAttachment` to a discriminated union with legacy draft compatibility.
3. Update draft parsing to accept both legacy provider attachments and new staged attachments.
4. Add size formatting helper if not already present in the UI layer.

Quality gate:

- `bun test src/browser/utils/attachmentsHandling.test.ts`
- `bun test src/browser/features/ChatInput/draftAttachmentsStorage.test.ts`

### Phase 2 — Backend staging endpoint and Git exclude helper

Files/symbols:

- `src/common/orpc/schemas/api.ts`
- `src/node/orpc/router.ts`
- `src/node/services/workspaceService.ts`
- New `src/node/utils/attachments/stageWorkspaceAttachment.ts`
- New `src/node/utils/git/ensureGitInfoExclude.ts`
- Tests under `src/node/**` or `tests/ipc/**`

Tasks:

1. Add `workspace.stageAttachment` schema and router handler.
2. Implement staging in a focused backend helper using `Runtime.writeFile()`.
3. Implement worktree-safe Git exclude helper using `git rev-parse --git-path info/exclude` plus `git rev-parse --show-prefix` to compute the exact exclude pattern.
4. Validate ZIP type, size, base64 length/decoding, sanitized filename, and returned path.
5. Ensure staging aborts in Git workspaces if the exclude helper cannot guarantee the staged directory is ignored; allow graceful no-exclude staging only for confirmed non-Git workspaces.
6. Add backend tests for binary integrity, duplicate-free exclude updates, non-Git workspace behavior, Git exclude failure behavior, path sanitization, and size/type rejection.

Quality gate:

- Targeted backend tests for the new staging helper and Git exclude helper.
- If an IPC-level test is added: verify `git status --porcelain` stays clean after staging.

### Phase 3 — Frontend attach/drop/send integration

Files/symbols:

- `src/browser/features/ChatInput/AttachFileButton.tsx`
- `src/browser/utils/attachmentsHandling.ts`
- `src/browser/features/ChatInput/index.tsx`
- `src/browser/features/ChatInput/ChatAttachments.tsx`

Tasks:

1. Extend picker accept/copy to mention ZIPs.
2. Update file processing to branch provider vs staged classification.
3. Add a workspace-only staging callback that calls `api.workspace.stageAttachment` for ZIPs.
4. Reject ZIPs outside workspace variant with a clear toast.
5. Update drag/drop, paste, and picker paths to process files individually so one failed ZIP does not block valid images/PDFs.
6. Track pending staging state and block Send until staging has resolved.
7. Render staged ZIP chips with filename, size, and remove button.
8. Build the staged attachment notice with a shared helper and append it before existing review/skill preparation so the final persisted user message includes the notice.
9. Wire the same helper into slash-command send/follow-up paths or block unsupported command+ZIP combinations explicitly.
10. Ensure `chatAttachmentsToFileParts()` sends only provider attachments.

Quality gate:

- Frontend attachment utility tests.
- ChatInput UI test with mocked `workspace.stageAttachment` verifying:
  - ZIP drop/picker stages file and renders a chip.
  - send payload message includes staged path notice.
  - `options.fileParts` excludes ZIPs but still includes image/PDF provider attachments.
  - ZIP-only send is allowed.

### Phase 4 — Integration polish and resilience

Tasks:

1. Ensure draft persistence/localStorage never stores ZIP base64.
2. Ensure restored draft after send failure keeps staged chip metadata.
3. Verify queued send and `/compact` follow-up paths receive lightweight prompt text and provider `fileParts` only.
4. Add defensive assertions/comments at the provider attachment conversion boundary explaining why staged attachments must not become `FilePart` provider attachments.
5. Consider adding `data-testid` or accessible labels only if tests cannot select existing accessible elements cleanly.

Quality gate:

- Targeted integration test for `workspace.stageAttachment` and git cleanliness.
- Targeted send-message/UI tests.

## Testing plan

### Unit tests

- `src/common/utils/attachments/supportedAttachmentMediaTypes.test.ts` or extend existing attachment tests:
  - `.zip` with empty MIME classifies as staged.
  - `application/zip` and `application/x-zip-compressed` classify as staged.
  - ZIP does not classify as provider-supported.
- `src/browser/utils/attachmentsHandling.test.ts`:
  - ZIP calls the staging callback and returns `kind: "staged"` metadata.
  - Provider files still become data URLs and resize images as before.
  - Mixed batches preserve successful attachments and report individual failures where applicable.
  - `chatAttachmentsToFileParts()` excludes staged attachments.
- `src/browser/features/ChatInput/draftAttachmentsStorage.test.ts`:
  - Legacy provider attachments parse successfully.
  - Staged ZIP attachments parse successfully.
  - Invalid staged attachment records self-heal to an empty attachment draft.

- ChatInput send/command helper tests:
  - `buildStagedAttachmentNotice()` formats filename, media type, size, and path consistently.
  - Normal send appends the notice.
  - `/compact` follow-up sends include the notice in follow-up text.
  - Unsupported slash-command + staged ZIP combinations are blocked or keep attachments in the draft, rather than silently dropping them.
  - Send is blocked while staging is pending.

### Backend tests

- New staging helper tests:
  - Writes exact ZIP bytes to `.mux/user-attachments/<uuid>/<safe>.zip`.
  - Rejects unsupported type/extension.
  - Rejects invalid base64 and size mismatches.
  - Rejects over-cap payloads.
  - Sanitizes traversal filenames like `../../evil.zip`.
- New Git exclude helper tests:
  - Uses `git rev-parse --git-path info/exclude` in a normal repo and a Git worktree.
  - Uses `git rev-parse --show-prefix` to add the exact root-relative pattern when `workspacePath` is a subdirectory.
  - Appends the computed staged-attachments pattern once.
  - Preserves existing exclude content.
  - Returns `notGit` outside Git repos.
  - Returns `failed` for ambiguous Git/exclude failures and causes staging to abort without writing a ZIP.
- oRPC/workspace service test:
  - Calls `workspace.stageAttachment` against a real test workspace, verifies file exists, bytes match, and `git status --porcelain` stays clean.

### UI tests

- ChatInput attachment test with mocked API:
  - Picker/drop of a ZIP calls `workspace.stageAttachment`.
  - Renders ZIP chip with filename and size.
  - Removing ZIP chip excludes it from the sent prompt notice.
  - Send with ZIP + image sends only the image in `fileParts` and includes ZIP path in message text.
  - Send with ZIP-only prompt succeeds with generated attachment notice text.

### Regression tests

- Existing image/PDF send tests should continue to pass.
- Existing edit-message behavior should preserve current provider attachments. No staged binary re-upload is expected.
- Existing `/compact` tests that include follow-up file parts should remain provider-file-only; add one staged-path text case only if the code path is touched enough to warrant it.

## Validation commands

Use targeted commands during implementation, then broader validation before handoff:

```bash
bun test src/browser/utils/attachmentsHandling.test.ts
bun test src/browser/features/ChatInput/draftAttachmentsStorage.test.ts
bun test src/node/utils/attachments/stageWorkspaceAttachment.test.ts
bun test src/node/utils/git/ensureGitInfoExclude.test.ts
bun test tests/ipc/streaming/sendMessage.images.test.ts
make typecheck
MUX_ESLINT_CONCURRENCY=1 make lint
make fmt-check
```

If the implementation touches broad schema/router types, run:

```bash
MUX_ESLINT_CONCURRENCY=1 make static-check
```

## Dogfooding plan

Use an isolated Mux sandbox and collect screenshots/video evidence for review.

### Setup

1. Start an isolated dev server/desktop using the repo sandbox skills or commands appropriate for the implementation environment.
2. Create a tiny test ZIP:
   ```bash
   tmpdir=$(mktemp -d)
   mkdir -p "$tmpdir/project"
   printf 'hello from zip\n' > "$tmpdir/project/README.txt"
   (cd "$tmpdir" && zip -r project.zip project)
   ```
3. Open a normal workspace chat in Mux.

### Functional dogfood

1. Drag/drop `project.zip` into the composer.
2. Verify a staged ZIP chip appears with the filename and size.
3. Send: “Inspect the attached zip and summarize its contents.”
4. Verify the user message includes the staged path notice.
5. Verify the agent can run something equivalent to:
   ```bash
   unzip -l .mux/user-attachments/<uuid>/project.zip
   ```
6. Verify the agent can summarize `README.txt` from the archive.

### Git cleanliness dogfood

From the workspace root used by agent tools:

```bash
git status --porcelain
git rev-parse --git-path info/exclude
cat "$(git rev-parse --git-path info/exclude)"
```

Success criteria:

- `git status --porcelain` does not show `.mux/user-attachments/`.
- The local exclude file contains exactly one staged-attachments pattern for the workspace path (for repo-root workspaces, `/.mux/user-attachments/`).
- Re-attaching another ZIP does not duplicate the exclude entry.

### UI dogfood and evidence

1. Capture a desktop screenshot of the composer with a ZIP chip.
2. Resize to a narrow/mobile width around 375px and capture a screenshot confirming:
   - chips wrap cleanly,
   - no right-edge overflow,
   - send/attach controls remain reachable,
   - keyboard shortcut labels are not introduced on mobile.
3. Record a short video showing drag/drop, send, and agent inspection of the staged path.
4. Attach screenshots/video to the eventual PR or handoff using the repo’s standard image upload/attachment workflow.

## Acceptance criteria

- Users can attach `.zip` files via drag/drop and paperclip in workspace chat.
- ZIP attachments are written to `.mux/user-attachments/<uuid>/<safe-filename>.zip` under the active workspace via the workspace `Runtime`.
- The exact staged attachment directory pattern is automatically and idempotently added to the workspace’s `.git/info/exclude` using `git rev-parse --git-path info/exclude` and `git rev-parse --show-prefix`.
- If Mux detects a Git workspace but cannot ensure the local exclude entry, ZIP staging fails with a clear error and does not leave an unignored ZIP behind.
- Send is disabled or blocked while ZIP staging is still in progress.
- ZIP attachments are never sent as provider `FilePart` model attachments.
- The sent user message includes a clear staged-file notice with filename, media type, size, and workspace-relative path.
- Sending a ZIP-only prompt is allowed and results in a non-empty attachment-notice prompt.
- Slash-command paths that send or queue user follow-up content include the same staged-file notice, and unsupported command combinations do not silently drop staged attachments.
- Existing image/SVG/PDF attachment behavior remains unchanged.
- Draft persistence stores only staged ZIP metadata, never ZIP base64.
- `git status --porcelain` remains clean after staging ZIP attachments in a Git workspace.
- Backend staging handles non-Git workspaces gracefully.
- Validation commands and dogfooding steps above pass, with screenshots/video captured.

## Risks and mitigations

| Risk | Mitigation |
| --- | --- |
| Large ZIPs bloat oRPC payloads | First-version size cap, clear error toast, future chunked upload if users need larger archives. |
| ZIP accidentally sent to provider | Discriminated attachment type plus defensive assertion/filter in `chatAttachmentsToFileParts()`. |
| Worktree exclude path incorrect | Resolve exclude with `git rev-parse --git-path info/exclude`, compute pattern with `git rev-parse --show-prefix`, and test normal repo, worktree, and subdirectory workspace cases. |
| Git workspace exclude update fails | Abort staging before writing and surface a clear toast/error; allow no-exclude staging only for confirmed non-Git directories. |
| Path traversal filename | Sanitize filename and write under generated UUID directory only. |
| ZIP bombs or unsafe extraction | Do not auto-extract; agent/user-controlled inspection only. Future agent guidance can recommend `unzip -l` before extraction. |
| Staging fails after partial write | Use `Runtime.writeFile()` atomic write behavior; return an error and do not add a staged chip if staging fails. |
| Creation prompt has no workspace path | Reject ZIPs outside workspace variant with clear toast for this slice. |
| Remote runtime path mismatch | Use workspace runtime context and return workspace-relative path for agent tools. |
| LocalStorage incompatibility with old drafts | Parse missing `kind` as legacy provider attachment; self-heal invalid staged records. |

## Open design notes for implementer

- Prefer small focused helpers over broad `ChatInput` growth. If `ChatInput/index.tsx` grows too much, extract staged-attachment helpers into `src/browser/features/ChatInput/stagedAttachments.ts`.
- Keep comments focused on “why”: ZIPs are staged because providers do not support ZIP input and because localStorage/history should not persist base64 archives.
- Avoid adding cleanup-on-remove unless necessary; it increases race surface with drafts and queued sends.
- If a future chunked upload endpoint is needed, keep the public staged attachment metadata shape stable so the composer/send logic does not change.

## Advisor review status

Approved by advisor after revisions. The advisor confirmed no blocking revisions remain. Non-blocking implementation cautions: verify actual oRPC/body transport limits before finalizing the 10 MB cap, keep `buildStagedAttachmentNotice()` as the single path for normal sends and command follow-ups, and make Git exclude failure tests assert no ZIP was written.

</details>

---

_Generated with `mux` • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$77.92`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=77.92 -->
