### PR TITLE
🤖 fix: recover task_list workspace-turn statuses

### DIFF
--- a/src/node/services/taskService.test.ts
+++ b/src/node/services/taskService.test.ts
@@ -3181,6 +3181,57 @@ describe("TaskService", () => {
     expect(workspaceMocks.remove).toHaveBeenCalledWith("childworkspace", true);
   });
 
+  test("listWorkspaceTurnTasks repairs restart-interrupted deferred handles before filtering", async () => {
+    const { config, parentId, taskService, historyService } = await startWorkspaceTurnForTest();
+    const muxMetadata = {
+      type: "workspace-turn-task" as const,
+      taskHandleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      turnId: "turn",
+    };
+    const appendResult = await historyService.appendToHistory(
+      "childworkspace",
+      createMuxMessage("msg_recovered_list", "assistant", "Recovered list text", {
+        model: "anthropic:claude-opus-4-6",
+        agentId: "exec",
+        finishReason: "stop",
+        muxMetadata,
+      })
+    );
+    expect(appendResult.success).toBe(true);
+    await new TaskHandleStore(config).upsertWorkspaceTurn({
+      kind: "workspace_turn",
+      handleId: "wst_handle",
+      ownerWorkspaceId: parentId,
+      workspaceId: "childworkspace",
+      turnId: "turn",
+      status: "interrupted",
+      createdAt: "2026-06-19T00:00:00.000Z",
+      updatedAt: "2026-06-19T00:00:01.000Z",
+      createdWorkspace: true,
+      disposableWorkspace: false,
+      deferredMessageIds: ["msg_recovered_list"],
+      error: "Workspace turn interrupted after restart",
+    });
+
+    const listed = await taskService.listWorkspaceTurnTasks(parentId, {
+      statuses: ["interrupted", "completed"],
+    });
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({
+      handleId: "wst_handle",
+      status: "completed",
+      messageId: "msg_recovered_list",
+      reportMarkdown: "Recovered list text",
+    });
+    expect(listed[0]?.error).toBeUndefined();
+
+    const interruptedOnly = await taskService.listWorkspaceTurnTasks(parentId, {
+      statuses: ["interrupted"],
+    });
+    expect(interruptedOnly.map((record) => record.handleId)).not.toContain("wst_handle");
+  });
+
   test("workspace-turn stale recovery repairs restart-interrupted deferred error handles", async () => {
     const { config, parentId, projectPath, taskService, historyService } =
       await startWorkspaceTurnForTest();

--- a/src/node/services/taskService.ts
+++ b/src/node/services/taskService.ts
@@ -5658,18 +5658,17 @@ export class TaskService {
     return result;
   }
 
-  async getWorkspaceTurnSnapshot(
-    ownerWorkspaceId: string,
-    handleId: string
+  private async normalizeWorkspaceTurnRecord(
+    record: WorkspaceTurnTaskHandleRecord
   ): Promise<WorkspaceTurnTaskHandleRecord | null> {
-    if (!isWorkspaceTurnTaskId(handleId)) {
-      return null;
-    }
-    const record = await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, handleId);
+    assert(record.ownerWorkspaceId.length > 0, "normalizeWorkspaceTurnRecord requires owner id");
+    assert(record.handleId.length > 0, "normalizeWorkspaceTurnRecord requires handle id");
+
     // Older recovery skipped deferred stream-end history and could mark a completed workspace turn
-    // interrupted. Re-check the durable child history so affected handles self-heal on next await.
+    // interrupted. Re-check the durable child history anywhere handles are observed so task_list and
+    // task_await agree on the self-healed terminal status.
     if (
-      record?.status === "interrupted" &&
+      record.status === "interrupted" &&
       record.error === "Workspace turn interrupted after restart" &&
       (record.deferredMessageIds?.length ?? 0) > 0
     ) {
@@ -5684,46 +5683,50 @@ export class TaskService {
         ) {
           this.activeWorkspaceTurnHandleByWorkspaceId.delete(record.workspaceId);
         }
-        return await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, handleId);
+        return await this.taskHandleStore.getWorkspaceTurn(
+          record.ownerWorkspaceId,
+          record.handleId
+        );
       }
     }
 
     if (
-      record != null &&
       (record.status === "queued" || record.status === "starting" || record.status === "running") &&
       !(await this.isLiveWorkspaceTurn(record))
     ) {
       await this.settleStaleWorkspaceTurn(record);
-      return await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, handleId);
+      return await this.taskHandleStore.getWorkspaceTurn(record.ownerWorkspaceId, record.handleId);
     }
+
     return record;
+  }
+
+  async getWorkspaceTurnSnapshot(
+    ownerWorkspaceId: string,
+    handleId: string
+  ): Promise<WorkspaceTurnTaskHandleRecord | null> {
+    if (!isWorkspaceTurnTaskId(handleId)) {
+      return null;
+    }
+    const record = await this.taskHandleStore.getWorkspaceTurn(ownerWorkspaceId, handleId);
+    if (record == null) {
+      return null;
+    }
+    return await this.normalizeWorkspaceTurnRecord(record);
   }
 
   async listWorkspaceTurnTasks(
     ownerWorkspaceId: string,
     options: { statuses?: readonly WorkspaceTurnTaskStatus[] } = {}
   ): Promise<WorkspaceTurnTaskHandleRecord[]> {
-    const records = await this.taskHandleStore.listWorkspaceTurns(ownerWorkspaceId, options);
+    const records = await this.taskHandleStore.listWorkspaceTurns(ownerWorkspaceId);
     const statuses = options.statuses != null ? new Set(options.statuses) : null;
     const result: WorkspaceTurnTaskHandleRecord[] = [];
     for (const record of records) {
-      if (
-        (record.status === "queued" ||
-          record.status === "starting" ||
-          record.status === "running") &&
-        !(await this.isLiveWorkspaceTurn(record))
-      ) {
-        await this.settleStaleWorkspaceTurn(record);
-        const latest = await this.taskHandleStore.getWorkspaceTurn(
-          record.ownerWorkspaceId,
-          record.handleId
-        );
-        if (latest != null && (statuses == null || statuses.has(latest.status))) {
-          result.push(latest);
-        }
-        continue;
+      const latest = await this.normalizeWorkspaceTurnRecord(record);
+      if (latest != null && (statuses == null || statuses.has(latest.status))) {
+        result.push(latest);
       }
-      result.push(record);
     }
     return result;
   }


### PR DESCRIPTION
## Summary

Fixes stale `task_list` output for workspace-turn tasks by making list results use the same restart-recovery normalization as `task_await` before applying status filters.

## Background

Workspace-turn handles can be persisted as `interrupted` during restart recovery even when their child workspace history later proves the turn completed. `task_await` already self-healed those handles, but `task_list` read the raw handle rows and could keep showing recovered workspaces as interrupted, encouraging agents to queue unnecessary continuation messages.

## Implementation

- Added a shared workspace-turn record normalization path in `TaskService`.
- Routed both `getWorkspaceTurnSnapshot` and `listWorkspaceTurnTasks` through that path.
- Changed `listWorkspaceTurnTasks` to repair handles before applying the caller's status filter, so a repaired `completed` handle no longer appears in `interrupted`-only lists.
- Added a regression test for restart-interrupted deferred handles listed through `listWorkspaceTurnTasks`.

## Validation

- `bun test src/node/services/taskService.test.ts -t "listWorkspaceTurnTasks repairs restart-interrupted deferred handles before filtering"`
- `bun test src/node/services/taskService.test.ts -t "workspace-turn stale recovery repairs restart-interrupted deferred handles after descendants stop blocking"`
- `bun test src/node/services/taskService.test.ts -t "listWorkspaceTurnTasks"`
- `bun test src/node/services/tools/task_list.test.ts`
- `make typecheck`
- `MUX_ESLINT_CONCURRENCY=1 make lint`
- `MUX_ESLINT_CONCURRENCY=1 make static-check` after rebasing onto current `origin/main`
- `git diff --check`

## Dogfooding

Backend/tooling-only change; no visual UI path changed. Dogfooded via the targeted task-list and workspace-turn recovery tests above, which exercise the same backend listing path used by the `task_list` tool.

## Risks

Low-to-moderate risk in workspace-turn task accounting: listing now reads all owner handles before filtering so stale rows can self-heal. The behavior is intentional, but it means listing may do recovery work even for terminal-status filters. The touched path is limited to workspace-turn task handles.

---

_Generated with [`mux`](https://github.com/coder/mux) • Model: `openai:gpt-5.5` • Thinking: `xhigh` • Cost: `$8.42`_

<!-- mux-attribution: model=openai:gpt-5.5 thinking=xhigh costs=8.42 -->
