### PR TITLE
🤖 fix: stop background monitor from re-waking on already-shown output

### DIFF
--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -451,6 +451,45 @@ describe("BackgroundProcessManager", () => {
       manager.off("monitor:match", handler);
     });
 
+    it("anchors matchedThroughOffset to the matched line, not later output in the same chunk", async () => {
+      // A matched line followed by a non-matching complete line in one poll: matchedThroughOffset
+      // must point at the end of the matched line (byte 8 of "ERR foo\n"), not the end of the whole
+      // complete region (byte 16 of "...nomatch\n"). Otherwise an agent that read only the matched
+      // line stays below the inflated offset and gets a redundant wake.
+      const result = await manager.spawn(
+        runtime,
+        testWorkspaceId,
+        "printf 'ERR foo\\nnomatch\\n'; sleep 5",
+        {
+          cwd: process.cwd(),
+          displayName: "monitor-matched-line-anchor",
+          monitor: {
+            filter: "ERR",
+            pattern: /ERR/,
+            exclude: false,
+            cooldownMs: 10_000,
+          },
+        }
+      );
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      // Wait until both lines have been scanned (cursor at 16, no fragment buffered).
+      let proc = await manager.getProcess(result.processId);
+      for (let attempt = 0; attempt < 60; attempt++) {
+        proc = await manager.getProcess(result.processId);
+        if (
+          (proc?.monitor?.lastReadOffset ?? 0) >= 16 &&
+          (proc?.monitor?.pendingLines.length ?? 0) > 0
+        )
+          break;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(proc?.monitor?.pendingLines ?? []).toEqual(["ERR foo"]);
+      expect(proc?.monitor?.matchedThroughOffset).toBe(8);
+      expect(proc?.monitor?.lastReadOffset).toBe(16);
+    });
+
     it("strips ANSI before matching and emitting matched lines", async () => {
       const eventPromise = waitForMonitorMatch(manager);
       const result = await manager.spawn(

--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -395,6 +395,62 @@ describe("BackgroundProcessManager", () => {
       expect(event.payload.lines).toEqual(["ERR boom"]);
     });
 
+    it("drops the wake for a matched line even when a trailing fragment follows it", async () => {
+      // A complete matched line followed by an unterminated fragment: getOutput returns the line
+      // and buffers only the fragment, so the agent HAS seen the match. The monitor's raw scan
+      // cursor (lastReadOffset) includes the fragment, so comparing against it would wrongly wake;
+      // matchedThroughOffset (end of the matched line) must drive the suppression instead.
+      let matchCount = 0;
+      const handler = () => {
+        matchCount++;
+      };
+      manager.on("monitor:match", handler);
+
+      const result = await manager.spawn(
+        runtime,
+        testWorkspaceId,
+        "printf 'ERR foo\\npartial'; sleep 5",
+        {
+          cwd: process.cwd(),
+          displayName: "monitor-line-plus-fragment",
+          monitor: {
+            filter: "ERR",
+            pattern: /ERR/,
+            exclude: false,
+            cooldownMs: 10_000,
+          },
+        }
+      );
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      // Wait until the monitor has recorded the match and parked the trailing fragment.
+      let proc = await manager.getProcess(result.processId);
+      for (let attempt = 0; attempt < 60; attempt++) {
+        proc = await manager.getProcess(result.processId);
+        if ((proc?.monitor?.pendingLines.length ?? 0) > 0 && proc?.monitor?.incompleteLineBuffer)
+          break;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(proc?.monitor?.pendingLines ?? []).toEqual(["ERR foo"]);
+      expect(proc?.monitor?.incompleteLineBuffer).toContain("partial");
+      // matchedThroughOffset ends at the matched line; the raw scan cursor sits past it.
+      expect(proc?.monitor?.matchedThroughOffset ?? 0).toBeLessThan(
+        proc?.monitor?.lastReadOffset ?? 0
+      );
+
+      // Agent reads inline: gets "ERR foo", buffers "partial".
+      const output = await manager.getOutput(result.processId, undefined, false, 1);
+      expect(output.success).toBe(true);
+      if (output.success) expect(output.output).toContain("ERR foo");
+
+      // The agent has been shown through the matched line, so the deferred flush must drop.
+      await manager.terminate(result.processId);
+      expect(matchCount).toBe(0);
+
+      manager.off("monitor:match", handler);
+    });
+
     it("strips ANSI before matching and emitting matched lines", async () => {
       const eventPromise = waitForMonitorMatch(manager);
       const result = await manager.spawn(

--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -310,6 +310,61 @@ describe("BackgroundProcessManager", () => {
       }
     });
 
+    it("drops a deferred monitor wake once the agent reads past the matched output", async () => {
+      // Regression: a monitor must not wake the agent about output the agent has already read
+      // inline (e.g. via a concurrent task_await / bash_output on the same bash task). Without
+      // the cursor guard in emitMonitorMatch the deferred flush double-reports the matched line.
+      let matchCount = 0;
+      const handler = () => {
+        matchCount++;
+      };
+      manager.on("monitor:match", handler);
+
+      // Print a matching line, then stay alive so the only flush we trigger is the explicit
+      // terminate() below -- never the cooldown timer (kept large) nor process exit.
+      const result = await manager.spawn(
+        runtime,
+        testWorkspaceId,
+        "printf 'ERR boom\\n'; sleep 5",
+        {
+          cwd: process.cwd(),
+          displayName: "monitor-already-read",
+          monitor: {
+            filter: "ERR",
+            pattern: /ERR/,
+            exclude: false,
+            cooldownMs: 10_000,
+          },
+        }
+      );
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      // Wait until the monitor has scanned and queued the match (flush deferred by the cooldown).
+      let proc = await manager.getProcess(result.processId);
+      for (let attempt = 0; attempt < 60; attempt++) {
+        proc = await manager.getProcess(result.processId);
+        if ((proc?.monitor?.pendingLines.length ?? 0) > 0) break;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(proc?.monitor?.pendingLines.length ?? 0).toBeGreaterThan(0);
+
+      // Agent reads the output inline, advancing its cursor to the monitor's scan position.
+      const output = await manager.getOutput(result.processId, undefined, false, 1);
+      expect(output.success).toBe(true);
+      if (output.success) expect(output.output).toContain("ERR boom");
+
+      // Precondition for the drop: the read cursor has caught up to the monitor's scan offset.
+      proc = await manager.getProcess(result.processId);
+      expect(proc?.outputBytesRead ?? 0).toBeGreaterThanOrEqual(proc?.monitor?.lastReadOffset ?? 0);
+
+      // Force the deferred flush. The cursor has caught up, so it must drop instead of waking.
+      await manager.terminate(result.processId);
+      expect(matchCount).toBe(0);
+
+      manager.off("monitor:match", handler);
+    });
+
     it("strips ANSI before matching and emitting matched lines", async () => {
       const eventPromise = waitForMonitorMatch(manager);
       const result = await manager.spawn(

--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -365,6 +365,36 @@ describe("BackgroundProcessManager", () => {
       manager.off("monitor:match", handler);
     });
 
+    it("still wakes when the matched line was only buffered (unterminated), not shown", async () => {
+      // getOutput advances outputBytesRead past an unterminated trailing line but keeps it in
+      // incompleteLineBuffer (not returned). The monitor only matches that line on exit, when the
+      // agent still hasn't seen it -- so the wake must NOT be suppressed by the read cursor.
+      const eventPromise = waitForMonitorMatch(manager, 6_000);
+      const result = await manager.spawn(runtime, testWorkspaceId, "printf 'ERR boom'; sleep 3", {
+        cwd: process.cwd(),
+        displayName: "monitor-buffered-unterminated",
+        monitor: {
+          filter: "ERR",
+          pattern: /ERR/,
+          exclude: false,
+          cooldownMs: 0,
+        },
+      });
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      // Read while running: "ERR boom" has no trailing newline, so it is buffered (cursor advances)
+      // rather than returned to the agent.
+      const reading = await manager.getOutput(result.processId, undefined, false, 1);
+      expect(reading.success).toBe(true);
+      const proc = await manager.getProcess(result.processId);
+      expect(proc?.incompleteLineBuffer).toContain("ERR boom");
+
+      // On exit the monitor finalizes the buffered line; the agent never saw it, so it still wakes.
+      const event = await eventPromise;
+      expect(event.payload.lines).toEqual(["ERR boom"]);
+    });
+
     it("strips ANSI before matching and emitting matched lines", async () => {
       const eventPromise = waitForMonitorMatch(manager);
       const result = await manager.spawn(

--- a/src/node/services/backgroundProcessManager.test.ts
+++ b/src/node/services/backgroundProcessManager.test.ts
@@ -490,6 +490,61 @@ describe("BackgroundProcessManager", () => {
       expect(proc?.monitor?.lastReadOffset).toBe(16);
     });
 
+    it("still wakes when a filtered read advanced past but did not show the matched line", async () => {
+      // A filtered task_await / bash_output read advances outputBytesRead past every complete line
+      // but returns only lines matching its own filter. A pending monitor match for "ERR" must still
+      // wake after the agent reads with filter="DONE": the error line was never shown to the agent.
+      let matchCount = 0;
+      const handler = () => {
+        matchCount++;
+      };
+      manager.on("monitor:match", handler);
+
+      const result = await manager.spawn(
+        runtime,
+        testWorkspaceId,
+        "printf 'ERR boom\\nDONE\\n'; sleep 5",
+        {
+          cwd: process.cwd(),
+          displayName: "monitor-filtered-read",
+          monitor: {
+            filter: "ERR",
+            pattern: /ERR/,
+            exclude: false,
+            cooldownMs: 10_000, // defer the flush so the filtered read happens first
+          },
+        }
+      );
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+
+      // Wait until the monitor has matched "ERR boom" (flush deferred by the cooldown).
+      let proc = await manager.getProcess(result.processId);
+      for (let attempt = 0; attempt < 60; attempt++) {
+        proc = await manager.getProcess(result.processId);
+        if ((proc?.monitor?.pendingLines.length ?? 0) > 0) break;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(proc?.monitor?.pendingLines ?? []).toEqual(["ERR boom"]);
+
+      // Agent reads with a filter that excludes the error line: it sees only "DONE".
+      const filtered = await manager.getOutput(result.processId, "DONE", false, 1);
+      expect(filtered.success).toBe(true);
+      if (filtered.success) {
+        expect(filtered.output).toContain("DONE");
+        expect(filtered.output).not.toContain("ERR boom");
+      }
+      // The filtered read must not have advanced the shown mark.
+      proc = await manager.getProcess(result.processId);
+      expect(proc?.shownThroughOffset ?? -1).toBe(0);
+
+      // Force the deferred flush. The error was never shown, so it must still wake.
+      await manager.terminate(result.processId);
+      expect(matchCount).toBe(1);
+
+      manager.off("monitor:match", handler);
+    });
+
     it("strips ANSI before matching and emitting matched lines", async () => {
       const eventPromise = waitForMonitorMatch(manager);
       const result = await manager.spawn(

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -91,10 +91,10 @@ export interface BackgroundProcessMonitorState extends BackgroundProcessMonitorC
   flushTimer?: ReturnType<typeof setTimeout>;
   lastReadOffset: number;
   /**
-   * File byte offset through the end of the last complete line that produced a match. Unlike
-   * lastReadOffset (the raw scan cursor, which includes a trailing unterminated fragment), this
-   * marks where the matched output actually ends. emitMonitorMatch compares it against the agent's
-   * shown-read offset to suppress wakes for output already delivered inline.
+   * File byte offset at the end of the last complete line that produced a match. Unlike
+   * lastReadOffset (the raw scan cursor, which can sit past the match on later/unmatched output),
+   * this marks where the matched output actually ends. emitMonitorMatch compares it against the
+   * agent's shown-read offset to suppress wakes for output already delivered inline.
    */
   matchedThroughOffset: number;
   pollIntervalMs: number;
@@ -445,43 +445,51 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
   private processMonitorContent(
     proc: BackgroundProcess,
     content: string,
-    options?: { includeIncompleteLine?: boolean }
+    options: { chunkStartOffset: number; includeIncompleteLine?: boolean }
   ): void {
     const monitor = proc.monitor;
     if (!monitor || monitor.stopped) return;
-    if (content.length === 0 && options?.includeIncompleteLine !== true) return;
+    if (content.length === 0 && options.includeIncompleteLine !== true) return;
 
     const rawWithBuffer = monitor.incompleteLineBuffer + content;
     const allLines = rawWithBuffer.split("\n");
     const hasTrailingNewline = rawWithBuffer.endsWith("\n");
-    const completeLines = hasTrailingNewline ? allLines.slice(0, -1) : allLines.slice(0, -1);
+    const completeLines = allLines.slice(0, -1);
 
-    const includeIncompleteLine = options?.includeIncompleteLine === true;
-    // Raw (unbounded, unsanitized) trailing fragment not part of any complete line. lastReadOffset
-    // counts raw file bytes, so the matched lines end at lastReadOffset minus this fragment's bytes.
-    // On exit (includeIncompleteLine) the fragment is promoted to a complete line, so there is none.
-    const rawTrailingIncomplete =
-      includeIncompleteLine || hasTrailingNewline ? "" : (allLines[allLines.length - 1] ?? "");
-    const completeRegionEndOffset =
-      monitor.lastReadOffset - Buffer.byteLength(rawTrailingIncomplete, "utf8");
+    // Absolute file byte offset where each complete line ends. A complete line always terminates at
+    // a newline within `content` (the prepended incompleteLineBuffer never contains one), so we can
+    // map each line's end to a file offset by walking content's newlines from this chunk's start.
+    // Tracking ends per-line (not per-chunk) means a matched line followed by later complete output
+    // in the same poll is suppressed as soon as the agent has read through that line specifically.
+    const lineEndOffsets: number[] = [];
+    const contentSegments = content.split("\n");
+    let cursor = options.chunkStartOffset;
+    for (let i = 0; i < contentSegments.length - 1; i++) {
+      cursor += Buffer.byteLength(contentSegments[i], "utf8") + 1; // +1 for the "\n"
+      lineEndOffsets.push(cursor);
+    }
 
+    const includeIncompleteLine = options.includeIncompleteLine === true;
     if (includeIncompleteLine && !hasTrailingNewline) {
       const last = allLines[allLines.length - 1];
       if (last.length > 0) {
         completeLines.push(last);
+        // The promoted fragment ends at the end of this chunk's content.
+        lineEndOffsets.push(options.chunkStartOffset + Buffer.byteLength(content, "utf8"));
       }
       monitor.incompleteLineBuffer = "";
     } else {
+      const rawTrailingIncomplete = hasTrailingNewline ? "" : (allLines[allLines.length - 1] ?? "");
       monitor.incompleteLineBuffer = this.boundMonitorIncompleteLineBuffer(
         this.sanitizeMonitorLine(rawTrailingIncomplete)
       );
     }
 
-    for (const rawLine of completeLines) {
+    for (let i = 0; i < completeLines.length; i++) {
       if (monitor.stopped) break;
-      const line = this.sanitizeMonitorLine(rawLine);
+      const line = this.sanitizeMonitorLine(completeLines[i]);
       if (this.monitorMatchesLine(monitor, line)) {
-        this.recordMonitorMatch(proc, line, completeRegionEndOffset);
+        this.recordMonitorMatch(proc, line, lineEndOffsets[i]);
       }
     }
   }
@@ -504,15 +512,16 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       const monitor = proc?.monitor;
       if (!proc || !monitor || monitor.stopped) return;
 
-      const read = await proc.handle.readOutput(monitor.lastReadOffset);
-      if (read.newOffset < monitor.lastReadOffset) {
+      const chunkStartOffset = monitor.lastReadOffset;
+      const read = await proc.handle.readOutput(chunkStartOffset);
+      if (read.newOffset < chunkStartOffset) {
         log.debug(`BackgroundProcessManager: monitor read offset moved backwards for ${processId}`);
         this.stopMonitor(proc, true);
         return;
       }
 
       monitor.lastReadOffset = read.newOffset;
-      this.processMonitorContent(proc, read.content);
+      this.processMonitorContent(proc, read.content, { chunkStartOffset });
 
       const exitCode = await proc.handle.getExitCode();
       if (exitCode !== null) {
@@ -530,9 +539,13 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
 
         // stdout/stderr redirection can lag exit-code observation by a tick.
         await new Promise((resolve) => setTimeout(resolve, monitor.pollIntervalMs));
-        const finalRead = await proc.handle.readOutput(monitor.lastReadOffset);
+        const finalChunkStartOffset = monitor.lastReadOffset;
+        const finalRead = await proc.handle.readOutput(finalChunkStartOffset);
         monitor.lastReadOffset = finalRead.newOffset;
-        this.processMonitorContent(proc, finalRead.content, { includeIncompleteLine: true });
+        this.processMonitorContent(proc, finalRead.content, {
+          chunkStartOffset: finalChunkStartOffset,
+          includeIncompleteLine: true,
+        });
         this.stopMonitor(proc, true);
         return;
       }

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -260,11 +260,15 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       monitor.flushTimer = undefined;
     }
 
-    // Don't wake the agent about output it has already read. If the read cursor
-    // (proc.outputBytesRead, advanced by task_await / bash_output) has caught up to the monitor's
-    // scan position, these matched lines were already delivered inline, so a wake would
-    // double-report them (e.g. firing the instant a concurrent task_await returns the same line).
-    if (proc.outputBytesRead >= monitor.lastReadOffset) {
+    // Don't wake the agent about output it has already been shown. getOutput (task_await /
+    // bash_output) advances outputBytesRead past content it only buffers -- an unterminated
+    // trailing line is kept in incompleteLineBuffer and not returned -- so the "shown" offset is
+    // the read cursor minus that still-buffered fragment. If that has reached the monitor's scan
+    // position the matched lines were already delivered inline and a wake would double-report them
+    // (e.g. firing the instant a concurrent task_await returns the same line). The buffered-but-
+    // unshown case stays below the scan offset, so its eventual on-exit match still wakes.
+    const shownBytes = proc.outputBytesRead - Buffer.byteLength(proc.incompleteLineBuffer, "utf8");
+    if (shownBytes >= monitor.lastReadOffset) {
       monitor.pendingLines = [];
       monitor.droppedLines = 0;
       return;

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -260,6 +260,16 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       monitor.flushTimer = undefined;
     }
 
+    // Don't wake the agent about output it has already read. If the read cursor
+    // (proc.outputBytesRead, advanced by task_await / bash_output) has caught up to the monitor's
+    // scan position, these matched lines were already delivered inline, so a wake would
+    // double-report them (e.g. firing the instant a concurrent task_await returns the same line).
+    if (proc.outputBytesRead >= monitor.lastReadOffset) {
+      monitor.pendingLines = [];
+      monitor.droppedLines = 0;
+      return;
+    }
+
     const lines = monitor.pendingLines;
     const droppedLines = monitor.droppedLines;
     monitor.pendingLines = [];

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -90,6 +90,13 @@ export interface BackgroundProcessMonitorState extends BackgroundProcessMonitorC
   lastLines: string[];
   flushTimer?: ReturnType<typeof setTimeout>;
   lastReadOffset: number;
+  /**
+   * File byte offset through the end of the last complete line that produced a match. Unlike
+   * lastReadOffset (the raw scan cursor, which includes a trailing unterminated fragment), this
+   * marks where the matched output actually ends. emitMonitorMatch compares it against the agent's
+   * shown-read offset to suppress wakes for output already delivered inline.
+   */
+  matchedThroughOffset: number;
   pollIntervalMs: number;
   incompleteLineBuffer: string;
   stopped: boolean;
@@ -230,6 +237,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       totalDroppedLines: 0,
       lastLines: [],
       lastReadOffset: 0,
+      matchedThroughOffset: 0,
       incompleteLineBuffer: "",
       stopped: false,
       pollIntervalMs: options.pollIntervalMs,
@@ -260,15 +268,16 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       monitor.flushTimer = undefined;
     }
 
-    // Don't wake the agent about output it has already been shown. getOutput (task_await /
-    // bash_output) advances outputBytesRead past content it only buffers -- an unterminated
-    // trailing line is kept in incompleteLineBuffer and not returned -- so the "shown" offset is
-    // the read cursor minus that still-buffered fragment. If that has reached the monitor's scan
-    // position the matched lines were already delivered inline and a wake would double-report them
-    // (e.g. firing the instant a concurrent task_await returns the same line). The buffered-but-
-    // unshown case stays below the scan offset, so its eventual on-exit match still wakes.
+    // Don't wake the agent about output it has already been shown. Both sides use "end of complete
+    // line" semantics: getOutput (task_await / bash_output) returns complete lines and keeps only a
+    // trailing unterminated fragment in incompleteLineBuffer, so shownBytes is the read cursor minus
+    // that fragment; matchedThroughOffset is where the matched lines end (excluding any trailing
+    // fragment the monitor scanned but has not matched). If the agent has been shown through the
+    // matched output, a wake would only double-report it (e.g. firing the instant a concurrent
+    // task_await returns the same line), so drop. Output not yet shown -- including a line still
+    // buffered unterminated, which matches only on exit -- stays below shownBytes and still wakes.
     const shownBytes = proc.outputBytesRead - Buffer.byteLength(proc.incompleteLineBuffer, "utf8");
-    if (shownBytes >= monitor.lastReadOffset) {
+    if (shownBytes >= monitor.matchedThroughOffset) {
       monitor.pendingLines = [];
       monitor.droppedLines = 0;
       return;
@@ -392,7 +401,11 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     )}`;
   }
 
-  private recordMonitorMatch(proc: BackgroundProcess, line: string): void {
+  private recordMonitorMatch(
+    proc: BackgroundProcess,
+    line: string,
+    completeRegionEndOffset: number
+  ): void {
     const monitor = proc.monitor;
     if (!monitor || monitor.stopped) return;
 
@@ -400,6 +413,9 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     monitor.matchesCount++;
     monitor.pendingLines.push(boundedLine);
     monitor.lastLines.push(boundedLine);
+    // Offsets only grow, so this advances to the end of the latest matched line. Set before any
+    // flush (including the maxEvents-triggered stopMonitor below) so emitMonitorMatch sees it.
+    monitor.matchedThroughOffset = completeRegionEndOffset;
 
     if (monitor.lastLines.length > MONITOR_MAX_LAST_LINES) {
       monitor.lastLines.splice(0, monitor.lastLines.length - MONITOR_MAX_LAST_LINES);
@@ -441,6 +457,14 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     const completeLines = hasTrailingNewline ? allLines.slice(0, -1) : allLines.slice(0, -1);
 
     const includeIncompleteLine = options?.includeIncompleteLine === true;
+    // Raw (unbounded, unsanitized) trailing fragment not part of any complete line. lastReadOffset
+    // counts raw file bytes, so the matched lines end at lastReadOffset minus this fragment's bytes.
+    // On exit (includeIncompleteLine) the fragment is promoted to a complete line, so there is none.
+    const rawTrailingIncomplete =
+      includeIncompleteLine || hasTrailingNewline ? "" : (allLines[allLines.length - 1] ?? "");
+    const completeRegionEndOffset =
+      monitor.lastReadOffset - Buffer.byteLength(rawTrailingIncomplete, "utf8");
+
     if (includeIncompleteLine && !hasTrailingNewline) {
       const last = allLines[allLines.length - 1];
       if (last.length > 0) {
@@ -448,9 +472,8 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       }
       monitor.incompleteLineBuffer = "";
     } else {
-      const incompleteLine = hasTrailingNewline ? "" : (allLines[allLines.length - 1] ?? "");
       monitor.incompleteLineBuffer = this.boundMonitorIncompleteLineBuffer(
-        this.sanitizeMonitorLine(incompleteLine)
+        this.sanitizeMonitorLine(rawTrailingIncomplete)
       );
     }
 
@@ -458,7 +481,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       if (monitor.stopped) break;
       const line = this.sanitizeMonitorLine(rawLine);
       if (this.monitorMatchesLine(monitor, line)) {
-        this.recordMonitorMatch(proc, line);
+        this.recordMonitorMatch(proc, line, completeRegionEndOffset);
       }
     }
   }

--- a/src/node/services/backgroundProcessManager.ts
+++ b/src/node/services/backgroundProcessManager.ts
@@ -123,6 +123,14 @@ export interface BackgroundProcess {
   isForeground: boolean;
   /** Tracks read position for incremental output retrieval */
   outputBytesRead: number;
+  /**
+   * File byte offset through the end of the last complete line an *unfiltered* getOutput call
+   * (task_await / bash_output) has delivered to the agent. Unlike outputBytesRead, this never
+   * advances for filtered reads (which may drop matched lines) or for buffered trailing fragments,
+   * so it is the faithful "agent has been shown this" signal the monitor consults. Both this and
+   * the monitor's matchedThroughOffset are absolute file offsets, so suppression is race-free.
+   */
+  shownThroughOffset: number;
   /** Mutex to serialize getOutput() calls (prevents race condition when
    * parallel tool calls read from same offset before position is updated) */
   outputLock: AsyncMutex;
@@ -268,16 +276,15 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       monitor.flushTimer = undefined;
     }
 
-    // Don't wake the agent about output it has already been shown. Both sides use "end of complete
-    // line" semantics: getOutput (task_await / bash_output) returns complete lines and keeps only a
-    // trailing unterminated fragment in incompleteLineBuffer, so shownBytes is the read cursor minus
-    // that fragment; matchedThroughOffset is where the matched lines end (excluding any trailing
-    // fragment the monitor scanned but has not matched). If the agent has been shown through the
-    // matched output, a wake would only double-report it (e.g. firing the instant a concurrent
-    // task_await returns the same line), so drop. Output not yet shown -- including a line still
-    // buffered unterminated, which matches only on exit -- stays below shownBytes and still wakes.
-    const shownBytes = proc.outputBytesRead - Buffer.byteLength(proc.incompleteLineBuffer, "utf8");
-    if (shownBytes >= monitor.matchedThroughOffset) {
+    // Don't wake the agent about output it has already been shown. shownThroughOffset is the file
+    // position an unfiltered task_await / bash_output read has delivered complete lines through;
+    // matchedThroughOffset is where the matched line ends. Both are absolute file offsets, so this
+    // is order-independent (no race between the reader and the monitor). If the agent was shown
+    // through the match, a wake would only double-report it (e.g. a concurrent task_await that just
+    // returned the same line), so drop. Anything still beyond the shown mark -- a filtered-out
+    // match (filtered reads never advance the mark), a line still buffered unterminated (matched
+    // only on exit), or genuinely new output -- stays above it and still wakes.
+    if (proc.shownThroughOffset >= monitor.matchedThroughOffset) {
       monitor.pendingLines = [];
       monitor.droppedLines = 0;
       return;
@@ -660,6 +667,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       displayName: config.displayName,
       isForeground: config.isForeground ?? false,
       outputBytesRead: 0,
+      shownThroughOffset: 0,
       outputLock: new AsyncMutex(),
       getOutputCallCount: 0,
       incompleteLineBuffer: "",
@@ -779,6 +787,7 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
       displayName,
       isForeground: false, // Now in background
       outputBytesRead: 0,
+      shownThroughOffset: 0,
       outputLock: new AsyncMutex(),
       getOutputCallCount: 0,
       incompleteLineBuffer: "",
@@ -1108,6 +1117,16 @@ export class BackgroundProcessManager extends EventEmitter<BackgroundProcessMana
     // Update buffer for next call (clear on exit, keep incomplete line otherwise)
     proc.incompleteLineBuffer =
       currentStatus === "running" && !hasTrailingNewline ? allLines[allLines.length - 1] : "";
+
+    // Advance the monitor's "shown through" mark only on unfiltered reads. A filtered read may have
+    // dropped matched lines, so it must not count as having shown them. End-of-last-complete-line =
+    // read cursor minus the trailing fragment we just buffered (cleared, hence 0, on exit). Offsets
+    // only grow; Math.max guards against any out-of-order/partial call regressing the mark.
+    if (!filter) {
+      const shownThrough =
+        proc.outputBytesRead - Buffer.byteLength(proc.incompleteLineBuffer, "utf8");
+      proc.shownThroughOffset = Math.max(proc.shownThroughOffset, shownThrough);
+    }
 
     log.debug(
       `BackgroundProcessManager.getOutput: read rawLen=${accumulatedRaw.length}, completeLines=${linesToReturn.length}`


### PR DESCRIPTION
## Summary

A background bash `monitor` could wake the agent about output that had already been delivered inline, producing a redundant synthetic wake immediately after the read returned (e.g. a `task_await` on a bash task returns the matching FAIL line, then a wake about that same line fires the instant the await resolves).

## Background

`monitor` matches and the agent's own reads (`task_await` / `bash_output`) run on independent paths through `BackgroundProcessManager`. The monitor scans output and emits `monitor:match`; agent reads advance a read cursor via `getOutput()`. Nothing connected the two, so when a match flush was deferred (cooldown window) and the agent read the same bytes inline in the meantime, the deferred flush still fired and double-reported output the agent had already seen.

## Implementation

Suppression is decided at the single emit chokepoint, `emitMonitorMatch`, by comparing two absolute file byte offsets:

- `monitor.matchedThroughOffset` — the end offset of the last complete line that produced a match. Tracked per matched line (computed by walking the chunk's newlines from its start offset), so a match is never inflated by later or unmatched output in the same poll.
- `proc.shownThroughOffset` — the end offset of the last complete line actually delivered to the agent by an **unfiltered** `getOutput` read. It advances in exactly one place and only when no `filter`/`filter_exclude` is in play, so a filtered read (which may drop matched lines) never counts as having shown them.

If `shownThroughOffset >= matchedThroughOffset`, the matched output was already delivered inline and the pending match is dropped instead of emitted. Because both sides are absolute file offsets, the comparison is order-independent — there is no race between the reader advancing its cursor and the monitor recording its match.

This replaces an earlier, fragile approach that reused the raw read cursor (`outputBytesRead`) as the "agent has seen this" signal. That cursor advances past content the agent is not actually shown — buffered unterminated fragments, and lines filtered out of a read — which is what made the naive comparison leak wakes in several edge cases.

The change is upstream of `WorkspaceService`: once a wake is emitted, all existing queue/drain/tool-end delivery behavior is unchanged. Genuinely-new matches and fire-and-forget monitors (whose shown offset stays at 0) wake exactly as before.

## Risks

Low. The new state is monitor-local and the suppression only narrows emission in the already-shown case. The main behaviors to preserve are covered by tests: drop after an unfiltered read past the match; still wake for a line only buffered unterminated (matched on exit); still wake when later/unmatched output shares the poll; and still wake when a filtered read advanced the cursor without showing the match.

---

_Generated with `mux` • Model: `anthropic:claude-opus-4-8` • Thinking: `xhigh` • Cost: `$15.86`_

<!-- mux-attribution: model=anthropic:claude-opus-4-8 thinking=xhigh costs=15.86 -->
