### PR TITLE
🤖 fix: use shared settings header tooltips

### DIFF
--- a/src/browser/features/Settings/SettingsPage.tsx
+++ b/src/browser/features/Settings/SettingsPage.tsx
@@ -18,6 +18,7 @@ import {
   Lock,
 } from "lucide-react";
 import { useSettings } from "@/browser/contexts/SettingsContext";
+import { TooltipIfPresent } from "@/browser/components/Tooltip/Tooltip";
 import { useOnboardingPause } from "@/browser/features/SplashScreens/SplashScreenProvider";
 import { useExperimentValue } from "@/browser/hooks/useExperiments";
 import { isEditableElement, KEYBINDS, matchesKeybind } from "@/browser/utils/ui/keybinds";
@@ -227,30 +228,32 @@ export function SettingsPage(props: SettingsPageProps) {
       >
         <div className="flex min-w-0 items-center gap-2">
           {props.leftSidebarCollapsed && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={props.onToggleLeftSidebarCollapsed}
-              title="Open sidebar"
-              aria-label="Open sidebar menu"
-              className="mobile-menu-btn text-muted hover:text-foreground hidden h-6 w-6 shrink-0"
-            >
-              <Menu className="h-4 w-4" />
-            </Button>
+            <TooltipIfPresent tooltip="Open sidebar" side="bottom">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={props.onToggleLeftSidebarCollapsed}
+                aria-label="Open sidebar menu"
+                className="mobile-menu-btn text-muted hover:text-foreground hidden h-6 w-6 shrink-0"
+              >
+                <Menu className="h-4 w-4" />
+              </Button>
+            </TooltipIfPresent>
           )}
           <span className="text-foreground text-sm font-semibold">Settings</span>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={close}
-          title="Back"
-          aria-label="Back to previous page"
-          className="text-muted hover:text-foreground px-2"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-          Back
-        </Button>
+        <TooltipIfPresent tooltip="Back" side="bottom">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={close}
+            aria-label="Back to previous page"
+            className="text-muted hover:text-foreground px-2"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back
+          </Button>
+        </TooltipIfPresent>
       </div>
 
       <div className="flex min-h-0 flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary

Replaces the native `title` attributes on the mobile Settings header controls with the shared `TooltipIfPresent` component.

## Background

Mux tooltips should use the shared tooltip system instead of browser-native titles so they portal above clipped containers and avoid duplicate OS/browser tooltip behavior. This keeps the Settings mobile header aligned with that pattern while preserving the existing `aria-label` text for assistive technology.

## Validation

- `./node_modules/.bin/eslint src/browser/features/Settings/SettingsPage.tsx`
- `./node_modules/.bin/prettier --check src/browser/features/Settings/SettingsPage.tsx`
- `./node_modules/.bin/tsgo --noEmit --project tsconfig.json`
- `git diff --check origin/main...HEAD`
- `make static-check`

---

_Generated with `mux` • Model: `GPT-5` • Thinking: `unknown` • Cost: `$unknown`_

<!-- mux-attribution: model=GPT-5 thinking=unknown costs=unknown -->
